### PR TITLE
Sandbox: tools_enabled default, seccomp fix, wait race, ask permissions

### DIFF
--- a/crates/agent/src/llm.rs
+++ b/crates/agent/src/llm.rs
@@ -107,7 +107,7 @@ impl LlmConfig {
             max_tokens: 4096,
             temperature: 0.7,
             region: None,
-            tools_enabled: false,
+            tools_enabled: true,
             context_window: 8_192,
         }
     }
@@ -172,7 +172,7 @@ impl LlmConfig {
             max_tokens: 4096,
             temperature: 0.7,
             region: None,
-            tools_enabled: provider != "ollama",
+            tools_enabled: true,
             context_window,
         }
     }

--- a/crates/agent/src/runtime.rs
+++ b/crates/agent/src/runtime.rs
@@ -2146,7 +2146,7 @@ impl Agent {
     /// [`Self::verify`] to recompute `tools_hash`. Tool defs are
     /// sorted by name for stable hashing (matches the slice 1 sort
     /// in `process_message`).
-    async fn snapshot_tool_defs(&self) -> Vec<crate::tool::ToolDef> {
+    pub(crate) async fn snapshot_tool_defs(&self) -> Vec<crate::tool::ToolDef> {
         let mcp_defs = match &self.mcp {
             Some(mcp) => mcp.lock().await.definitions(),
             None => Vec::new(),

--- a/crates/agent/src/sandbox.rs
+++ b/crates/agent/src/sandbox.rs
@@ -138,7 +138,10 @@ impl DockerSandbox {
             .await
             .map_err(|e| AgentError::Sandbox(format!("start container: {e}")))?;
 
-        // Wait for container to finish, with timeout
+        // Wait for container to finish, with timeout.
+        // Bollard surfaces any container exit with status_code > 0
+        // as `DockerContainerWaitError`; treat it as a successful
+        // wait with a non-zero exit code rather than a sandbox error.
         let timeout = std::time::Duration::from_secs(self.config.timeout_secs);
         let wait_result = tokio::time::timeout(timeout, async {
             let mut stream = self.client.wait_container(
@@ -150,6 +153,9 @@ impl DockerSandbox {
             if let Some(result) = stream.next().await {
                 match result {
                     Ok(exit) => return Ok(exit.status_code),
+                    Err(bollard::errors::Error::DockerContainerWaitError { code, .. }) => {
+                        return Ok(code);
+                    }
                     Err(e) => return Err(AgentError::Sandbox(format!("wait: {e}"))),
                 }
             }
@@ -200,7 +206,8 @@ impl DockerSandbox {
             }
         }
 
-        // Cleanup (auto_remove should handle it, but be safe)
+        // Cleanup — auto_remove is off so logs can be collected; we
+        // must remove the container explicitly here.
         let _ = self.kill_and_remove(&container.id).await;
 
         let mut result = String::new();
@@ -290,7 +297,11 @@ pub(crate) fn build_host_config(config: &SandboxConfig, workspace_str: &str) -> 
         network_mode,
         memory: Some(MEMORY_LIMIT),
         pids_limit: Some(PIDS_LIMIT),
-        auto_remove: Some(true),
+        // With auto_remove=true the container is torn down the
+        // moment it exits, which races the post-wait `logs` call and
+        // leaves no output to return to the agent. Rely on the
+        // explicit `kill_and_remove` cleanup instead.
+        auto_remove: Some(false),
         runtime: config.mode.runtime_name(),
         cap_drop: Some(vec!["ALL".into()]),
         cap_add: Some(Vec::new()),

--- a/crates/agent/src/sandbox.rs
+++ b/crates/agent/src/sandbox.rs
@@ -267,10 +267,10 @@ impl DockerSandbox {
 ///   case breaks this, re-evaluate rather than loosening by default.
 /// * `no-new-privileges`: block setuid/setgid elevation inside the
 ///   container. Pairs with `cap_drop`.
-/// * `seccomp=default`: pin Docker's default seccomp profile
-///   explicitly, so a daemon-wide `"seccomp": "unconfined"`
-///   misconfiguration does not silently disable syscall filtering
-///   for our containers.
+/// * seccomp: rely on Docker's default seccomp profile. Docker
+///   applies it automatically when no seccomp SecurityOpt is set;
+///   the string `seccomp=default` is not a valid option and causes
+///   the daemon to reject container start.
 /// * `readonly_rootfs`: make the container's `/` read-only. The
 ///   workspace bind-mount stays RW, and a tmpfs at `/tmp` gives the
 ///   shell somewhere to scratch.
@@ -296,7 +296,7 @@ pub(crate) fn build_host_config(config: &SandboxConfig, workspace_str: &str) -> 
         cap_add: Some(Vec::new()),
         security_opt: Some(vec![
             "no-new-privileges:true".into(),
-            "seccomp=default".into(),
+            // Docker applies its default seccomp profile when no seccomp SecurityOpt is set.
         ]),
         readonly_rootfs: Some(true),
         tmpfs: Some(tmpfs_mounts),

--- a/crates/agent/src/tests.rs
+++ b/crates/agent/src/tests.rs
@@ -2107,7 +2107,9 @@ fn host_config_preserves_workspace_and_resource_caps() {
     assert_eq!(hc.network_mode.as_deref(), Some("none"));
     assert_eq!(hc.memory, Some(512 * 1024 * 1024));
     assert_eq!(hc.pids_limit, Some(256));
-    assert_eq!(hc.auto_remove, Some(true));
+    // auto_remove is off so post-wait log collection can still read
+    // the container; cleanup is explicit via kill_and_remove.
+    assert_eq!(hc.auto_remove, Some(false));
 }
 
 #[test]

--- a/crates/agent/src/tests.rs
+++ b/crates/agent/src/tests.rs
@@ -2067,9 +2067,12 @@ fn host_config_sets_no_new_privileges_and_seccomp() {
         opts.iter().any(|o| o == "no-new-privileges:true"),
         "security_opt must include no-new-privileges:true, got {opts:?}"
     );
+    // Docker applies its default seccomp profile when no seccomp
+    // SecurityOpt is set; setting `seccomp=default` is not a valid
+    // option string and causes the daemon to reject container start.
     assert!(
-        opts.iter().any(|o| o == "seccomp=default"),
-        "security_opt must pin seccomp=default, got {opts:?}"
+        !opts.iter().any(|o| o.starts_with("seccomp=")),
+        "security_opt must not set a seccomp option, got {opts:?}"
     );
 }
 

--- a/crates/agent/src/tests.rs
+++ b/crates/agent/src/tests.rs
@@ -3701,13 +3701,8 @@ mod verify {
         });
     }
 
-    async fn agent_snapshot_tools(_agent: &Agent) -> Vec<crate::tool::ToolDef> {
-        // Match Agent::snapshot_tool_defs exactly: when the LLM
-        // config has tools_enabled = false (e.g., Ollama), the
-        // agent sends no tool defs to the model and the tools_hash
-        // is the hash of an empty Vec. This test uses Ollama, so
-        // return empty.
-        Vec::new()
+    async fn agent_snapshot_tools(agent: &Agent) -> Vec<crate::tool::ToolDef> {
+        agent.snapshot_tool_defs().await
     }
 
     #[test]

--- a/crates/cli/src/commands/agent.rs
+++ b/crates/cli/src/commands/agent.rs
@@ -1,8 +1,11 @@
+use std::sync::{Arc, Mutex};
+
 use anyhow::{Context, Result};
 
 use wirken_agent::Agent;
 use wirken_agent::llm::LlmConfig;
 use wirken_gateway::agent_config::AgentConfigStore;
+use wirken_gateway::permissions::PermissionStore;
 use wirken_vault::{CredentialStore, probe_keychain};
 
 use super::config;
@@ -95,6 +98,13 @@ pub async fn send(message: &str, agent_id: &str) -> Result<()> {
         super::load_sandbox_config(&cfg.data_dir),
     )?;
 
+    // Attach the gateway's permission store so tier gating applies
+    // on the ask path too — otherwise Tier 2/3 actions execute
+    // unchecked and bypass the three-tier model.
+    let perms = PermissionStore::open(&cfg.permissions_db_path())
+        .context("Failed to open permission store")?;
+    agent.set_permissions(Arc::new(Mutex::new(perms)));
+
     let skills_dir = cfg.data_dir.join("skills");
     if skills_dir.is_dir() {
         let _ = agent.load_skills(&skills_dir);
@@ -161,6 +171,10 @@ async fn send_with_agent_config(
         session_log,
         super::load_sandbox_config(&cfg.data_dir),
     )?;
+
+    let perms = PermissionStore::open(&cfg.permissions_db_path())
+        .context("Failed to open permission store")?;
+    agent.set_permissions(Arc::new(Mutex::new(perms)));
 
     let skills_dir = cfg.agent_skills_dir(&agent_cfg.id);
     if skills_dir.is_dir() {


### PR DESCRIPTION
## Summary

Four independent fixes to the sandbox / tool-dispatch path, each unblocking a different walkthrough receipt.

## Commits

1. **Default tools_enabled=true for all providers** (`crates/agent/src/llm.rs`)
   Ollama used to be disabled from tool dispatch, so the agent never exercised any tool path under the local provider. Flipping the default lets every provider receive tool defs; per-agent override remains available via `AgentConfig.tools_enabled`.

2. **Drop invalid `seccomp=default` SecurityOpt string** (`crates/agent/src/sandbox.rs`)
   `seccomp=default` is not a valid Docker SecurityOpt value; the daemon rejects container start with `invalid character 'd' looking for beginning of value`. Docker applies its default seccomp profile automatically when no SecurityOpt is set.

3. **Fix sandbox wait_container race on non-zero exits** (`crates/agent/src/sandbox.rs`)
   Bollard surfaces any container exit with `status_code > 0` as `DockerContainerWaitError`, which the agent was treating as a sandbox error rather than a normal non-zero exit. Also flips `auto_remove` to `false` so the post-wait `logs` call can read container output before teardown; explicit `kill_and_remove` handles cleanup.

4. **Attach permission store to `wirken ask`** (`crates/cli/src/commands/agent.rs`)
   The `ask` path was constructing an Agent without a `PermissionStore`, silently bypassing the three-tier model. Opens the same permissions.db the gateway uses and wires it into the agent. Tier 2/3 actions now gate on `ask` the same way they do on every other entry point.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --all-targets` clean (3 pre-existing warnings in files untouched by this PR)
- [x] `cargo test --workspace` — 478 passed, 0 failed
- [x] `sandbox_blocks_{write_to_rootfs,chown_via_cap_drop,setuid}` integration tests pass
- [x] Live gateway run exercises the sandbox end-to-end (container executes, output returns to agent)

## Known follow-up

`wirken ask` now correctly denies Tier 2 and Tier 3 actions — but there is currently no user-facing path to *approve* a Tier 2 action anywhere in the product. `PermissionStore::approve` is called only by tests. That gap is tracked separately; this PR closes the "bypass" half of the problem.