### PR TITLE
audit: serde default for PermissionDenied.action_key

### DIFF
--- a/crates/audit/src/session_log.rs
+++ b/crates/audit/src/session_log.rs
@@ -234,6 +234,10 @@ pub enum SessionEvent {
     /// to reparse tool arguments.
     PermissionDenied {
         tool: String,
+        /// Defaulted for rows written before this field existed; old
+        /// audit events deserialize with an empty key so a pre-upgrade
+        /// session log stays readable.
+        #[serde(default)]
         action_key: String,
         tier: String,
         agent_id: String,

--- a/crates/audit/src/tests.rs
+++ b/crates/audit/src/tests.rs
@@ -1027,4 +1027,28 @@ mod session {
         let expected1 = format!("{:x}", hasher.finalize());
         assert_eq!(rows[1].hash.0, expected1);
     }
+
+    #[test]
+    fn permission_denied_deserializes_without_action_key() {
+        // Legacy rows written before `action_key` was added must
+        // still deserialize; the field defaults to an empty string.
+        let legacy = r#"{"kind":"permission_denied","tool":"exec","tier":"tier3","agent_id":"default","trigger":"hi"}"#;
+        let event: SessionEvent = serde_json::from_str(legacy).unwrap();
+        match event {
+            SessionEvent::PermissionDenied {
+                tool,
+                action_key,
+                tier,
+                agent_id,
+                trigger,
+            } => {
+                assert_eq!(tool, "exec");
+                assert_eq!(action_key, "");
+                assert_eq!(tier, "tier3");
+                assert_eq!(agent_id, "default");
+                assert_eq!(trigger.as_deref(), Some("hi"));
+            }
+            other => panic!("expected PermissionDenied, got {other:?}"),
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Regression fix from #40. The new `action_key: String` field on `SessionEvent::PermissionDenied` has no `#[serde(default)]`, so audit log rows written before the upgrade fail to deserialize with `missing field 'action_key'`. Any install carrying pre-upgrade audit history sees `factory.wake` fail and the gateway cannot rebuild agent state from the session log.

Fix: `#[serde(default)]` on the field. Legacy rows now deserialize with an empty key; forward-logged rows carry the real value. Added a regression test that deserializes a representative legacy JSON blob.

## Test plan

- [x] New test `permission_denied_deserializes_without_action_key` passes.
- [x] `cargo test --workspace` — 479 passed, 0 failed.
- [x] `cargo fmt --check` clean.
- [x] `cargo clippy --workspace` clean.

## How this was discovered

Hit live during receipt capture after #40 merged, against a scratch `~/.wirken/audit.db` that carried events from pre-#40 runs. Gateway streamed `data: {"type":"error","text":"factory.wake failed: serialization error: missing field 'action_key'"}` on the first POST to `/api/chat`. Worked around by wiping the audit.db for the capture; not an option on a real install.