### PR TITLE
security audit fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,13 @@ env:
   RUSTFLAGS: "-D warnings"
 
 jobs:
+  deny:
+    name: Deny
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: EmbarkStudios/cargo-deny-action@v2
+
   fmt:
     name: Format
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5859,7 +5859,7 @@ dependencies = [
 
 [[package]]
 name = "wirken-adapter-discord"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "capnp",
@@ -5877,7 +5877,7 @@ dependencies = [
 
 [[package]]
 name = "wirken-adapter-google-chat"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "capnp",
  "chrono",
@@ -5894,7 +5894,7 @@ dependencies = [
 
 [[package]]
 name = "wirken-adapter-imessage"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "capnp",
  "reqwest 0.13.2",
@@ -5910,7 +5910,7 @@ dependencies = [
 
 [[package]]
 name = "wirken-adapter-matrix"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "capnp",
@@ -5928,7 +5928,7 @@ dependencies = [
 
 [[package]]
 name = "wirken-adapter-signal"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "capnp",
  "reqwest 0.13.2",
@@ -5944,7 +5944,7 @@ dependencies = [
 
 [[package]]
 name = "wirken-adapter-slack"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "capnp",
@@ -5962,7 +5962,7 @@ dependencies = [
 
 [[package]]
 name = "wirken-adapter-teams"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "capnp",
@@ -5980,7 +5980,7 @@ dependencies = [
 
 [[package]]
 name = "wirken-adapter-telegram"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "capnp",
@@ -5998,7 +5998,7 @@ dependencies = [
 
 [[package]]
 name = "wirken-adapter-whatsapp"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "capnp",
@@ -6018,7 +6018,7 @@ dependencies = [
 
 [[package]]
 name = "wirken-agent"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "base64",
@@ -6047,7 +6047,7 @@ dependencies = [
 
 [[package]]
 name = "wirken-audit"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "chrono",
  "reqwest 0.13.2",
@@ -6063,7 +6063,7 @@ dependencies = [
 
 [[package]]
 name = "wirken-cli"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "capnp",
@@ -6099,7 +6099,7 @@ dependencies = [
 
 [[package]]
 name = "wirken-gateway"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "base64",
@@ -6124,7 +6124,7 @@ dependencies = [
 
 [[package]]
 name = "wirken-ipc"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "capnp",
  "capnpc",
@@ -6140,7 +6140,7 @@ dependencies = [
 
 [[package]]
 name = "wirken-vault"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "argon2",
  "chacha20poly1305",
@@ -6161,7 +6161,7 @@ dependencies = [
 
 [[package]]
 name = "wirken-webchat"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "thiserror 2.0.18",
  "tokio",

--- a/crates/agent/src/runtime.rs
+++ b/crates/agent/src/runtime.rs
@@ -456,6 +456,11 @@ fn truncate(s: &str, max: usize) -> String {
     if s.len() <= max {
         s.to_string()
     } else {
-        format!("{}...", &s[..max])
+        // Find a char boundary at or before `max` to avoid panicking on multi-byte UTF-8.
+        let mut end = max;
+        while end > 0 && !s.is_char_boundary(end) {
+            end -= 1;
+        }
+        format!("{}...", &s[..end])
     }
 }

--- a/crates/agent/src/sandbox.rs
+++ b/crates/agent/src/sandbox.rs
@@ -285,12 +285,5 @@ pub async fn detect_gvisor() -> bool {
 }
 
 fn short_id() -> String {
-    let mut bytes = [0u8; 6];
-    // Simple counter-based ID since we don't need crypto randomness here
-    let ns = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap_or_default()
-        .subsec_nanos();
-    bytes[0..4].copy_from_slice(&ns.to_le_bytes());
-    bytes.iter().map(|b| format!("{b:02x}")).collect()
+    uuid::Uuid::new_v4().simple().to_string()[..12].to_string()
 }

--- a/crates/audit/src/error.rs
+++ b/crates/audit/src/error.rs
@@ -17,4 +17,7 @@ pub enum AuditError {
 
     #[error("serialization error: {0}")]
     Serialization(#[from] serde_json::Error),
+
+    #[error("SIEM configuration error: {0}")]
+    SiemConfig(String),
 }

--- a/crates/audit/src/log.rs
+++ b/crates/audit/src/log.rs
@@ -175,7 +175,7 @@ impl AuditLog {
     /// Verify the hash chain integrity.
     pub fn verify(&self) -> Result<VerifyResult, AuditError> {
         let mut stmt = self.conn.prepare(
-            "SELECT id, ts, actor, action, target, detail, hash
+            "SELECT id, ts, actor, action, target, channel, session, detail, hash
              FROM audit_events ORDER BY id ASC",
         )?;
 
@@ -188,6 +188,8 @@ impl AuditLog {
                 row.get::<_, String>(4)?,
                 row.get::<_, String>(5)?,
                 row.get::<_, String>(6)?,
+                row.get::<_, String>(7)?,
+                row.get::<_, String>(8)?,
             ))
         })?;
 
@@ -195,7 +197,8 @@ impl AuditLog {
         let mut count = 0usize;
 
         for row in rows {
-            let (id, ts_str, actor, action, target, detail_str, stored_hash) = row?;
+            let (id, ts_str, actor, action, target, channel, session, detail_str, stored_hash) =
+                row?;
 
             let ts = chrono::DateTime::parse_from_rfc3339(&ts_str)
                 .unwrap_or_default()
@@ -207,8 +210,8 @@ impl AuditLog {
                 actor,
                 action,
                 target,
-                channel: String::new(), // not used in hash
-                session: String::new(), // not used in hash
+                channel,
+                session,
                 detail,
             };
 
@@ -236,15 +239,31 @@ impl AuditLog {
     }
 
     /// Prune events older than the given number of days.
-    /// Preserves the hash chain by keeping a checkpoint hash.
+    /// Preserves the hash chain by keeping the last event before the cutoff
+    /// as a checkpoint so that `verify()` can still validate the remaining chain.
     pub fn prune(&self, retention_days: u32) -> Result<usize, AuditError> {
         let cutoff = Utc::now() - chrono::Duration::days(retention_days as i64);
         let cutoff_str = cutoff.to_rfc3339();
 
-        let deleted = self.conn.execute(
-            "DELETE FROM audit_events WHERE ts < ?1",
-            params![cutoff_str],
-        )?;
+        // Find the last event before the cutoff to use as the chain checkpoint.
+        // We keep this row so the first retained event can still be verified
+        // against its predecessor's hash.
+        let checkpoint_id: Option<i64> = self
+            .conn
+            .query_row(
+                "SELECT id FROM audit_events WHERE ts < ?1 ORDER BY id DESC LIMIT 1",
+                params![&cutoff_str],
+                |row| row.get(0),
+            )
+            .ok();
+
+        let deleted = match checkpoint_id {
+            Some(keep_id) => self.conn.execute(
+                "DELETE FROM audit_events WHERE ts < ?1 AND id < ?2",
+                params![cutoff_str, keep_id],
+            )?,
+            None => 0, // nothing to prune
+        };
 
         Ok(deleted)
     }
@@ -265,13 +284,16 @@ impl AuditLog {
     }
 }
 
-/// Compute SHA-256(previous_hash || ts || actor || action || detail)
+/// Compute SHA-256(previous_hash || ts || actor || action || target || channel || session || detail)
 fn compute_hash(previous_hash: &str, event: &AuditEvent) -> String {
     let mut hasher = Sha256::new();
     hasher.update(previous_hash.as_bytes());
     hasher.update(event.ts.to_rfc3339().as_bytes());
     hasher.update(event.actor.as_bytes());
     hasher.update(event.action.as_bytes());
+    hasher.update(event.target.as_bytes());
+    hasher.update(event.channel.as_bytes());
+    hasher.update(event.session.as_bytes());
     hasher.update(event.detail.to_string().as_bytes());
     format!("{:x}", hasher.finalize())
 }

--- a/crates/audit/src/siem.rs
+++ b/crates/audit/src/siem.rs
@@ -38,11 +38,26 @@ pub struct SiemForwarder {
 }
 
 impl SiemForwarder {
-    pub fn new(config: SiemConfig) -> Self {
-        Self {
+    /// Create a new SIEM forwarder.
+    /// Returns an error if the endpoint uses plaintext HTTP (credential leakage risk).
+    /// Localhost endpoints are exempt for development use.
+    pub fn new(config: SiemConfig) -> Result<Self, String> {
+        let is_localhost = config.endpoint.starts_with("http://localhost")
+            || config.endpoint.starts_with("http://127.0.0.1")
+            || config.endpoint.starts_with("http://[::1]");
+
+        if !config.endpoint.starts_with("https://") && !is_localhost {
+            return Err(format!(
+                "SIEM endpoint must use HTTPS (got {}). \
+                 API keys would be sent in plaintext over HTTP.",
+                config.endpoint
+            ));
+        }
+
+        Ok(Self {
             config,
             http: reqwest::Client::new(),
-        }
+        })
     }
 
     /// Forward a batch of audit events. Errors are logged, not propagated —

--- a/crates/audit/src/tests.rs
+++ b/crates/audit/src/tests.rs
@@ -209,10 +209,12 @@ fn prune_old_events() {
 
     let log2 = AuditLog::open(&db_path).unwrap();
     let deleted = log2.prune(90).unwrap();
-    assert_eq!(deleted, 5);
+    // 4 deleted: the last old event is kept as a hash chain checkpoint
+    assert_eq!(deleted, 4);
 
     let remaining = log.query(&AuditQuery::default()).unwrap();
-    assert_eq!(remaining.len(), 3);
+    // 3 recent + 1 checkpoint = 4
+    assert_eq!(remaining.len(), 4);
 }
 
 #[test]

--- a/crates/audit/src/writer.rs
+++ b/crates/audit/src/writer.rs
@@ -36,7 +36,10 @@ impl AuditWriter {
 
         let (tx, rx) = mpsc::channel(CHANNEL_CAPACITY);
         let path = db_path.to_path_buf();
-        let forwarder = siem_config.map(SiemForwarder::new);
+        let forwarder = match siem_config {
+            Some(cfg) => Some(SiemForwarder::new(cfg).map_err(AuditError::SiemConfig)?),
+            None => None,
+        };
         let handle = tokio::spawn(flush_loop(rx, path, forwarder));
 
         Ok((Self { tx }, handle))

--- a/crates/gateway/src/router.rs
+++ b/crates/gateway/src/router.rs
@@ -27,21 +27,24 @@ impl Router {
 
     /// Add a routing binding.
     pub fn bind(&self, binding: RouteBinding) {
-        self.bindings.write().unwrap().push(binding);
+        self.bindings
+            .write()
+            .unwrap_or_else(|e| e.into_inner())
+            .push(binding);
     }
 
     /// Remove all bindings for a channel.
     pub fn unbind_channel(&self, channel: &str) {
         self.bindings
             .write()
-            .unwrap()
+            .unwrap_or_else(|e| e.into_inner())
             .retain(|b| b.channel != channel);
     }
 
     /// Resolve which agent should handle a message from a given channel + conversation.
     /// Checks specific conversation matches first, then wildcard "*" bindings.
     pub fn resolve(&self, channel: &str, conversation_id: &str) -> Result<String, GatewayError> {
-        let bindings = self.bindings.read().unwrap();
+        let bindings = self.bindings.read().unwrap_or_else(|e| e.into_inner());
 
         // First pass: exact conversation match
         for binding in bindings.iter() {
@@ -65,7 +68,10 @@ impl Router {
 
     /// List all current bindings.
     pub fn list_bindings(&self) -> Vec<RouteBinding> {
-        self.bindings.read().unwrap().clone()
+        self.bindings
+            .read()
+            .unwrap_or_else(|e| e.into_inner())
+            .clone()
     }
 }
 

--- a/crates/vault/src/crypto.rs
+++ b/crates/vault/src/crypto.rs
@@ -82,12 +82,10 @@ pub fn decrypt(encrypted: &[u8], key: &VaultSecret) -> Result<VaultSecret, Vault
 
 /// Generate a random 32-byte key as a VaultSecret.
 pub fn generate_key() -> VaultSecret {
-    let mut key_bytes = [0u8; 32];
-    rand::thread_rng().fill_bytes(&mut key_bytes);
-    // Encode as hex string (64 chars = 32 bytes of entropy)
-    let hex = hex_encode(&key_bytes);
-    // Zero the raw bytes
-    key_bytes.fill(0);
+    let mut key_bytes = Zeroizing::new([0u8; 32]);
+    rand::thread_rng().fill_bytes(&mut *key_bytes);
+    let hex = hex_encode(&*key_bytes);
+    // key_bytes zeroed on drop by Zeroizing
     VaultSecret::new(hex)
 }
 
@@ -118,12 +116,12 @@ pub fn derive_key_from_passphrase(
         Params::new(65536, 3, 1, Some(32)).map_err(|e| VaultError::Derivation(e.to_string()))?;
     let argon2 = Argon2::new(Algorithm::Argon2id, Version::V0x13, params);
 
-    let mut output = [0u8; 32];
+    let mut output = Zeroizing::new([0u8; 32]);
     argon2
-        .hash_password_into(passphrase.as_bytes(), salt, &mut output)
+        .hash_password_into(passphrase.as_bytes(), salt, &mut *output)
         .map_err(|e| VaultError::Derivation(e.to_string()))?;
 
-    let hex = hex_encode(&output);
-    output.fill(0);
+    let hex = hex_encode(&*output);
+    // output zeroed on drop by Zeroizing
     Ok(VaultSecret::new(hex))
 }

--- a/crates/vault/src/store.rs
+++ b/crates/vault/src/store.rs
@@ -301,10 +301,11 @@ impl CredentialStore {
 
         // Safety: caller guarantees fd is valid and open for writing
         let mut file = unsafe { std::fs::File::from_raw_fd(fd) };
-        file.write_all(&encrypted)?;
-        // Prevent File from closing the fd on drop — caller owns it
+        let result = file.write_all(&encrypted);
+        // Always prevent File from closing the fd — caller owns it.
+        // Must run even on write error to avoid double-close.
         std::mem::forget(file);
-        Ok(())
+        result.map_err(Into::into)
     }
 }
 

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,35 @@
+[advisories]
+vulnerability = "deny"
+unmaintained = "warn"
+yanked = "warn"
+
+[licenses]
+unlicensed = "deny"
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "ISC",
+    "Unicode-3.0",
+    "Unicode-DFS-2016",
+    "Zlib",
+    "OpenSSL",
+    "Ring",
+]
+confidence-threshold = 0.8
+
+[[licenses.clarify]]
+name = "ring"
+expression = "Ring"
+license-files = [{ path = "LICENSE", hash = 0xbd0eed23 }]
+
+[bans]
+multiple-versions = "warn"
+wildcards = "allow"
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = []


### PR DESCRIPTION
## Summary
- Fix UTF-8 truncation panic in agent tracing
- Use Zeroizing for key material instead of manual fill(0)
- Fix fd double-close in vault write_to_fd
- Use uuid for sandbox container names
- Recover from poisoned RwLock in router
- Include all fields in audit hash chain, fix prune to preserve chain
- Reject plaintext HTTP for SIEM endpoints
- Add cargo-deny to CI for dependency and license auditing

## Test plan
- [x] cargo test --workspace (all 316 tests pass)
- [x] cargo clippy --workspace -D warnings (clean)
- [ ] cargo-deny check (runs in CI)