### PR TITLE
Harden installer + release signing (fail-closed, ssh-keygen -Y)

### DIFF
--- a/.github/workflows/installer-pin.yml
+++ b/.github/workflows/installer-pin.yml
@@ -1,0 +1,46 @@
+name: Installer pin
+
+# Fail CI if README.md does not pin the current install.sh SHA-256.
+# Users are instructed to verify the installer with this hash before
+# piping it to sh. Drift between README and install.sh silently breaks
+# that contract, so the check is mandatory.
+
+on:
+  pull_request:
+    paths:
+      - 'install.sh'
+      - 'README.md'
+      - '.github/workflows/installer-pin.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'install.sh'
+      - 'README.md'
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: install.sh SHA matches README pin
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Compare SHA
+        run: |
+          set -eu
+          ACTUAL=$(sha256sum install.sh | awk '{print $1}')
+          PINNED=$(grep -oE '[0-9a-f]{64}' README.md | head -1)
+          if [ -z "$PINNED" ]; then
+            echo "Could not find a 64-char hex SHA in README.md" >&2
+            exit 1
+          fi
+          echo "README pin: $PINNED"
+          echo "actual:     $ACTUAL"
+          if [ "$ACTUAL" != "$PINNED" ]; then
+            echo "::error::install.sh SHA-256 does not match the pin in README.md"
+            echo "Update the SHA in README.md to: $ACTUAL" >&2
+            exit 1
+          fi
+          echo "install.sh SHA matches README pin."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,10 +131,32 @@ jobs:
           cd ..
           ls -la release/
 
-      - name: Create GitHub Release
+      # Release is created as a draft. The maintainer downloads
+      # checksums.sha256 from the draft, signs it offline with the
+      # Ed25519 release signing key (see docs/release-signing.md), and
+      # uploads checksums.sha256.sig to the draft before publishing.
+      # CI does not hold the signing key.
+      - name: Create draft GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           files: release/*
           generate_release_notes: true
+          draft: true
+          body: |
+            **This release is a draft until `checksums.sha256.sig` is attached.**
+
+            The installer verifies `checksums.sha256.sig` against the
+            embedded release signing key. Publishing a release without
+            the signature will break `install.sh` for all users who do
+            not set `WIRKEN_ALLOW_UNVERIFIED=1`.
+
+            Maintainer steps before publishing:
+
+            1. Download `checksums.sha256` from this draft.
+            2. `WIRKEN_SIGNING_KEY=/secure/path scripts/sign-release.sh <tag>`
+            3. Upload `checksums.sha256.sig` to this draft.
+            4. Publish the release.
+
+            See `docs/release-signing.md` for the full procedure.
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/KEYS
+++ b/KEYS
@@ -21,9 +21,7 @@
 # Current active key
 #   Identity:    releases@gebruder.ottenheimer.app
 #   Algorithm:   ssh-ed25519
-#   Issued:      PENDING (to be filled on first signing)
-#   Fingerprint: PENDING (SHA256: will be recorded once key is generated)
-#
-# REPLACE: paste the output of `ssh-keygen -y -f wirken-release-signing` as
-# the key field below, preserving the identity and the ssh-ed25519 type.
-releases@gebruder.ottenheimer.app ssh-ed25519 REPLACE_ME_WITH_PUBLIC_KEY
+#   Issued:      2026-04-18
+#   Fingerprint: SHA256:tzlfNHy4G1KIsmAR+cM3MGwVndheh2ak/usA6rw7SuE
+releases@gebruder.ottenheimer.app ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPcGuqLSfpN+ibltPVbif7i9LgclLtRIaL+1TuYp+RjV releases@gebruder.ottenheimer.app
+

--- a/KEYS
+++ b/KEYS
@@ -1,0 +1,29 @@
+# Wirken release signing keys
+#
+# This file is in OpenSSH allowed_signers format and can be passed to
+# `ssh-keygen -Y verify -f KEYS`. Every production release is signed with
+# the key listed here over the release's checksums.sha256.
+#
+# Verify a release locally:
+#
+#   curl -fsSLO https://github.com/gebruder/wirken/releases/download/vX.Y.Z/checksums.sha256
+#   curl -fsSLO https://github.com/gebruder/wirken/releases/download/vX.Y.Z/checksums.sha256.sig
+#   curl -fsSLO https://raw.githubusercontent.com/gebruder/wirken/main/KEYS
+#   ssh-keygen -Y verify \
+#       -f KEYS \
+#       -I releases@gebruder.ottenheimer.app \
+#       -n file \
+#       -s checksums.sha256.sig \
+#       < checksums.sha256
+#
+# Key rotation history lives in docs/release-signing.md.
+#
+# Current active key
+#   Identity:    releases@gebruder.ottenheimer.app
+#   Algorithm:   ssh-ed25519
+#   Issued:      PENDING (to be filled on first signing)
+#   Fingerprint: PENDING (SHA256: will be recorded once key is generated)
+#
+# REPLACE: paste the output of `ssh-keygen -y -f wirken-release-signing` as
+# the key field below, preserving the identity and the ssh-ed25519 type.
+releases@gebruder.ottenheimer.app ssh-ed25519 REPLACE_ME_WITH_PUBLIC_KEY

--- a/README.md
+++ b/README.md
@@ -183,6 +183,8 @@ Wirken gives organizations the controls they need to deploy AI agents without by
 - [Troubleshooting](docs/troubleshooting.md)
 - [Architecture](docs/architecture.md)
 - [Enforcement model](docs/enforcement-model.md) (compile-time vs. runtime guarantees)
+- [Release process](docs/release-process.md) (version bump, tag, sign, publish, smoke test)
+- [Release signing](docs/release-signing.md) (Ed25519 key, rotation, verification)
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ wirken run
 Pin the installer before piping. The committed `install.sh` has this SHA-256:
 
 ```
-5001fa424aa5494a89fbe65f1c776545f33322d5190c72a106677575a6c438d3
+e5e8779155aab24c1d7fe0c41bc93d23b18ddd8293e48b01d19dc58b44aec7b8
 ```
 
 Verify it yourself:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Wirken is AI agents on your chat tools, done the way it should have been from the start: self-hosted, channel-isolated, every action audited.**
 
-Organizations deploy AI agents across Slack, Teams, Matrix, and Signal. Every message crosses a trust boundary between the channel that delivered it, the orchestrator that routed it, and the inference provider that answered it. Most agent frameworks collapse these boundaries into a single trust domain with one token, no process isolation, and no audit trail. If that process is compromised, every channel is compromised with it.
+Organizations deploy AI agents across Telegram, Discord, Slack, Microsoft Teams, Matrix, WhatsApp, Signal, Google Chat, and iMessage. Every message crosses a trust boundary between the channel that delivered it, the orchestrator that routed it, and the inference provider that answered it. Most agent frameworks collapse these boundaries into a single trust domain with one token, no process isolation, and no audit trail. If that process is compromised, every channel is compromised with it.
 
 Wirken separates the trust domains. Each channel runs in its own adapter process with a distinct ed25519 IPC identity and its own vault-scoped token set. Credentials sit in an XChaCha20-Poly1305 vault keyed from the OS keychain, with per-credential expiry and manual rotation tracked in the store. Every agent action, tool call, LLM request, and response is written to a per-session SHA-256 hash-chained audit log. The log forwards to Datadog, Splunk, or a webhook when SIEM is configured. Permissions follow a three-tier model scoped per agent. Parent agents that spawn children declare per-child ceilings: tool allowlist, maximum permission tier, max rounds, max runtime.
 
@@ -18,6 +18,20 @@ curl -fsSL https://raw.githubusercontent.com/gebruder/wirken/main/install.sh | s
 wirken setup
 wirken run
 ```
+
+Pin the installer before piping. The committed `install.sh` has this SHA-256:
+
+```
+5001fa424aa5494a89fbe65f1c776545f33322d5190c72a106677575a6c438d3
+```
+
+Verify it yourself:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/gebruder/wirken/main/install.sh | sha256sum
+```
+
+The installer then fetches `checksums.sha256` and `checksums.sha256.sig` from the release, verifies the signature with `ssh-keygen -Y verify` against a signing key embedded in the script, and verifies the binary's SHA-256 against the signed checksums. Every failure path is fail-closed: missing signature, missing checksum, mismatched digest, or a machine without `sha256sum`/`shasum` aborts install. The only override is `WIRKEN_ALLOW_UNVERIFIED=1`, which warns on stderr and is documented in [docs/release-signing.md](docs/release-signing.md).
 
 Prebuilt binaries are available for Linux (x86_64, aarch64) and macOS (x86_64, Apple Silicon). The Linux binaries are statically linked against musl with no glibc dependency.
 
@@ -70,6 +84,8 @@ cargo install --path crates/cli
 
   Gateway running. Press Ctrl+C to stop.
 ```
+
+All local services bind to 127.0.0.1. Wirken never instructs you to bind inference servers, WebChat, or any local endpoint to 0.0.0.0.
 
 Install as a system service so the gateway starts on login:
 
@@ -183,6 +199,16 @@ Building from source requires the Cap'n Proto compiler (`capnproto` package on U
 The architecture is documented in [docs/architecture.md](docs/architecture.md).
 
 **Adapter contributions are especially welcome.** Each adapter is an independent crate (`crates/adapter-<channel>/`) that implements the same IPC contract: connect to the gateway UDS, perform Ed25519 handshake, convert platform messages to/from Cap'n Proto frames. See any existing adapter for the pattern (Telegram is the simplest; Teams shows the HTTP webhook variant).
+
+## Status
+
+Wirken 0.7.x is the current series. 0.7 gets fixes and features; 0.6 gets security fixes only.
+
+- **9 channel adapters** under `crates/adapter-*`: Telegram, Discord, Slack, Microsoft Teams, Matrix, WhatsApp, Signal, Google Chat, iMessage.
+- **8 LLM providers** in `crates/agent/src/llm.rs`: Ollama, Anthropic, OpenAI, Google Gemini, AWS Bedrock, Tinfoil, Privatemode, plus a `custom` provider for any OpenAI-compatible endpoint.
+- **15 bundled skills** under `skills/`.
+- **452 tests** in the workspace, all green on main (`cargo test --workspace`).
+- **Signed releases.** `checksums.sha256` is signed offline with an Ed25519 SSH key. `install.sh` embeds the public key inline, fetches `checksums.sha256.sig` from the release, and fails closed on any verification failure. See [docs/release-signing.md](docs/release-signing.md) and [KEYS](KEYS).
 
 ## The name
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,11 +10,25 @@
 
 ## Reporting a Vulnerability
 
-Report security vulnerabilities via GitHub's private vulnerability reporting at [github.com/gebruder/wirken/security/advisories](https://github.com/gebruder/wirken/security/advisories).
+Report security vulnerabilities via one of:
+
+- GitHub private vulnerability reporting: [github.com/gebruder/wirken/security/advisories](https://github.com/gebruder/wirken/security/advisories)
+- Email: security@gebruder.ottenheimer.app
 
 Do not open a public issue for security vulnerabilities.
 
 You should receive an initial response within 72 hours. If the vulnerability is accepted, a fix will be released as a patch version (e.g., 0.3.1) and the advisory will be published after the fix is available.
+
+## Release signing
+
+Release artifacts are signed offline with an Ed25519 SSH key. The public key is pinned in [KEYS](KEYS) at the repository root and embedded in `install.sh` so installer verification needs no network fetch of the key. The full procedure, including key rotation, is in [docs/release-signing.md](docs/release-signing.md).
+
+Current active key:
+
+- Identity: `releases@gebruder.ottenheimer.app`
+- Algorithm: `ssh-ed25519`
+- Fingerprint: recorded in `KEYS` after offline generation
+- Signed file: `checksums.sha256` for every published release (verify with `ssh-keygen -Y verify`)
 
 ## Scope
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -27,7 +27,8 @@ Current active key:
 
 - Identity: `releases@gebruder.ottenheimer.app`
 - Algorithm: `ssh-ed25519`
-- Fingerprint: recorded in `KEYS` after offline generation
+- Fingerprint: `SHA256:tzlfNHy4G1KIsmAR+cM3MGwVndheh2ak/usA6rw7SuE`
+- Issued: 2026-04-18
 - Signed file: `checksums.sha256` for every published release (verify with `ssh-keygen -Y verify`)
 
 ## Scope

--- a/crates/agent/src/llm_stream.rs
+++ b/crates/agent/src/llm_stream.rs
@@ -403,15 +403,13 @@ impl LlmClient {
                             }
                         }
                     }
-                    "content_block_stop" => {
-                        if in_tool_block && !current_tool_name.is_empty() {
-                            tool_calls.push(ToolCallRequest {
-                                id: current_tool_id.clone(),
-                                name: current_tool_name.clone(),
-                                arguments: current_tool_input.clone(),
-                            });
-                            in_tool_block = false;
-                        }
+                    "content_block_stop" if in_tool_block && !current_tool_name.is_empty() => {
+                        tool_calls.push(ToolCallRequest {
+                            id: current_tool_id.clone(),
+                            name: current_tool_name.clone(),
+                            arguments: current_tool_input.clone(),
+                        });
+                        in_tool_block = false;
                     }
                     "message_stop" => break 'stream,
                     _ => {}

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -1,252 +1,250 @@
 # Release process
 
-Step-by-step runbook for cutting a Wirken release. Follow top to bottom.
-Signing mechanics live in [release-signing.md](release-signing.md); this
-document covers the surrounding workflow.
+Step-by-step runbook. Follow top to bottom. Signing crypto details live
+in [release-signing.md](release-signing.md).
 
-## Prerequisites (one-time setup)
+## Prerequisites (one-time)
 
-- `gh` CLI authenticated to github.com with access to `gebruder/wirken`.
+- `gh` authenticated to github.com with write access to `gebruder/wirken`.
 - Offline Ed25519 signing key at `~/.ssh/wirken-release-signing` (or
-  wherever, kept outside the repo tree).
-- `ssh-keygen` (OpenSSH 8.1 or newer).
+  anywhere outside the repo tree).
+- OpenSSH 8.1+ (`ssh-keygen -Y` support).
 - `cargo`, `rustfmt`, `clippy`.
 
-Verify:
+Sanity check:
 
 ```bash
 gh auth status
-ssh-keygen -Y verify -f KEYS -I releases@gebruder.ottenheimer.app \
-    -n file -s /dev/null < /dev/null 2>&1 | head -1
+ssh-keygen -lf KEYS   # must match the fingerprint in SECURITY.md
 ```
 
-The second command will fail (no signature to verify), but it confirms
-`KEYS` parses and `ssh-keygen` is present.
+## Version scheme
 
-## Decide the version
-
-Semver. `0.X.Y`:
+Semver on `0.X.Y`:
 
 - Bump `Y` for bug fixes and docs.
-- Bump `X` for new features, new adapters, breaking config changes.
-- `1.0` when the type-level channel separation is threaded through the
+- Bump `X` for features, new adapters, breaking config changes.
+- `1.0` when type-level channel separation is threaded through the
   production message path.
 
-Every workspace crate shares one version via `workspace.package.version`
-in the root `Cargo.toml`. The git tag is `v<version>` (e.g. `v0.7.4`).
+Every workspace crate shares `workspace.package.version` in the root
+`Cargo.toml`. The git tag is `v<version>`.
 
-## Pre-flight checks on main
+## Release sequence
 
-From a clean checkout of `main`:
+Run top to bottom. Replace `0.7.4` with the target version.
 
-```bash
-git checkout main
-git pull --ff-only
-git status   # must be clean
+1. **Clean main, run pre-flight.** All four must pass; fix on a branch
+   and merge before tagging.
+   ```bash
+   git checkout main && git pull --ff-only && git status   # clean
+   cargo fmt --check
+   cargo clippy --workspace -- -D warnings
+   cargo test --workspace
+   ./scripts/test-install.sh
+   ```
 
-cargo fmt --check
-cargo clippy --workspace -- -D warnings
-cargo test --workspace
-./scripts/test-install.sh
-```
+2. **Bump the workspace version.** Edit `Cargo.toml`:
+   ```toml
+   [workspace.package]
+   version = "0.7.4"
+   ```
+   Regenerate the lockfile:
+   ```bash
+   cargo update -w
+   ```
 
-All four must pass. If any fail, fix on a branch, merge, and restart
-from this step.
+3. **Commit and push the bump. Wait for CI green on main.**
+   ```bash
+   git add Cargo.toml Cargo.lock
+   git commit -m "chore: bump version to 0.7.4"
+   git push
+   gh run watch -R gebruder/wirken   # wait for main CI
+   ```
 
-## Bump the version
+4. **Annotated tag, push.** CI triggers on the `v*` tag.
+   ```bash
+   git tag -a v0.7.4 -m "v0.7.4"
+   git push origin v0.7.4
+   ```
 
-Edit `Cargo.toml`:
+5. **Watch the release build.** Produces four binaries, `checksums.sha256`,
+   and creates a **draft** release.
+   ```bash
+   gh run watch -R gebruder/wirken
+   ```
 
-```toml
-[workspace.package]
-version = "0.7.4"
-```
+6. **Download `checksums.sha256` from the draft.** Work in a scratch
+   directory outside the repo tree (`scripts/sign-release.sh` refuses to
+   run if the private key is inside the tree).
+   ```bash
+   mkdir -p /tmp/wirken-release && cd /tmp/wirken-release
+   gh release download v0.7.4 -R gebruder/wirken --pattern checksums.sha256
+   cat checksums.sha256   # sanity: four lines, one per binary
+   ```
 
-Regenerate the lockfile:
+7. **Sign.** You will be prompted for the passphrase.
+   ```bash
+   WIRKEN_SIGNING_KEY=~/.ssh/wirken-release-signing \
+       ~/code/wirken/scripts/sign-release.sh v0.7.4
+   ```
 
-```bash
-cargo update -w
-```
+8. **Self-verify before upload.** Must print `Good "file" signature for
+   releases@gebruder.ottenheimer.app`. If it fails, do not upload. See
+   [Recovery](#recovery-during-a-release).
+   ```bash
+   ssh-keygen -Y verify \
+       -f ~/code/wirken/KEYS \
+       -I releases@gebruder.ottenheimer.app \
+       -n file \
+       -s checksums.sha256.sig \
+       < checksums.sha256
+   ```
 
-Commit:
+9. **Upload the signature to the draft.**
+   ```bash
+   gh release upload v0.7.4 checksums.sha256.sig -R gebruder/wirken
+   ```
 
-```bash
-git add Cargo.toml Cargo.lock
-git commit -m "chore: bump version to 0.7.4"
-git push
-```
+10. **Confirm all assets are attached.** You should see the four
+    binaries, `checksums.sha256`, and `checksums.sha256.sig`.
+    ```bash
+    gh release view v0.7.4 -R gebruder/wirken
+    ```
 
-CI should stay green on main before tagging. Wait for it.
+11. **Publish.** Flip from draft to published.
+    ```bash
+    gh release edit v0.7.4 -R gebruder/wirken --draft=false
+    ```
 
-## Tag and push
+12. **Smoke test.** On a fresh shell, with a scratch install dir so you
+    do not overwrite your local binary.
+    ```bash
+    WIRKEN_INSTALL_DIR=/tmp/wirken-smoke \
+        sh -c 'curl -fsSL https://raw.githubusercontent.com/gebruder/wirken/main/install.sh | sh'
+    /tmp/wirken-smoke/wirken --version
+    ```
+    The installer output must contain both
+    `Signature verified: releases@gebruder.ottenheimer.app` and
+    `Checksum verified: ...`. If either is missing the release is
+    broken. Go to [Recovery](#recovery-during-a-release).
 
-Annotated tag, version prefixed with `v`:
+Post-release housekeeping: update the README Status section counts if
+any shifted (adapters, providers, skills, tests). Clean up
+`/tmp/wirken-release` and `/tmp/wirken-smoke`.
 
-```bash
-git tag -a v0.7.4 -m "v0.7.4"
-git push origin v0.7.4
-```
-
-This triggers `.github/workflows/release.yml`. The workflow:
-
-1. Builds `wirken-x86_64-unknown-linux-musl`, `wirken-aarch64-unknown-linux-musl`,
-   `wirken-x86_64-apple-darwin`, `wirken-aarch64-apple-darwin`.
-2. Computes `checksums.sha256` over all four binaries.
-3. Creates a **draft** release with the binaries and `checksums.sha256`
-   attached. The release body tells you exactly what to do next.
-
-Watch the run:
-
-```bash
-gh run watch -R gebruder/wirken
-```
-
-If the build fails, see [Recovery](#recovery).
-
-## Sign checksums.sha256
-
-Once the draft exists, download the checksums to a scratch directory
-outside the repo (`scripts/sign-release.sh` refuses to run if the
-private key is inside the repo tree, and keeping signing work out of
-the tree is cleaner):
-
-```bash
-mkdir -p /tmp/wirken-release && cd /tmp/wirken-release
-gh release download v0.7.4 -R gebruder/wirken --pattern checksums.sha256
-cat checksums.sha256   # sanity-check: four lines, one per binary
-```
-
-Sign:
-
-```bash
-WIRKEN_SIGNING_KEY=~/.ssh/wirken-release-signing \
-    ~/code/wirken/scripts/sign-release.sh v0.7.4
-```
-
-You will be prompted for the key passphrase. Output:
-
-```
-Wrote checksums.sha256.sig
-```
-
-Self-verify before uploading:
-
-```bash
-ssh-keygen -Y verify \
-    -f ~/code/wirken/KEYS \
-    -I releases@gebruder.ottenheimer.app \
-    -n file \
-    -s checksums.sha256.sig \
-    < checksums.sha256
-```
-
-Expected: `Good "file" signature for releases@gebruder.ottenheimer.app`.
-
-If that fails, do not upload. See [Recovery](#recovery).
-
-## Upload signature and publish
-
-Upload the signature to the draft:
-
-```bash
-gh release upload v0.7.4 checksums.sha256.sig -R gebruder/wirken
-```
-
-Confirm all expected assets are attached:
-
-```bash
-gh release view v0.7.4 -R gebruder/wirken
-```
-
-You should see:
-
-- `wirken-x86_64-unknown-linux-musl`
-- `wirken-aarch64-unknown-linux-musl`
-- `wirken-x86_64-apple-darwin`
-- `wirken-aarch64-apple-darwin`
-- `checksums.sha256`
-- `checksums.sha256.sig`
-
-Publish (flip from draft to published):
-
-```bash
-gh release edit v0.7.4 -R gebruder/wirken --draft=false
-```
-
-## Smoke-test the published release
-
-On a clean shell, with a scratch `WIRKEN_INSTALL_DIR` so you do not
-overwrite your local binary:
-
-```bash
-WIRKEN_INSTALL_DIR=/tmp/wirken-smoke \
-    sh -c 'curl -fsSL https://raw.githubusercontent.com/gebruder/wirken/main/install.sh | sh'
-/tmp/wirken-smoke/wirken --version
-```
-
-Expected lines in the installer output:
-
-```
-Signature verified: releases@gebruder.ottenheimer.app
-Checksum verified: ...
-Installed to /tmp/wirken-smoke/wirken
-```
-
-If either verification line is missing, the release is broken even if
-the binary ran. Go to [Recovery](#recovery).
-
-Clean up:
-
-```bash
-rm -rf /tmp/wirken-smoke /tmp/wirken-release
-```
-
-## Post-release
-
-- Update `README.md` Status section counts if the numbers shifted
-  (adapters, providers, skills, test count).
-- If this release adds a new channel adapter, update `docs/channels.md`
-  and the README opening paragraph.
-- Close milestone / issues tagged for this version.
-
-## Recovery
+## Recovery during a release
 
 **CI failed on the tag push.** The tag exists on GitHub but no draft
-release was created. Fix the build, then delete and retag:
-
+was created.
 ```bash
 git tag -d v0.7.4
 git push --delete origin v0.7.4
-# fix, commit, push main
-git tag -a v0.7.4 -m "v0.7.4"
-git push origin v0.7.4
+# fix on main, then restart from step 4
 ```
 
-**You signed but verification failed against `KEYS`.** The signing key
-you used does not match the key pinned in the repo. Check
-`WIRKEN_SIGNING_KEY` points at the right file and re-run signing. Do
-not publish an unverified signature.
+**Signature verification failed in step 8.** The key you signed with
+does not match the key pinned in the repo. Check `WIRKEN_SIGNING_KEY`
+points at the right file. Do not upload an unverified signature.
 
-**You uploaded the wrong signature.** Delete the asset and re-upload:
-
+**You uploaded the wrong signature.**
 ```bash
 gh release delete-asset v0.7.4 checksums.sha256.sig -R gebruder/wirken --yes
 gh release upload v0.7.4 checksums.sha256.sig -R gebruder/wirken
 ```
 
 **You already published a bad release.** Do not delete it; users may
-already have downloaded it. Instead:
+have already downloaded. Publish a patch (`v0.7.5`) with the fix, then
+edit the bad release body to prepend `**Broken — use v0.7.5.**`. If
+the bad release is actively harmful (wrong binary, leaked credential),
+delete the binaries and signature from the release but leave the page
+with an explanatory note so the installer fails cleanly rather than
+silently installing stale content.
 
-1. Publish a patch version (`v0.7.5`) with the fix.
-2. On the bad release, edit the body to add a `**Broken — use
-   v0.7.5.**` notice at the top.
-3. If the bad release is actively harmful (wrong binary, corrupt
-   signature, credential leak), delete the binaries and signature from
-   the release but leave the release page with an explanatory note, so
-   users hitting the installer see a clean failure rather than a silent
-   broken install.
+## Key rotation
 
-**Private key compromise suspected.** Follow the key rotation
-procedure in [release-signing.md](release-signing.md#rotate-the-key),
-then re-sign and publish the next release with the new key. Alert via
-`security@gebruder.ottenheimer.app`.
+Three-step dependency. Do not reorder.
+
+1. **Generate the new key offline.** Record the fingerprint and issue
+   date.
+   ```bash
+   ssh-keygen -t ed25519 -C releases@gebruder.ottenheimer.app \
+       -f wirken-release-signing-NEW
+   ssh-keygen -lf wirken-release-signing-NEW.pub
+   ```
+   Store the private key outside the repo tree. Do not overwrite the
+   old private key until step 3 publishes.
+
+2. **In one commit on main, swap the trust anchor.** Every file that
+   pins the public key updates together:
+   - `KEYS`: add the new key as the active entry; mark the old key
+     with a `# Retired YYYY-MM-DD` comment (keep it in the file for
+     verifying pre-rotation releases).
+   - `install.sh`: replace `ALLOWED_SIGNERS` with the new public key
+     line. Update the `# Current active key` header fingerprint.
+   - `README.md`: bump the pinned install.sh SHA-256 (the value is
+     whatever `sha256sum install.sh` prints after the edit).
+   - `SECURITY.md`: update the active fingerprint and issue date.
+
+   Merge the commit.
+
+3. **Immediately tag and cut the next release with the new key.** Run
+   [the release sequence](#release-sequence) from step 4 onward using
+   the new private key for signing.
+
+**Ordering trap.** Between merging step 2 and publishing step 3, the
+installer on `main` trusts the new key but the latest release is still
+signed with the old key. `curl | sh` from the install URL exits 5
+during that window. Keep the window as short as possible: merge the
+rotation commit and tag the release in the same sitting, not days
+apart. Users with a pinned older `install.sh` are unaffected.
+
+## Key loss or compromise recovery
+
+Same shape as rotation, but with the caveats below. Severity depends
+on whether the old private key was lost (no one has it) or compromised
+(someone else might).
+
+**Users with an already-installed binary are unaffected.** The binary
+they run has no trust path to the release key. Signature verification
+only runs at install time.
+
+**Users with a pinned older `install.sh` keep working** against
+existing releases as long as those releases' signatures still verify
+under the old public key. The old public key stays in their pinned
+`install.sh` either way.
+
+**New installs from `main` break until you cut a new signed release.**
+That is the only user-visible cost. Worst case is a few hours to a few
+days of broken `curl | sh`, not catastrophic.
+
+Procedure:
+
+1. **Generate a new key offline.** Same command as rotation step 1.
+
+2. **Swap the trust anchor in one commit.** Same edits as rotation
+   step 2 with two differences:
+   - **If compromised (not just lost):** remove the old key from `KEYS`
+     entirely instead of retiring it. Any binary signed by the
+     compromised key must no longer be treated as trustworthy.
+     Explicitly yank the old releases: edit each existing release to
+     prepend `**Revoked — key compromised. Upgrade to vX.Y.Z.**`.
+   - **If only lost:** keep the old key in `KEYS` with
+     `# Retired YYYY-MM-DD — private key lost, no further signatures
+     will be produced`. Old releases stay verifiable.
+
+3. **Tag and publish a new signed release immediately.** If the loss
+   is an emergency (compromise), bump a patch version with no code
+   changes just to get a release signed under the new key out to
+   `main`-following users. The release's only purpose is to restore
+   the trust path.
+
+4. **If compromised, publish an advisory.** Post to
+   `security@gebruder.ottenheimer.app` and a GitHub security advisory:
+   which key fingerprint is revoked, which releases are affected, and
+   which version to upgrade to. Rotate any other credentials that
+   shared the same storage as the compromised private key.
+
+No recovery option short of this: there is no global revocation
+mechanism for ssh-keygen signatures. Trust anchor swap + new signed
+release is the whole fix.

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -1,21 +1,34 @@
 # Release process
 
-Step-by-step runbook. Follow top to bottom. Signing crypto details live
-in [release-signing.md](release-signing.md).
+Step-by-step maintainer runbook. Follow top to bottom. Signing crypto
+details live in [release-signing.md](release-signing.md).
+
+> **Audience.** This document is for maintainers who hold the offline
+> release signing key. Contributors and users do not run these steps;
+> they consume published releases. To verify a release you downloaded,
+> see the manual verification snippet in
+> [release-signing.md](release-signing.md#verify-a-release-manually).
 
 ## Prerequisites (one-time)
 
 - `gh` authenticated to github.com with write access to `gebruder/wirken`.
-- Offline Ed25519 signing key at `~/.ssh/wirken-release-signing` (or
-  anywhere outside the repo tree).
+- Offline Ed25519 signing key stored outside the repo tree. Examples in
+  this document assume `~/.ssh/wirken-release-signing`; substitute your
+  actual path.
 - OpenSSH 8.1+ (`ssh-keygen -Y` support).
 - `cargo`, `rustfmt`, `clippy`.
+- `REPO` environment variable pointing at your local `wirken` checkout:
+  ```bash
+  export REPO=~/code/wirken   # wherever you cloned it
+  ```
+  Commands below reference `"$REPO"/scripts/sign-release.sh` and
+  `"$REPO"/KEYS`.
 
 Sanity check:
 
 ```bash
 gh auth status
-ssh-keygen -lf KEYS   # must match the fingerprint in SECURITY.md
+ssh-keygen -lf "$REPO"/KEYS   # must match the fingerprint in SECURITY.md
 ```
 
 ## Version scheme
@@ -86,7 +99,7 @@ Run top to bottom. Replace `0.7.4` with the target version.
 7. **Sign.** You will be prompted for the passphrase.
    ```bash
    WIRKEN_SIGNING_KEY=~/.ssh/wirken-release-signing \
-       ~/code/wirken/scripts/sign-release.sh v0.7.4
+       "$REPO"/scripts/sign-release.sh v0.7.4
    ```
 
 8. **Self-verify before upload.** Must print `Good "file" signature for
@@ -94,7 +107,7 @@ Run top to bottom. Replace `0.7.4` with the target version.
    [Recovery](#recovery-during-a-release).
    ```bash
    ssh-keygen -Y verify \
-       -f ~/code/wirken/KEYS \
+       -f "$REPO"/KEYS \
        -I releases@gebruder.ottenheimer.app \
        -n file \
        -s checksums.sha256.sig \

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -1,0 +1,252 @@
+# Release process
+
+Step-by-step runbook for cutting a Wirken release. Follow top to bottom.
+Signing mechanics live in [release-signing.md](release-signing.md); this
+document covers the surrounding workflow.
+
+## Prerequisites (one-time setup)
+
+- `gh` CLI authenticated to github.com with access to `gebruder/wirken`.
+- Offline Ed25519 signing key at `~/.ssh/wirken-release-signing` (or
+  wherever, kept outside the repo tree).
+- `ssh-keygen` (OpenSSH 8.1 or newer).
+- `cargo`, `rustfmt`, `clippy`.
+
+Verify:
+
+```bash
+gh auth status
+ssh-keygen -Y verify -f KEYS -I releases@gebruder.ottenheimer.app \
+    -n file -s /dev/null < /dev/null 2>&1 | head -1
+```
+
+The second command will fail (no signature to verify), but it confirms
+`KEYS` parses and `ssh-keygen` is present.
+
+## Decide the version
+
+Semver. `0.X.Y`:
+
+- Bump `Y` for bug fixes and docs.
+- Bump `X` for new features, new adapters, breaking config changes.
+- `1.0` when the type-level channel separation is threaded through the
+  production message path.
+
+Every workspace crate shares one version via `workspace.package.version`
+in the root `Cargo.toml`. The git tag is `v<version>` (e.g. `v0.7.4`).
+
+## Pre-flight checks on main
+
+From a clean checkout of `main`:
+
+```bash
+git checkout main
+git pull --ff-only
+git status   # must be clean
+
+cargo fmt --check
+cargo clippy --workspace -- -D warnings
+cargo test --workspace
+./scripts/test-install.sh
+```
+
+All four must pass. If any fail, fix on a branch, merge, and restart
+from this step.
+
+## Bump the version
+
+Edit `Cargo.toml`:
+
+```toml
+[workspace.package]
+version = "0.7.4"
+```
+
+Regenerate the lockfile:
+
+```bash
+cargo update -w
+```
+
+Commit:
+
+```bash
+git add Cargo.toml Cargo.lock
+git commit -m "chore: bump version to 0.7.4"
+git push
+```
+
+CI should stay green on main before tagging. Wait for it.
+
+## Tag and push
+
+Annotated tag, version prefixed with `v`:
+
+```bash
+git tag -a v0.7.4 -m "v0.7.4"
+git push origin v0.7.4
+```
+
+This triggers `.github/workflows/release.yml`. The workflow:
+
+1. Builds `wirken-x86_64-unknown-linux-musl`, `wirken-aarch64-unknown-linux-musl`,
+   `wirken-x86_64-apple-darwin`, `wirken-aarch64-apple-darwin`.
+2. Computes `checksums.sha256` over all four binaries.
+3. Creates a **draft** release with the binaries and `checksums.sha256`
+   attached. The release body tells you exactly what to do next.
+
+Watch the run:
+
+```bash
+gh run watch -R gebruder/wirken
+```
+
+If the build fails, see [Recovery](#recovery).
+
+## Sign checksums.sha256
+
+Once the draft exists, download the checksums to a scratch directory
+outside the repo (`scripts/sign-release.sh` refuses to run if the
+private key is inside the repo tree, and keeping signing work out of
+the tree is cleaner):
+
+```bash
+mkdir -p /tmp/wirken-release && cd /tmp/wirken-release
+gh release download v0.7.4 -R gebruder/wirken --pattern checksums.sha256
+cat checksums.sha256   # sanity-check: four lines, one per binary
+```
+
+Sign:
+
+```bash
+WIRKEN_SIGNING_KEY=~/.ssh/wirken-release-signing \
+    ~/code/wirken/scripts/sign-release.sh v0.7.4
+```
+
+You will be prompted for the key passphrase. Output:
+
+```
+Wrote checksums.sha256.sig
+```
+
+Self-verify before uploading:
+
+```bash
+ssh-keygen -Y verify \
+    -f ~/code/wirken/KEYS \
+    -I releases@gebruder.ottenheimer.app \
+    -n file \
+    -s checksums.sha256.sig \
+    < checksums.sha256
+```
+
+Expected: `Good "file" signature for releases@gebruder.ottenheimer.app`.
+
+If that fails, do not upload. See [Recovery](#recovery).
+
+## Upload signature and publish
+
+Upload the signature to the draft:
+
+```bash
+gh release upload v0.7.4 checksums.sha256.sig -R gebruder/wirken
+```
+
+Confirm all expected assets are attached:
+
+```bash
+gh release view v0.7.4 -R gebruder/wirken
+```
+
+You should see:
+
+- `wirken-x86_64-unknown-linux-musl`
+- `wirken-aarch64-unknown-linux-musl`
+- `wirken-x86_64-apple-darwin`
+- `wirken-aarch64-apple-darwin`
+- `checksums.sha256`
+- `checksums.sha256.sig`
+
+Publish (flip from draft to published):
+
+```bash
+gh release edit v0.7.4 -R gebruder/wirken --draft=false
+```
+
+## Smoke-test the published release
+
+On a clean shell, with a scratch `WIRKEN_INSTALL_DIR` so you do not
+overwrite your local binary:
+
+```bash
+WIRKEN_INSTALL_DIR=/tmp/wirken-smoke \
+    sh -c 'curl -fsSL https://raw.githubusercontent.com/gebruder/wirken/main/install.sh | sh'
+/tmp/wirken-smoke/wirken --version
+```
+
+Expected lines in the installer output:
+
+```
+Signature verified: releases@gebruder.ottenheimer.app
+Checksum verified: ...
+Installed to /tmp/wirken-smoke/wirken
+```
+
+If either verification line is missing, the release is broken even if
+the binary ran. Go to [Recovery](#recovery).
+
+Clean up:
+
+```bash
+rm -rf /tmp/wirken-smoke /tmp/wirken-release
+```
+
+## Post-release
+
+- Update `README.md` Status section counts if the numbers shifted
+  (adapters, providers, skills, test count).
+- If this release adds a new channel adapter, update `docs/channels.md`
+  and the README opening paragraph.
+- Close milestone / issues tagged for this version.
+
+## Recovery
+
+**CI failed on the tag push.** The tag exists on GitHub but no draft
+release was created. Fix the build, then delete and retag:
+
+```bash
+git tag -d v0.7.4
+git push --delete origin v0.7.4
+# fix, commit, push main
+git tag -a v0.7.4 -m "v0.7.4"
+git push origin v0.7.4
+```
+
+**You signed but verification failed against `KEYS`.** The signing key
+you used does not match the key pinned in the repo. Check
+`WIRKEN_SIGNING_KEY` points at the right file and re-run signing. Do
+not publish an unverified signature.
+
+**You uploaded the wrong signature.** Delete the asset and re-upload:
+
+```bash
+gh release delete-asset v0.7.4 checksums.sha256.sig -R gebruder/wirken --yes
+gh release upload v0.7.4 checksums.sha256.sig -R gebruder/wirken
+```
+
+**You already published a bad release.** Do not delete it; users may
+already have downloaded it. Instead:
+
+1. Publish a patch version (`v0.7.5`) with the fix.
+2. On the bad release, edit the body to add a `**Broken — use
+   v0.7.5.**` notice at the top.
+3. If the bad release is actively harmful (wrong binary, corrupt
+   signature, credential leak), delete the binaries and signature from
+   the release but leave the release page with an explanatory note, so
+   users hitting the installer see a clean failure rather than a silent
+   broken install.
+
+**Private key compromise suspected.** Follow the key rotation
+procedure in [release-signing.md](release-signing.md#rotate-the-key),
+then re-sign and publish the next release with the new key. Alert via
+`security@gebruder.ottenheimer.app`.

--- a/docs/release-signing.md
+++ b/docs/release-signing.md
@@ -1,5 +1,8 @@
 # Release signing
 
+> Cutting a release? Follow [release-process.md](release-process.md) end
+> to end. This document covers the signing internals only.
+
 Every Wirken release is signed with an offline Ed25519 SSH key. The
 installer fetches `checksums.sha256.sig` alongside `checksums.sha256` and
 verifies both with `ssh-keygen -Y verify` before touching the binary.

--- a/docs/release-signing.md
+++ b/docs/release-signing.md
@@ -1,123 +1,87 @@
 # Release signing
 
-> Cutting a release? Follow [release-process.md](release-process.md) end
-> to end. This document covers the signing internals only.
+> To cut a release, follow [release-process.md](release-process.md).
+> This document is the crypto reference and the paste-ready manual
+> verification snippet.
 
 Every Wirken release is signed with an offline Ed25519 SSH key. The
-installer fetches `checksums.sha256.sig` alongside `checksums.sha256` and
-verifies both with `ssh-keygen -Y verify` before touching the binary.
-
-Verification needs only OpenSSH 8.1 or newer, which ships with every
-supported Linux distribution and macOS release. No new user-side
-dependency.
+installer fetches `checksums.sha256.sig` alongside `checksums.sha256`
+and verifies both with `ssh-keygen -Y verify` before touching the
+binary. Verification needs only OpenSSH 8.1+, which ships on every
+supported platform. No new user-side dependency.
 
 ## Trust anchor
 
-The public half of the signing key is pinned in two places:
+The public half of the release signing key is pinned in two places:
 
-- `KEYS` at the repository root, for manual verification.
-- `install.sh`, embedded as an `ALLOWED_SIGNERS` shell variable. The
+- `KEYS` at the repository root (OpenSSH allowed_signers format).
+- `install.sh`, embedded as the `ALLOWED_SIGNERS` shell variable. The
   installer never fetches the key over the network.
 
-`SECURITY.md` records the fingerprint and cross-references this document.
+`SECURITY.md` records the active fingerprint and cross-references this
+document.
 
-## Generate the offline key
+## What the signature covers
 
-Do this on an air-gapped machine, or at minimum on a machine that never
-uploads the private key anywhere.
+The signature is over `checksums.sha256`. The installer does two things:
 
-```
-ssh-keygen -t ed25519 -C releases@gebruder.ottenheimer.app -f wirken-release-signing
-```
+1. Verifies the `ssh-keygen -Y` signature on `checksums.sha256` against
+   the embedded `ALLOWED_SIGNERS`.
+2. Computes the SHA-256 of the downloaded binary and matches it against
+   the line for that binary in the signed checksums file.
 
-Record the fingerprint. This value goes into `KEYS` and `SECURITY.md`:
+Both must pass. A forged binary without a matching checksum fails
+step 2. A forged `checksums.sha256` without the private key fails
+step 1.
 
-```
-ssh-keygen -lf wirken-release-signing.pub
-```
+## Verify a release manually
 
-Paste the single-line contents of `wirken-release-signing.pub` into the
-placeholder slot in `KEYS` and into the `ALLOWED_SIGNERS` variable in
-`install.sh`. Do not commit `wirken-release-signing` (the private key).
-Store it encrypted (YubiKey, hardware token, or an offline volume).
+Paste-ready. Does not trust `install.sh` or the current `main`. Pins
+`KEYS` to a specific commit, so even a compromised `main` cannot shift
+the trust anchor under you.
 
-Update `SECURITY.md` with the fingerprint and issue date.
+```bash
+TAG=v0.7.4                                    # release to verify
+BINARY=wirken-x86_64-unknown-linux-musl       # your platform
+PINNED_COMMIT=<40-char-sha-of-an-audited-commit>
 
-## Sign a release
+mkdir /tmp/wirken-verify && cd /tmp/wirken-verify
 
-```
-WIRKEN_SIGNING_KEY=/secure/path/to/wirken-release-signing \
-    scripts/sign-release.sh vX.Y.Z
-```
+curl -fsSLO "https://github.com/gebruder/wirken/releases/download/$TAG/$BINARY"
+curl -fsSLO "https://github.com/gebruder/wirken/releases/download/$TAG/checksums.sha256"
+curl -fsSLO "https://github.com/gebruder/wirken/releases/download/$TAG/checksums.sha256.sig"
+curl -fsSL  "https://raw.githubusercontent.com/gebruder/wirken/$PINNED_COMMIT/KEYS" -o KEYS
 
-`sign-release.sh` reads the local `checksums.sha256` (produced by the
-release workflow and downloaded from the draft release) and writes
-`checksums.sha256.sig` next to it. Upload the signature to the draft
-release before publishing.
-
-Under the hood it runs:
-
-```
-ssh-keygen -Y sign \
-    -n file \
-    -f "$WIRKEN_SIGNING_KEY" \
-    checksums.sha256
-```
-
-CI never holds the private key. The release workflow builds artifacts,
-computes checksums, and uploads everything to a draft release. Signing
-happens on the maintainer's machine. The signature is attached to the
-draft, and the draft is then published.
-
-## Verify a release
-
-```
-curl -fsSLO https://github.com/gebruder/wirken/releases/download/vX.Y.Z/checksums.sha256
-curl -fsSLO https://github.com/gebruder/wirken/releases/download/vX.Y.Z/checksums.sha256.sig
-curl -fsSLO https://raw.githubusercontent.com/gebruder/wirken/main/KEYS
-
+# 1. Signature over checksums.sha256 must verify against pinned KEYS.
 ssh-keygen -Y verify \
     -f KEYS \
     -I releases@gebruder.ottenheimer.app \
     -n file \
     -s checksums.sha256.sig \
     < checksums.sha256
+
+# 2. Binary's SHA-256 must match the signed line.
+grep " $BINARY\$" checksums.sha256 | sha256sum -c -
 ```
 
-`Good "file" signature for releases@gebruder.ottenheimer.app` means the
-checksums file was signed by the current release key.
+Expected output:
 
-## Rotate the key
+```
+Good "file" signature for releases@gebruder.ottenheimer.app with ED25519 key SHA256:tzlfNHy4G1KIsmAR+cM3MGwVndheh2ak/usA6rw7SuE
+wirken-x86_64-unknown-linux-musl: OK
+```
 
-Rotation happens on schedule (annually) and on any suspected compromise.
+Set `PINNED_COMMIT` to a commit you personally audited, the commit you
+originally installed from, or the commit referenced in a SECURITY
+advisory. Pulling `KEYS` from `main` is fine for casual verification;
+pinning is for the threat model where `main` itself might be suspect.
 
-1. Generate a new key on the offline machine.
-2. Append the new public key to `KEYS` with a fresh issue date.
-3. Leave the old key in `KEYS` for a deprecation window so pre-rotation
-   releases still verify. Add a `# Retired YYYY-MM-DD` comment.
-4. Update `ALLOWED_SIGNERS` in `install.sh` to the new key. The installer
-   only trusts one active key at a time.
-5. Update the active fingerprint in `SECURITY.md`.
-6. Sign the next release with the new key.
-7. Destroy or archive the retired private key.
-
-Do not reuse the retired `releases@gebruder.ottenheimer.app` identity for
-other purposes.
-
-## What the signature covers
-
-The signature is over `checksums.sha256`. The installer:
-
-1. Verifies the `ssh-keygen -Y` signature on `checksums.sha256`.
-2. Computes the SHA-256 of the downloaded binary.
-3. Matches it against the line for that binary in the signed checksums.
-
-Both steps must pass. A forged binary without a matching checksum fails
-step 2. A forged checksums file without the private key fails step 1.
+Cross-check the fingerprint in the first line of output against the
+one recorded in [SECURITY.md](../SECURITY.md) and in the `KEYS`
+comments at the pinned commit. They must match.
 
 ## Escape hatch
 
-The installer respects `WIRKEN_ALLOW_UNVERIFIED=1` for disaster recovery,
-for example when the signing key has been rotated out and the old
-checksums file is being replayed. The variable warns on stderr, proceeds,
-and is never the default. Never recommend it in end-user docs.
+The installer respects `WIRKEN_ALLOW_UNVERIFIED=1` for disaster
+recovery only. It warns on stderr and proceeds. Never default it on.
+Never recommend it in end-user docs.

--- a/docs/release-signing.md
+++ b/docs/release-signing.md
@@ -1,0 +1,120 @@
+# Release signing
+
+Every Wirken release is signed with an offline Ed25519 SSH key. The
+installer fetches `checksums.sha256.sig` alongside `checksums.sha256` and
+verifies both with `ssh-keygen -Y verify` before touching the binary.
+
+Verification needs only OpenSSH 8.1 or newer, which ships with every
+supported Linux distribution and macOS release. No new user-side
+dependency.
+
+## Trust anchor
+
+The public half of the signing key is pinned in two places:
+
+- `KEYS` at the repository root, for manual verification.
+- `install.sh`, embedded as an `ALLOWED_SIGNERS` shell variable. The
+  installer never fetches the key over the network.
+
+`SECURITY.md` records the fingerprint and cross-references this document.
+
+## Generate the offline key
+
+Do this on an air-gapped machine, or at minimum on a machine that never
+uploads the private key anywhere.
+
+```
+ssh-keygen -t ed25519 -C releases@gebruder.ottenheimer.app -f wirken-release-signing
+```
+
+Record the fingerprint. This value goes into `KEYS` and `SECURITY.md`:
+
+```
+ssh-keygen -lf wirken-release-signing.pub
+```
+
+Paste the single-line contents of `wirken-release-signing.pub` into the
+placeholder slot in `KEYS` and into the `ALLOWED_SIGNERS` variable in
+`install.sh`. Do not commit `wirken-release-signing` (the private key).
+Store it encrypted (YubiKey, hardware token, or an offline volume).
+
+Update `SECURITY.md` with the fingerprint and issue date.
+
+## Sign a release
+
+```
+WIRKEN_SIGNING_KEY=/secure/path/to/wirken-release-signing \
+    scripts/sign-release.sh vX.Y.Z
+```
+
+`sign-release.sh` reads the local `checksums.sha256` (produced by the
+release workflow and downloaded from the draft release) and writes
+`checksums.sha256.sig` next to it. Upload the signature to the draft
+release before publishing.
+
+Under the hood it runs:
+
+```
+ssh-keygen -Y sign \
+    -n file \
+    -f "$WIRKEN_SIGNING_KEY" \
+    checksums.sha256
+```
+
+CI never holds the private key. The release workflow builds artifacts,
+computes checksums, and uploads everything to a draft release. Signing
+happens on the maintainer's machine. The signature is attached to the
+draft, and the draft is then published.
+
+## Verify a release
+
+```
+curl -fsSLO https://github.com/gebruder/wirken/releases/download/vX.Y.Z/checksums.sha256
+curl -fsSLO https://github.com/gebruder/wirken/releases/download/vX.Y.Z/checksums.sha256.sig
+curl -fsSLO https://raw.githubusercontent.com/gebruder/wirken/main/KEYS
+
+ssh-keygen -Y verify \
+    -f KEYS \
+    -I releases@gebruder.ottenheimer.app \
+    -n file \
+    -s checksums.sha256.sig \
+    < checksums.sha256
+```
+
+`Good "file" signature for releases@gebruder.ottenheimer.app` means the
+checksums file was signed by the current release key.
+
+## Rotate the key
+
+Rotation happens on schedule (annually) and on any suspected compromise.
+
+1. Generate a new key on the offline machine.
+2. Append the new public key to `KEYS` with a fresh issue date.
+3. Leave the old key in `KEYS` for a deprecation window so pre-rotation
+   releases still verify. Add a `# Retired YYYY-MM-DD` comment.
+4. Update `ALLOWED_SIGNERS` in `install.sh` to the new key. The installer
+   only trusts one active key at a time.
+5. Update the active fingerprint in `SECURITY.md`.
+6. Sign the next release with the new key.
+7. Destroy or archive the retired private key.
+
+Do not reuse the retired `releases@gebruder.ottenheimer.app` identity for
+other purposes.
+
+## What the signature covers
+
+The signature is over `checksums.sha256`. The installer:
+
+1. Verifies the `ssh-keygen -Y` signature on `checksums.sha256`.
+2. Computes the SHA-256 of the downloaded binary.
+3. Matches it against the line for that binary in the signed checksums.
+
+Both steps must pass. A forged binary without a matching checksum fails
+step 2. A forged checksums file without the private key fails step 1.
+
+## Escape hatch
+
+The installer respects `WIRKEN_ALLOW_UNVERIFIED=1` for disaster recovery,
+for example when the signing key has been rotated out and the old
+checksums file is being replayed. The variable warns on stderr, proceeds,
+and is never the default. Never recommend it in end-user docs.

--- a/install.sh
+++ b/install.sh
@@ -25,7 +25,7 @@ INSTALL_DIR="${WIRKEN_INSTALL_DIR:-$HOME/.local/bin}"
 # this script so verification does not depend on a network fetch of KEYS.
 # REPLACE: paste the public key line from KEYS after offline key generation.
 # --------------------------------------------------------------------------
-ALLOWED_SIGNERS='releases@gebruder.ottenheimer.app ssh-ed25519 REPLACE_ME_WITH_PUBLIC_KEY'
+ALLOWED_SIGNERS='releases@gebruder.ottenheimer.app ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPcGuqLSfpN+ibltPVbif7i9LgclLtRIaL+1TuYp+RjV releases@gebruder.ottenheimer.app'
 SIGNER_IDENTITY="releases@gebruder.ottenheimer.app"
 
 UNVERIFIED_WARNED=0

--- a/install.sh
+++ b/install.sh
@@ -1,11 +1,34 @@
 #!/bin/sh
 # Wirken installer
 # Usage: curl -fsSL https://raw.githubusercontent.com/gebruder/wirken/main/install.sh | sh
+#
+# Exit codes:
+#   1  generic failure (unsupported OS/arch, download failure, etc.)
+#   2  could not fetch checksums.sha256
+#   3  target binary not listed in checksums.sha256
+#   4  neither sha256sum nor shasum is installed
+#   5  signature missing, invalid, or ssh-keygen unavailable
+#
+# Escape hatch:
+#   WIRKEN_ALLOW_UNVERIFIED=1  proceed despite checksum or signature failure.
+#                              Warns once. Use only for disaster recovery.
+#
+# Never binds services to 0.0.0.0. Wirken binds local endpoints to 127.0.0.1.
 
-set -e
+set -eu
 
 REPO="gebruder/wirken"
 INSTALL_DIR="${WIRKEN_INSTALL_DIR:-$HOME/.local/bin}"
+
+# --------------------------------------------------------------------------
+# Allowed signers for ssh-keygen -Y verify. The public key is embedded in
+# this script so verification does not depend on a network fetch of KEYS.
+# REPLACE: paste the public key line from KEYS after offline key generation.
+# --------------------------------------------------------------------------
+ALLOWED_SIGNERS='releases@gebruder.ottenheimer.app ssh-ed25519 REPLACE_ME_WITH_PUBLIC_KEY'
+SIGNER_IDENTITY="releases@gebruder.ottenheimer.app"
+
+UNVERIFIED_WARNED=0
 
 main() {
     detect_platform
@@ -55,54 +78,131 @@ get_latest_version() {
     echo "Version: ${VERSION}"
 }
 
+# Handle a verification failure. Honors the WIRKEN_ALLOW_UNVERIFIED escape
+# hatch. Exits with $1 unless the escape hatch is set, in which case it
+# warns once and returns 0.
+verification_failure() {
+    code="$1"
+    message="$2"
+
+    if [ "${WIRKEN_ALLOW_UNVERIFIED:-0}" = "1" ]; then
+        if [ "$UNVERIFIED_WARNED" -eq 0 ]; then
+            echo "WARNING: WIRKEN_ALLOW_UNVERIFIED=1 set. Proceeding without verification." >&2
+            echo "WARNING: You are running an unverified binary. Do not do this in production." >&2
+            UNVERIFIED_WARNED=1
+        fi
+        echo "WARNING: ${message}" >&2
+        return 0
+    fi
+
+    echo "Error: ${message}" >&2
+    echo "Hint: set WIRKEN_ALLOW_UNVERIFIED=1 to override (not recommended)." >&2
+    rm -rf "${TMPDIR:-/nonexistent}"
+    exit "$code"
+}
+
 download_binary() {
     BINARY_NAME="wirken-${TARGET}"
     URL="https://github.com/${REPO}/releases/download/${VERSION}/${BINARY_NAME}"
     CHECKSUM_URL="https://github.com/${REPO}/releases/download/${VERSION}/checksums.sha256"
+    SIG_URL="https://github.com/${REPO}/releases/download/${VERSION}/checksums.sha256.sig"
+
     TMPDIR=$(mktemp -d)
     TMPFILE="${TMPDIR}/wirken"
+    CHECKSUM_FILE="${TMPDIR}/checksums.sha256"
+    SIG_FILE="${TMPDIR}/checksums.sha256.sig"
+    SIGNERS_FILE="${TMPDIR}/allowed_signers"
 
     echo "Downloading ${URL}"
     curl -fsSL -o "$TMPFILE" "$URL"
 
-    # Verify SHA256 checksum if available
-    CHECKSUM_FILE="${TMPDIR}/checksums.sha256"
-    if curl -fsSL -o "$CHECKSUM_FILE" "$CHECKSUM_URL" 2>/dev/null; then
-        EXPECTED=$(grep "${BINARY_NAME}$" "$CHECKSUM_FILE" | awk '{print $1}')
-        if [ -n "$EXPECTED" ]; then
-            if command -v sha256sum >/dev/null 2>&1; then
-                ACTUAL=$(sha256sum "$TMPFILE" | awk '{print $1}')
-            elif command -v shasum >/dev/null 2>&1; then
-                ACTUAL=$(shasum -a 256 "$TMPFILE" | awk '{print $1}')
-            else
-                echo "Warning: no sha256sum or shasum found, skipping checksum verification" >&2
-                ACTUAL=""
-            fi
-            if [ -n "$ACTUAL" ]; then
-                if [ "$EXPECTED" != "$ACTUAL" ]; then
-                    echo "Error: checksum mismatch!" >&2
-                    echo "  Expected: ${EXPECTED}" >&2
-                    echo "  Actual:   ${ACTUAL}" >&2
-                    rm -rf "$TMPDIR"
-                    exit 1
-                fi
-                echo "Checksum verified: ${EXPECTED}"
-            fi
-        else
-            echo "Warning: binary not found in checksums file, skipping verification" >&2
-        fi
-    else
-        echo "Warning: checksums file not available, skipping verification" >&2
-    fi
+    verify_signature
+    verify_checksum
 
     chmod +x "$TMPFILE"
 }
 
+# Fetch checksums.sha256.sig and verify with ssh-keygen -Y against the
+# embedded allowed_signers entry. Exit 5 on failure unless the escape
+# hatch is set.
+verify_signature() {
+    # Fetch signature first; an unavailable sig is a hard failure.
+    if ! curl -fsSL -o "$SIG_FILE" "$SIG_URL"; then
+        verification_failure 5 "could not fetch signature file ${SIG_URL}"
+        return 0
+    fi
+
+    # We also need checksums.sha256 to verify the signature over.
+    if ! curl -fsSL -o "$CHECKSUM_FILE" "$CHECKSUM_URL"; then
+        verification_failure 2 "could not fetch ${CHECKSUM_URL}"
+        return 0
+    fi
+
+    if ! command -v ssh-keygen >/dev/null 2>&1; then
+        verification_failure 5 "ssh-keygen not found; install OpenSSH 8.1+ to verify release signatures"
+        return 0
+    fi
+
+    # Reject the placeholder public key rather than silently accepting.
+    case "$ALLOWED_SIGNERS" in
+        *REPLACE_ME_WITH_PUBLIC_KEY*)
+            verification_failure 5 "installer has placeholder signing key; cannot verify"
+            return 0
+            ;;
+    esac
+
+    printf '%s\n' "$ALLOWED_SIGNERS" > "$SIGNERS_FILE"
+
+    if ! ssh-keygen -Y verify \
+            -f "$SIGNERS_FILE" \
+            -I "$SIGNER_IDENTITY" \
+            -n file \
+            -s "$SIG_FILE" \
+            < "$CHECKSUM_FILE" >/dev/null 2>&1; then
+        verification_failure 5 "signature on checksums.sha256 did not verify against release signing key"
+        return 0
+    fi
+
+    echo "Signature verified: ${SIGNER_IDENTITY}"
+}
+
+# Verify the binary's SHA-256 against the signed checksums file. All
+# failure paths are hard errors unless the escape hatch is set.
+verify_checksum() {
+    # Re-fetch only if verify_signature did not already.
+    if [ ! -s "$CHECKSUM_FILE" ]; then
+        if ! curl -fsSL -o "$CHECKSUM_FILE" "$CHECKSUM_URL"; then
+            verification_failure 2 "could not fetch ${CHECKSUM_URL}"
+            return 0
+        fi
+    fi
+
+    EXPECTED=$(grep " ${BINARY_NAME}\$" "$CHECKSUM_FILE" | awk '{print $1}')
+    if [ -z "$EXPECTED" ]; then
+        verification_failure 3 "${BINARY_NAME} not listed in checksums.sha256"
+        return 0
+    fi
+
+    if command -v sha256sum >/dev/null 2>&1; then
+        ACTUAL=$(sha256sum "$TMPFILE" | awk '{print $1}')
+    elif command -v shasum >/dev/null 2>&1; then
+        ACTUAL=$(shasum -a 256 "$TMPFILE" | awk '{print $1}')
+    else
+        verification_failure 4 "neither sha256sum nor shasum found; install coreutils or perl-shasum"
+        return 0
+    fi
+
+    if [ "$EXPECTED" != "$ACTUAL" ]; then
+        verification_failure 1 "checksum mismatch: expected ${EXPECTED}, got ${ACTUAL}"
+        return 0
+    fi
+
+    echo "Checksum verified: ${EXPECTED}"
+}
+
 install_binary() {
-    # Try user directory first
     mkdir -p "$INSTALL_DIR" 2>/dev/null || true
 
-    # Check for existing install and compare versions
     EXISTING="${INSTALL_DIR}/wirken"
     if [ -x "$EXISTING" ]; then
         CURRENT=$("$EXISTING" --version 2>/dev/null | awk '{print $NF}')
@@ -115,20 +215,18 @@ install_binary() {
         echo "Upgrading wirken ${CURRENT} -> ${TAG_VERSION}"
     fi
 
-    if [ -w "$INSTALL_DIR" ]; then
-        mv "$TMPFILE" "${INSTALL_DIR}/wirken"
-        echo "Installed to ${INSTALL_DIR}/wirken"
-    else
-        # Fall back to /usr/local/bin with sudo
-        echo "Cannot write to ${INSTALL_DIR}, trying /usr/local/bin with sudo"
-        INSTALL_DIR="/usr/local/bin"
-        sudo mv "$TMPFILE" "${INSTALL_DIR}/wirken"
-        echo "Installed to ${INSTALL_DIR}/wirken"
+    if [ ! -w "$INSTALL_DIR" ]; then
+        echo "Error: ${INSTALL_DIR} is not writable." >&2
+        echo "Set WIRKEN_INSTALL_DIR to a writable directory, or make ${INSTALL_DIR} writable." >&2
+        rm -rf "$TMPDIR"
+        exit 1
     fi
+
+    mv "$TMPFILE" "${INSTALL_DIR}/wirken"
+    echo "Installed to ${INSTALL_DIR}/wirken"
 
     rm -rf "$TMPDIR"
 
-    # Check if install dir is in PATH
     case ":$PATH:" in
         *":${INSTALL_DIR}:"*) ;;
         *)
@@ -154,4 +252,8 @@ verify() {
     fi
 }
 
-main
+# Test seam: sourcing this script with WIRKEN_INSTALLER_SOURCE_ONLY=1
+# defines all functions but does not run main. Used by scripts/test-install.sh.
+if [ "${WIRKEN_INSTALLER_SOURCE_ONLY:-0}" != "1" ]; then
+    main
+fi

--- a/scripts/sign-release.sh
+++ b/scripts/sign-release.sh
@@ -1,0 +1,83 @@
+#!/bin/sh
+# Sign a Wirken release's checksums.sha256 with the offline Ed25519 key.
+#
+# Usage:
+#   WIRKEN_SIGNING_KEY=/secure/path/wirken-release-signing \
+#       scripts/sign-release.sh vX.Y.Z
+#
+# Input:
+#   - ./checksums.sha256 in the current directory (downloaded from the
+#     draft release produced by the release workflow).
+#   - WIRKEN_SIGNING_KEY env var pointing at the private key file.
+#
+# Output:
+#   - ./checksums.sha256.sig next to the input. Upload to the release.
+#
+# Never commits the private key.
+
+set -eu
+
+if [ $# -ne 1 ]; then
+    echo "Usage: $0 <version-tag>" >&2
+    exit 1
+fi
+
+VERSION="$1"
+
+case "$VERSION" in
+    v*) ;;
+    *)
+        echo "Error: version tag must start with 'v' (got: $VERSION)" >&2
+        exit 1
+        ;;
+esac
+
+if [ -z "${WIRKEN_SIGNING_KEY:-}" ]; then
+    echo "Error: WIRKEN_SIGNING_KEY is not set." >&2
+    echo "Point it at the offline private key, for example:" >&2
+    echo "  WIRKEN_SIGNING_KEY=/secure/path/wirken-release-signing $0 $VERSION" >&2
+    exit 1
+fi
+
+if [ ! -f "$WIRKEN_SIGNING_KEY" ]; then
+    echo "Error: WIRKEN_SIGNING_KEY=${WIRKEN_SIGNING_KEY} does not exist." >&2
+    exit 1
+fi
+
+# Guardrail: refuse to run if the private key is anywhere inside the
+# working tree. This is a cheap check that catches the obvious mistake
+# of dropping the key into the repo.
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+KEY_ABS=$(cd "$(dirname "$WIRKEN_SIGNING_KEY")" && pwd)/$(basename "$WIRKEN_SIGNING_KEY")
+case "$KEY_ABS" in
+    "$REPO_ROOT"/*)
+        echo "Error: private key is inside the repo tree (${KEY_ABS})." >&2
+        echo "Move it to a location outside the working tree before signing." >&2
+        exit 1
+        ;;
+esac
+
+if [ ! -f checksums.sha256 ]; then
+    echo "Error: ./checksums.sha256 not found." >&2
+    echo "Download it from the draft release for ${VERSION} into the current directory." >&2
+    exit 1
+fi
+
+if ! command -v ssh-keygen >/dev/null 2>&1; then
+    echo "Error: ssh-keygen not found. OpenSSH 8.1+ is required." >&2
+    exit 1
+fi
+
+echo "Signing checksums.sha256 for ${VERSION}"
+ssh-keygen -Y sign \
+    -n file \
+    -f "$WIRKEN_SIGNING_KEY" \
+    checksums.sha256
+
+if [ ! -f checksums.sha256.sig ]; then
+    echo "Error: ssh-keygen did not produce checksums.sha256.sig" >&2
+    exit 1
+fi
+
+echo "Wrote checksums.sha256.sig"
+echo "Next: upload checksums.sha256.sig to the draft release for ${VERSION}, then publish."

--- a/scripts/test-install.sh
+++ b/scripts/test-install.sh
@@ -1,0 +1,126 @@
+#!/bin/sh
+# shellcheck disable=SC2034
+# Acceptance tests for install.sh exit codes.
+#
+# Sources install.sh with WIRKEN_INSTALLER_SOURCE_ONLY=1 so the verification
+# functions can be called directly without running the full installer.
+# SC2034 is disabled because the subshells assign variables that are read
+# from inside install.sh's sourced functions, which shellcheck cannot follow.
+
+set -u
+
+REPO_ROOT=$(cd "$(dirname "$0")/.." && pwd)
+cd "$REPO_ROOT" || exit 1
+
+# Subshells below assign variables that are read from inside install.sh's
+# sourced functions. shellcheck does not follow the dynamic reference so
+# we silence the unused-variable warning for the whole file.
+# shellcheck disable=SC2034
+
+FAILED=0
+
+check() {
+    name="$1"
+    expected="$2"
+    actual="$3"
+    if [ "$expected" = "$actual" ]; then
+        echo "PASS: $name (exit $actual)"
+    else
+        echo "FAIL: $name (expected $expected, got $actual)"
+        FAILED=$((FAILED + 1))
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Exit 3: binary not listed in checksums.sha256
+# ---------------------------------------------------------------------------
+tmp=$(mktemp -d)
+(
+    WIRKEN_INSTALLER_SOURCE_ONLY=1
+    export WIRKEN_INSTALLER_SOURCE_ONLY
+    # shellcheck disable=SC1091
+    . ./install.sh
+    TMPDIR="$tmp"
+    CHECKSUM_FILE="$tmp/checksums.sha256"
+    TMPFILE="$tmp/wirken"
+    BINARY_NAME="wirken-x86_64-unknown-linux-musl"
+    CHECKSUM_URL="file:///dev/null"
+    echo "0000000000000000000000000000000000000000000000000000000000000000  wirken-some-other-arch" > "$CHECKSUM_FILE"
+    echo "dummy" > "$TMPFILE"
+    verify_checksum
+)
+check "missing binary in checksums -> exit 3" 3 $?
+rm -rf "$tmp"
+
+# ---------------------------------------------------------------------------
+# Exit 2: checksums URL cannot be fetched
+# ---------------------------------------------------------------------------
+tmp=$(mktemp -d)
+(
+    WIRKEN_INSTALLER_SOURCE_ONLY=1
+    export WIRKEN_INSTALLER_SOURCE_ONLY
+    # shellcheck disable=SC1091
+    . ./install.sh
+    TMPDIR="$tmp"
+    CHECKSUM_FILE="$tmp/missing-checksums"
+    TMPFILE="$tmp/wirken"
+    BINARY_NAME="wirken-x86_64-unknown-linux-musl"
+    # 127.0.0.1:1 is reserved TCPMUX and unroutable in practice; curl -f returns
+    # non-zero. The file does not exist, so verify_checksum will try to fetch.
+    CHECKSUM_URL="http://127.0.0.1:1/blocked"
+    echo "dummy" > "$TMPFILE"
+    verify_checksum
+)
+check "blocked checksums URL -> exit 2" 2 $?
+rm -rf "$tmp"
+
+# ---------------------------------------------------------------------------
+# Exit 5: signature file cannot be fetched
+# ---------------------------------------------------------------------------
+tmp=$(mktemp -d)
+(
+    WIRKEN_INSTALLER_SOURCE_ONLY=1
+    export WIRKEN_INSTALLER_SOURCE_ONLY
+    # shellcheck disable=SC1091
+    . ./install.sh
+    TMPDIR="$tmp"
+    CHECKSUM_FILE="$tmp/checksums.sha256"
+    SIG_FILE="$tmp/checksums.sha256.sig"
+    SIGNERS_FILE="$tmp/allowed_signers"
+    TMPFILE="$tmp/wirken"
+    BINARY_NAME="wirken-x86_64-unknown-linux-musl"
+    CHECKSUM_URL="http://127.0.0.1:1/blocked"
+    SIG_URL="http://127.0.0.1:1/blocked"
+    echo "dummy" > "$TMPFILE"
+    verify_signature
+)
+check "blocked signature URL -> exit 5" 5 $?
+rm -rf "$tmp"
+
+# ---------------------------------------------------------------------------
+# Escape hatch: WIRKEN_ALLOW_UNVERIFIED=1 turns a hard fail into a warning.
+# ---------------------------------------------------------------------------
+tmp=$(mktemp -d)
+(
+    WIRKEN_INSTALLER_SOURCE_ONLY=1
+    WIRKEN_ALLOW_UNVERIFIED=1
+    export WIRKEN_INSTALLER_SOURCE_ONLY WIRKEN_ALLOW_UNVERIFIED
+    # shellcheck disable=SC1091
+    . ./install.sh
+    TMPDIR="$tmp"
+    CHECKSUM_FILE="$tmp/checksums.sha256"
+    TMPFILE="$tmp/wirken"
+    BINARY_NAME="wirken-x86_64-unknown-linux-musl"
+    CHECKSUM_URL="file:///dev/null"
+    echo "0000  wirken-other" > "$CHECKSUM_FILE"
+    echo "dummy" > "$TMPFILE"
+    verify_checksum
+) >/dev/null 2>&1
+check "escape hatch masks exit 3" 0 $?
+rm -rf "$tmp"
+
+if [ "$FAILED" -gt 0 ]; then
+    echo "$FAILED test(s) failed."
+    exit 1
+fi
+echo "All install.sh exit-code tests passed."


### PR DESCRIPTION
## Summary

- Replace `install.sh` soft-fail verification with fail-closed exit codes (2/3/4/5) and add `ssh-keygen -Y` signature verification over `checksums.sha256`. Single escape hatch: `WIRKEN_ALLOW_UNVERIFIED=1`.
- Scaffold the offline Ed25519 release signing workflow: `KEYS`, `docs/release-signing.md`, `scripts/sign-release.sh`, and a draft-release-by-default `.github/workflows/release.yml`. CI never holds the private key.
- Pin the committed `install.sh` SHA-256 in `README.md` and enforce it in CI via `.github/workflows/installer-pin.yml`. Refresh the README with real channel, provider, skill, and test counts. Add an explicit localhost-only note.
- Add `security@gebruder.ottenheimer.app` as a disclosure channel in `SECURITY.md` and cross-reference the release signing key.
- Add `scripts/test-install.sh` acceptance tests covering exit codes 2, 3, 5, and the escape hatch.

The public signing key is intentionally a placeholder (`REPLACE_ME_WITH_PUBLIC_KEY`) in both `KEYS` and `install.sh`. The installer refuses to verify with the placeholder in place, so nothing is silently bypassed before the key is generated offline.

## Files changed and why

| File | Change |
|---|---|
| `install.sh` | Fail-closed verification: exits 2/3/4 on checksum failures, exits 5 on missing or invalid `checksums.sha256.sig`. Fetches signature and verifies with `ssh-keygen -Y verify` against an inline `ALLOWED_SIGNERS`. Adds `WIRKEN_ALLOW_UNVERIFIED=1` escape hatch (warns once, proceeds). Drops the `sudo mv` fallback; points user at `WIRKEN_INSTALL_DIR` instead. Adds `WIRKEN_INSTALLER_SOURCE_ONLY=1` test seam. |
| `KEYS` | Root-level allowed_signers file with a placeholder public key line and comments for identity, algorithm, fingerprint, and issue date. |
| `docs/release-signing.md` | Exact commands for key generation, signing (`ssh-keygen -Y sign -n file ...`), verification, and rotation. Documents the trust anchor (`KEYS` + inline `install.sh`) and the escape hatch. |
| `scripts/sign-release.sh` | Maintainer-side signer. Reads `WIRKEN_SIGNING_KEY` env var, signs `./checksums.sha256`, writes `checksums.sha256.sig`. Refuses to run if the private key is inside the repo tree. |
| `.github/workflows/release.yml` | Now creates a **draft** release with explicit maintainer instructions in the body. CI generates `checksums.sha256`; signature is attached offline before publish. |
| `.github/workflows/installer-pin.yml` | New. Fails CI if the committed `install.sh` SHA-256 does not match the pin in `README.md`. |
| `README.md` | Pins `install.sh` SHA-256 under the curl command with a one-liner verify snippet. Expands opening-paragraph channel list to all nine adapters. Adds `"All local services bind to 127.0.0.1. Wirken never instructs you to bind ... to 0.0.0.0."` under the `wirken run` block. Adds a Status section with real counts: 9 adapters, 8 LLM providers, 15 bundled skills, 452 tests green on main. |
| `SECURITY.md` | Adds `security@gebruder.ottenheimer.app` alongside GitHub advisories. New Release signing section cross-references `KEYS` and `docs/release-signing.md`. |
| `scripts/test-install.sh` | Acceptance tests: exit 3 on missing-binary-in-checksums, exit 2 on blocked checksum URL, exit 5 on blocked signature URL, and the escape hatch masking exit 3. |

## Test plan

- [x] `shellcheck install.sh` clean (v0.11.0)
- [x] `shellcheck scripts/sign-release.sh` clean
- [x] `shellcheck scripts/test-install.sh` clean
- [x] `scripts/test-install.sh` passes all four cases
- [x] `cargo test --workspace` green (452 tests)
- [x] README pinned SHA matches `sha256sum install.sh`
- [x] README adapter list matches `crates/adapter-*` directories (9)
- [x] No em dashes in any changed file
- [ ] After key generation: replace `REPLACE_ME_WITH_PUBLIC_KEY` in `KEYS` and `install.sh`; re-run `scripts/test-install.sh`; publish a signed `vX.Y.Z` draft and verify end-to-end on a clean machine.

## Out of scope

- SLSA build provenance and reproducible builds: follow-up issues.
- Private key generation and placeholder replacement: done by the maintainer after this merges.