### PR TITLE
CLI: wirken permissions approve and list-pending

### DIFF
--- a/crates/agent/src/runtime.rs
+++ b/crates/agent/src/runtime.rs
@@ -1233,6 +1233,7 @@ impl Agent {
                                     TrustLevel::System,
                                     SessionEvent::PermissionDenied {
                                         tool: ctx.tool_name.clone(),
+                                        action_key: ctx.action.approval_key(),
                                         tier: ctx.requested_tier.label().to_string(),
                                         agent_id: ctx.agent_id.clone(),
                                         trigger: ctx.trigger_message.clone(),
@@ -1357,6 +1358,7 @@ impl Agent {
                         TrustLevel::System,
                         SessionEvent::PermissionDenied {
                             tool: name.to_string(),
+                            action_key: action.approval_key(),
                             tier: action.tier().label().to_string(),
                             agent_id: self.id.clone(),
                             trigger: self.current_trigger.clone(),
@@ -1449,6 +1451,7 @@ impl Agent {
                     TrustLevel::System,
                     SessionEvent::PermissionDenied {
                         tool: ctx.tool_name.clone(),
+                        action_key: ctx.action.approval_key(),
                         tier: ctx.requested_tier.label().to_string(),
                         agent_id: ctx.agent_id.clone(),
                         trigger: ctx.trigger_message.clone(),

--- a/crates/audit/src/lib.rs
+++ b/crates/audit/src/lib.rs
@@ -10,9 +10,9 @@ pub use error::AuditError;
 pub use event::AuditEvent;
 pub use log::{AuditLog, AuditQuery, VerifyResult};
 pub use session_log::{
-    HashHex, HexBytes, OwnSession, SessionEvent, SessionHandle, SessionId, SessionLog,
-    SessionScope, SessionVerifyResult, SqliteSessionLog, StoredSessionEvent, ToolCallRecord,
-    TrustLevel,
+    HashHex, HexBytes, OwnSession, PermissionDenialRecord, SessionEvent, SessionHandle, SessionId,
+    SessionLog, SessionScope, SessionVerifyResult, SqliteSessionLog, StoredSessionEvent,
+    ToolCallRecord, TrustLevel,
 };
 pub use siem::{SiemConfig, SiemForwarder, SiemTarget};
 pub use writer::AuditWriter;

--- a/crates/audit/src/session_log.rs
+++ b/crates/audit/src/session_log.rs
@@ -227,9 +227,14 @@ pub enum SessionEvent {
         tokens_out: u32,
         latency_ms: u64,
     },
-    /// Permission denial recorded by the harness.
+    /// Permission denial recorded by the harness. `action_key` is
+    /// the canonical key under which an operator can grant approval
+    /// (e.g., `shell:curl`); kept alongside `tool` so reviewers can
+    /// map the denial back to a permissions.db entry without having
+    /// to reparse tool arguments.
     PermissionDenied {
         tool: String,
+        action_key: String,
         tier: String,
         agent_id: String,
         trigger: Option<String>,
@@ -448,6 +453,19 @@ pub trait SessionLog: Send + Sync {
     -> Result<SessionVerifyResult, AuditError>;
 }
 
+/// A flattened `PermissionDenied` event, tagged with its session
+/// and sequence so operators can correlate against the session log.
+#[derive(Debug, Clone)]
+pub struct PermissionDenialRecord {
+    pub session_id: String,
+    pub seq: u64,
+    pub ts: String,
+    pub tool: String,
+    pub action_key: String,
+    pub tier: String,
+    pub trigger: Option<String>,
+}
+
 // ---------------------------------------------------------------------------
 // SQLite implementation
 // ---------------------------------------------------------------------------
@@ -484,6 +502,59 @@ impl SqliteSessionLog {
     #[cfg(test)]
     pub(crate) fn raw_conn_for_test(&self) -> &Mutex<Connection> {
         &self.conn
+    }
+
+    /// Scan every session for `PermissionDenied` events belonging to
+    /// `agent_id`. Returns one row per stored event, most recent
+    /// first. Used by `wirken permissions list-pending` to build its
+    /// view of denials that may want an approval. Scans are linear
+    /// in the size of the log; the caller is expected to run this
+    /// interactively, not on a hot path.
+    pub fn find_permission_denials(&self, agent_id: &str) -> Vec<PermissionDenialRecord> {
+        let conn = self.conn.lock().expect("session log mutex");
+        let mut stmt = match conn.prepare(
+            "SELECT session_id, seq, ts, payload FROM session_events
+             WHERE payload LIKE '%\"PermissionDenied\"%'
+             ORDER BY ts DESC",
+        ) {
+            Ok(s) => s,
+            Err(_) => return Vec::new(),
+        };
+        let rows: Vec<(String, u64, String, String)> = stmt
+            .query_map([], |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, i64>(1)? as u64,
+                    row.get::<_, String>(2)?,
+                    row.get::<_, String>(3)?,
+                ))
+            })
+            .map(|iter| iter.filter_map(|r| r.ok()).collect())
+            .unwrap_or_default();
+
+        rows.into_iter()
+            .filter_map(|(session_id, seq, ts, payload)| {
+                let event: SessionEvent = serde_json::from_str(&payload).ok()?;
+                match event {
+                    SessionEvent::PermissionDenied {
+                        tool,
+                        action_key,
+                        tier,
+                        agent_id: ev_agent,
+                        trigger,
+                    } if ev_agent == agent_id => Some(PermissionDenialRecord {
+                        session_id,
+                        seq,
+                        ts,
+                        tool,
+                        action_key,
+                        tier,
+                        trigger,
+                    }),
+                    _ => None,
+                }
+            })
+            .collect()
     }
 
     /// Item 6 slice 2: list child session IDs whose session_id

--- a/crates/audit/src/tests.rs
+++ b/crates/audit/src/tests.rs
@@ -911,6 +911,7 @@ mod session {
                 TrustLevel::System,
                 SessionEvent::PermissionDenied {
                     tool: "exec".into(),
+                    action_key: "shell:curl".into(),
                     tier: "tier3".into(),
                     agent_id: "default".into(),
                     trigger: Some("delete the universe".into()),

--- a/crates/cli/src/commands/permission.rs
+++ b/crates/cli/src/commands/permission.rs
@@ -1,5 +1,7 @@
 use anyhow::{Context, Result};
+use std::collections::HashSet;
 
+use wirken_audit::SqliteSessionLog;
 use wirken_gateway::permissions::PermissionStore;
 
 use super::config;
@@ -53,5 +55,78 @@ pub async fn revoke(key: &str, agent: &str) -> Result<()> {
         .context(format!("Failed to revoke permission '{key}'"))?;
 
     println!("  Permission '{key}' revoked for agent '{agent}'.");
+    Ok(())
+}
+
+/// Grant a 30-day approval for `key` to `agent`, operator-initiated.
+/// Writes directly to permissions.db; no prompt, no gateway round-trip.
+pub async fn approve(key: &str, agent: &str) -> Result<()> {
+    let cfg = config();
+    let store = PermissionStore::open(&cfg.permissions_db_path())
+        .context("Failed to open permission store")?;
+
+    let approval = store
+        .approve_by_key(key, agent, "operator")
+        .context(format!("Failed to approve permission '{key}'"))?;
+
+    println!(
+        "  Approved '{}' for agent '{}' until {}.",
+        approval.action_key,
+        approval.agent_id,
+        approval.expires_at.format("%Y-%m-%d %H:%M:%S UTC"),
+    );
+    Ok(())
+}
+
+/// Show `PermissionDenied` audit entries for `agent` whose action
+/// key has no current approval. Deduped by action_key so a single
+/// denied tool does not spam the list. Most recent occurrence wins.
+pub async fn list_pending(agent: &str) -> Result<()> {
+    let cfg = config();
+    let log = SqliteSessionLog::open(&cfg.audit_db_path()).context("Failed to open session log")?;
+    let perms = PermissionStore::open(&cfg.permissions_db_path())
+        .context("Failed to open permission store")?;
+
+    let denials = log.find_permission_denials(agent);
+
+    let mut seen: HashSet<String> = HashSet::new();
+    let mut pending: Vec<_> = Vec::new();
+    for rec in denials {
+        if !seen.insert(rec.action_key.clone()) {
+            continue;
+        }
+        if perms.has_approval(&rec.action_key, agent).unwrap_or(false) {
+            continue;
+        }
+        pending.push(rec);
+    }
+
+    if pending.is_empty() {
+        println!("  No pending permission approvals for agent '{agent}'.");
+        return Ok(());
+    }
+
+    println!("  Pending approvals for agent '{agent}':");
+    println!();
+    println!(
+        "  {:30}  {:6}  {:20}  TOOL",
+        "ACTION KEY", "TIER", "LAST SEEN",
+    );
+    println!(
+        "  {}  {}  {}  {}",
+        "─".repeat(30),
+        "─".repeat(6),
+        "─".repeat(20),
+        "─".repeat(8),
+    );
+    for rec in &pending {
+        let ts_short = rec.ts.get(..19).unwrap_or(rec.ts.as_str());
+        println!(
+            "  {:30}  {:6}  {:20}  {}",
+            rec.action_key, rec.tier, ts_short, rec.tool,
+        );
+    }
+    println!();
+    println!("  Approve one with: wirken permissions approve <ACTION KEY> --agent {agent}");
     Ok(())
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -165,10 +165,24 @@ enum PermissionCommands {
         #[arg(long, default_value = "default")]
         agent: String,
     },
+    /// Grant a 30-day approval for an action key
+    Approve {
+        /// Action key to approve (e.g., shell:sh, file:/path)
+        key: String,
+        /// Agent ID
+        #[arg(long, default_value = "default")]
+        agent: String,
+    },
     /// Revoke a permission
     Revoke {
         /// Action key to revoke
         key: String,
+        /// Agent ID
+        #[arg(long, default_value = "default")]
+        agent: String,
+    },
+    /// Show permission denials that have no current approval
+    ListPending {
         /// Agent ID
         #[arg(long, default_value = "default")]
         agent: String,
@@ -388,8 +402,14 @@ async fn main() -> Result<()> {
         },
         Commands::Permissions(cmd) => match cmd {
             PermissionCommands::List { agent } => commands::permission::list(&agent).await,
+            PermissionCommands::Approve { key, agent } => {
+                commands::permission::approve(&key, &agent).await
+            }
             PermissionCommands::Revoke { key, agent } => {
                 commands::permission::revoke(&key, &agent).await
+            }
+            PermissionCommands::ListPending { agent } => {
+                commands::permission::list_pending(&agent).await
             }
         },
         Commands::Credentials(cmd) => match cmd {

--- a/crates/gateway/src/permissions.rs
+++ b/crates/gateway/src/permissions.rs
@@ -1,5 +1,5 @@
 use chrono::{DateTime, Duration, Utc};
-use rusqlite::{Connection, params};
+use rusqlite::{Connection, OptionalExtension, params};
 use serde::{Deserialize, Serialize};
 use std::path::Path;
 
@@ -185,23 +185,56 @@ impl PermissionStore {
         agent_id: &str,
         approved_by: &str,
     ) -> Result<Approval, GatewayError> {
-        let key = action.approval_key();
+        self.approve_by_key(&action.approval_key(), agent_id, approved_by)
+    }
+
+    /// Record an approval using a pre-computed action key. Callers
+    /// that already have the key (e.g., the CLI `permissions approve`
+    /// command, reading it off a past `PermissionDenied` audit entry)
+    /// use this to avoid reparsing the key back into an [`Action`].
+    /// Tier semantics are unchanged: Tier 3 keys can be stored but
+    /// `check` ignores approvals for them.
+    pub fn approve_by_key(
+        &self,
+        action_key: &str,
+        agent_id: &str,
+        approved_by: &str,
+    ) -> Result<Approval, GatewayError> {
         let now = Utc::now();
         let expires = now + Duration::days(self.default_expiry_days as i64);
 
         self.conn.execute(
             "INSERT OR REPLACE INTO approvals (action_key, agent_id, approved_at, approved_by, expires_at)
              VALUES (?1, ?2, ?3, ?4, ?5)",
-            params![key, agent_id, now.to_rfc3339(), approved_by, expires.to_rfc3339()],
+            params![action_key, agent_id, now.to_rfc3339(), approved_by, expires.to_rfc3339()],
         )?;
 
         Ok(Approval {
-            action_key: key,
+            action_key: action_key.to_string(),
             agent_id: agent_id.to_string(),
             approved_at: now,
             approved_by: approved_by.to_string(),
             expires_at: expires,
         })
+    }
+
+    /// Check whether a specific `action_key` has a current (non-expired)
+    /// approval for `agent_id`. Used by `list-pending` to exclude
+    /// already-approved denials.
+    pub fn has_approval(&self, action_key: &str, agent_id: &str) -> Result<bool, GatewayError> {
+        let mut stmt = self
+            .conn
+            .prepare("SELECT expires_at FROM approvals WHERE action_key = ?1 AND agent_id = ?2")?;
+        let row = stmt
+            .query_row(params![action_key, agent_id], |row| row.get::<_, String>(0))
+            .optional()?;
+        match row {
+            None => Ok(false),
+            Some(expires) => {
+                let expires_at = parse_dt(&expires);
+                Ok(Utc::now() < expires_at)
+            }
+        }
     }
 
     /// Revoke an approval.


### PR DESCRIPTION
## Summary

First commit of the approval-path work. Wires a product-facing path to grant Tier 2 approvals so the three-tier permission model actually has a usable entry point; previously `PermissionStore::approve` was called only by tests.

Standalone deliverable. Subsequent commits (ask stdin prompt, webchat protocol, Telegram callback) land independently.

## Changes

- `SessionEvent::PermissionDenied` gains an `action_key: String` field so `list-pending` can map an audit denial to a permissions.db key without reparsing tool arguments. Three emit sites in `crates/agent/src/runtime.rs` updated; audit test updated.
- `PermissionStore::approve_by_key(key, agent_id, approved_by)` added; the existing `approve(Action, ...)` delegates to it. `PermissionStore::has_approval(key, agent_id) -> bool` added for the excluded-from-pending check.
- `SqliteSessionLog::find_permission_denials(agent_id)` scans the session log cross-session and returns a new `PermissionDenialRecord` with the flattened fields plus `session_id`/`seq`/`ts`. Exported from the audit crate.
- `wirken permissions approve <key> --agent <id>` grants a 30-day approval, `approved_by = "operator"`.
- `wirken permissions list-pending --agent <id>` lists denied action keys for the agent that have no current approval, deduped, most recent first. Prints the exact `approve` command the operator should run.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace` clean
- [x] `cargo test --workspace` — no regressions from this PR. Three pre-existing `sandbox_blocks_*` failures on `main` are the seccomp bug resolved separately in #39.
- [x] Manual: `approve shell:sh --agent default` writes to permissions.db, appears in `list` output, survives a fresh `wirken` invocation, `revoke` removes it.

## Follow-up work in this branch family

The full approval-path spec also covers:

- Interactive `wirken ask` prompt-and-retry on `NeedsApproval`.
- Webchat approval protocol (SSE event envelope plus `approve` field on POST `/api/chat`).
- Telegram adapter approval callback (YES/NO message reply).

Those are landing as separate PRs behind this one so each entry point is reviewable on its own.