### PR TITLE
fix: installer reports the binary it just installed, not PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ wirken run
 Pin the installer before piping. The committed `install.sh` has this SHA-256:
 
 ```
-e5e8779155aab24c1d7fe0c41bc93d23b18ddd8293e48b01d19dc58b44aec7b8
+73e678196ea073608e902c8ab11a01ede07e0d37fddccaa20c43fa5d62bd52f5
 ```
 
 Verify it yourself:

--- a/install.sh
+++ b/install.sh
@@ -239,14 +239,18 @@ install_binary() {
 }
 
 verify() {
-    if command -v wirken >/dev/null 2>&1; then
-        echo ""
-        wirken --version
-        echo ""
-        echo "Run 'wirken setup' to get started."
-    elif [ -x "${INSTALL_DIR}/wirken" ]; then
+    # Report the binary we just installed, not whatever `wirken` resolves
+    # to on PATH. A user installing to a non-PATH directory may have an
+    # older wirken elsewhere on PATH; querying PATH first misreports the
+    # installed version and makes a successful install look like a no-op.
+    if [ -x "${INSTALL_DIR}/wirken" ]; then
         echo ""
         "${INSTALL_DIR}/wirken" --version
+        echo ""
+        echo "Run 'wirken setup' to get started."
+    elif command -v wirken >/dev/null 2>&1; then
+        echo ""
+        wirken --version
         echo ""
         echo "Run 'wirken setup' to get started."
     fi

--- a/scripts/test-install.sh
+++ b/scripts/test-install.sh
@@ -1,11 +1,13 @@
 #!/bin/sh
-# shellcheck disable=SC2034
+# shellcheck disable=SC2034,SC2030,SC2031
 # Acceptance tests for install.sh exit codes.
 #
 # Sources install.sh with WIRKEN_INSTALLER_SOURCE_ONLY=1 so the verification
 # functions can be called directly without running the full installer.
 # SC2034 is disabled because the subshells assign variables that are read
 # from inside install.sh's sourced functions, which shellcheck cannot follow.
+# SC2030/SC2031 are disabled because each test is intentionally scoped to
+# its own subshell; variable mutations do not leak to subsequent tests.
 
 set -u
 
@@ -118,6 +120,51 @@ tmp=$(mktemp -d)
 ) >/dev/null 2>&1
 check "escape hatch masks exit 3" 0 $?
 rm -rf "$tmp"
+
+# ---------------------------------------------------------------------------
+# verify() reports the binary the installer just wrote to INSTALL_DIR, not
+# whatever wirken resolves to on PATH. An older wirken on PATH would
+# otherwise make a successful install look like a no-op.
+# ---------------------------------------------------------------------------
+install_dir=$(mktemp -d)
+path_dir=$(mktemp -d)
+
+# Older wirken on PATH.
+cat > "$path_dir/wirken" <<'STUB'
+#!/bin/sh
+echo "wirken 0.0.1-stub"
+STUB
+chmod +x "$path_dir/wirken"
+
+# Freshly installed wirken in INSTALL_DIR. verify() should report this one.
+cat > "$install_dir/wirken" <<'STUB'
+#!/bin/sh
+echo "wirken 0.7.4-installed"
+STUB
+chmod +x "$install_dir/wirken"
+
+output=$(
+    WIRKEN_INSTALLER_SOURCE_ONLY=1
+    PATH="$path_dir:$PATH"
+    export WIRKEN_INSTALLER_SOURCE_ONLY PATH
+    # shellcheck disable=SC1091
+    . ./install.sh
+    INSTALL_DIR="$install_dir"
+    verify 2>&1
+)
+
+if echo "$output" | grep -q "0.7.4-installed" \
+        && ! echo "$output" | grep -q "0.0.1-stub"; then
+    echo "PASS: verify() reports installed binary, not PATH wirken"
+elif echo "$output" | grep -q "0.0.1-stub"; then
+    echo "FAIL: verify() reported PATH wirken (0.0.1-stub) instead of installed"
+    FAILED=$((FAILED + 1))
+else
+    echo "FAIL: verify() output matched neither expected version:"
+    printf '  %s\n' "$output"
+    FAILED=$((FAILED + 1))
+fi
+rm -rf "$install_dir" "$path_dir"
 
 if [ "$FAILED" -gt 0 ]; then
     echo "$FAILED test(s) failed."


### PR DESCRIPTION
## Bug

After a successful install to a non-PATH directory (e.g. `WIRKEN_INSTALL_DIR=/tmp/smoke`), `verify()` ran `wirken --version`, which resolved to whatever older wirken was already on PATH. The installer's success output then printed the wrong version, making `Installed to /tmp/smoke/wirken` followed by `wirken 0.6.4` look like the install silently failed.

## Fix

Invert the priority in `verify()`: check `"${INSTALL_DIR}/wirken"` first, fall back to `command -v wirken` only if the install-dir binary is somehow not there.

```diff
 verify() {
-    if command -v wirken >/dev/null 2>&1; then
+    if [ -x "${INSTALL_DIR}/wirken" ]; then
         echo ""
-        wirken --version
+        "${INSTALL_DIR}/wirken" --version
         ...
-    elif [ -x "${INSTALL_DIR}/wirken" ]; then
+    elif command -v wirken >/dev/null 2>&1; then
         echo ""
-        "${INSTALL_DIR}/wirken" --version
+        wirken --version
         ...
 }
```

Silent-continue-on-neither-branch behavior is intentionally unchanged; changing that is a separate decision.

## Regression test

New case in `scripts/test-install.sh` that stages two stub wirken binaries:
- PATH version reports `wirken 0.0.1-stub`.
- Install-dir version reports `wirken 0.7.4-installed`.

Asserts `verify()` prints the install-dir version and does not print the PATH version. Negative-tested: reverting the `install.sh` fix makes the new test fail with the exact reproduction ("`verify() reported PATH wirken (0.0.1-stub) instead of installed`").

## README pin

`install.sh` changed, so the pinned SHA in `README.md` moves:

```
OLD: e5e8779155aab24c1d7fe0c41bc93d23b18ddd8293e48b01d19dc58b44aec7b8
NEW: 73e678196ea073608e902c8ab11a01ede07e0d37fddccaa20c43fa5d62bd52f5
```

## Out of scope

- Version bump. This lands on main; the 0.7.5 bump happens as part of the release runbook.
- `verify()` silent-continue when neither branch matches. Separate decision.

## Test plan

- [x] `shellcheck install.sh scripts/test-install.sh` clean
- [x] `./scripts/test-install.sh` passes all five cases (four existing + the new one)
- [x] Negative test: reverting just the `install.sh` hunk makes the new test fail with the reproduction message
- [x] README pinned SHA matches `sha256sum install.sh`
- [x] No em dashes in changed files
