### PR TITLE
Fix Tier 3 bypass via array-form shell command arguments

### DIFF
--- a/crates/agent/src/tests.rs
+++ b/crates/agent/src/tests.rs
@@ -2311,6 +2311,83 @@ fn tool_to_action_exec_empty_command() {
 }
 
 #[test]
+fn tool_to_action_exec_array_form_curl_is_tier3() {
+    // A model that emits `command` as an array must not escape the
+    // high-risk-prefix check. Pre-fix behavior collapsed this to
+    // pattern="" → Tier 2. After the fix the first array element
+    // becomes the pattern.
+    use crate::tool::tool_to_action;
+    use wirken_gateway::permissions::{Action, PermissionTier};
+
+    let args = serde_json::json!({"command": ["curl", "https://example.com"]});
+    let action = tool_to_action("exec", &args).unwrap();
+    match action {
+        Action::ShellExec { ref pattern } => assert_eq!(pattern, "curl"),
+        other => panic!("expected ShellExec, got {other:?}"),
+    }
+    assert_eq!(action.tier(), PermissionTier::Tier3);
+}
+
+#[test]
+fn tool_to_action_exec_array_form_ssh_is_tier3() {
+    use crate::tool::tool_to_action;
+    use wirken_gateway::permissions::{Action, PermissionTier};
+
+    let args = serde_json::json!({"command": ["ssh", "user@host", "uptime"]});
+    let action = tool_to_action("exec", &args).unwrap();
+    match action {
+        Action::ShellExec { ref pattern } => assert_eq!(pattern, "ssh"),
+        other => panic!("expected ShellExec, got {other:?}"),
+    }
+    assert_eq!(action.tier(), PermissionTier::Tier3);
+}
+
+#[test]
+fn tool_to_action_exec_array_form_ls_is_tier2() {
+    // Non-high-risk prefixes keep their Tier 2 classification under
+    // array form, same as string form.
+    use crate::tool::tool_to_action;
+    use wirken_gateway::permissions::{Action, PermissionTier};
+
+    let args = serde_json::json!({"command": ["ls", "-la"]});
+    let action = tool_to_action("exec", &args).unwrap();
+    match action {
+        Action::ShellExec { ref pattern } => assert_eq!(pattern, "ls"),
+        other => panic!("expected ShellExec, got {other:?}"),
+    }
+    assert_eq!(action.tier(), PermissionTier::Tier2);
+}
+
+#[test]
+fn extract_exec_command_rejects_malformed_shapes() {
+    use crate::tool::extract_exec_command;
+
+    // Object form: not a shell command.
+    let args = serde_json::json!({"command": {"argv": ["curl"]}});
+    assert!(extract_exec_command(&args).is_err());
+
+    // Null.
+    let args = serde_json::json!({"command": null});
+    assert!(extract_exec_command(&args).is_err());
+
+    // Array containing non-string elements.
+    let args = serde_json::json!({"command": ["curl", 42]});
+    assert!(extract_exec_command(&args).is_err());
+
+    // Missing entirely.
+    let args = serde_json::json!({});
+    assert!(extract_exec_command(&args).is_err());
+
+    // String form: passes through.
+    let args = serde_json::json!({"command": "ls /"});
+    assert_eq!(extract_exec_command(&args).unwrap(), "ls /");
+
+    // Array of strings: space-joined.
+    let args = serde_json::json!({"command": ["curl", "https://x"]});
+    assert_eq!(extract_exec_command(&args).unwrap(), "curl https://x");
+}
+
+#[test]
 fn tool_to_action_read_file() {
     use crate::tool::tool_to_action;
     use wirken_gateway::permissions::Action;

--- a/crates/agent/src/tool.rs
+++ b/crates/agent/src/tool.rs
@@ -289,18 +289,16 @@ impl ToolRegistry {
     }
 
     async fn exec_command(&self, args: &serde_json::Value) -> Result<ToolResult, AgentError> {
-        let command = args["command"]
-            .as_str()
-            .ok_or_else(|| AgentError::Tool("missing 'command' argument".into()))?;
+        let command = extract_exec_command(args)?;
 
         // Use sandbox if available (provisioned lazily on first call)
         if let Some(sandbox) = self.sandbox().await {
-            return sandbox.exec(command, &self.workspace).await;
+            return sandbox.exec(&command, &self.workspace).await;
         }
 
         let child = tokio::process::Command::new("sh")
             .arg("-c")
-            .arg(command)
+            .arg(&command)
             .current_dir(&self.workspace)
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
@@ -796,13 +794,52 @@ fn urlencoding_decode(s: &str) -> String {
     String::from_utf8_lossy(&result).into_owned()
 }
 
+/// Extract the shell command string from an `exec` tool call's args.
+/// Accepts either `command: "curl foo"` (string) or
+/// `command: ["curl", "foo"]` (array of strings, space-joined for
+/// both tier classification and sandbox execution).
+///
+/// Returns an error for missing, null, object, or array-with-
+/// non-string-elements forms. This matters for tier enforcement:
+/// the pre-fix code swallowed non-string `command` via `as_str()`,
+/// yielding an empty pattern that fell through to Tier 2 even for
+/// high-risk prefixes like `curl` or `ssh`.
+pub fn extract_exec_command(args: &serde_json::Value) -> Result<String, AgentError> {
+    match args.get("command") {
+        Some(serde_json::Value::String(s)) => Ok(s.clone()),
+        Some(serde_json::Value::Array(items)) => {
+            let mut parts = Vec::with_capacity(items.len());
+            for item in items {
+                match item.as_str() {
+                    Some(s) => parts.push(s.to_string()),
+                    None => {
+                        return Err(AgentError::Tool(
+                            "exec.command array must contain only strings".into(),
+                        ));
+                    }
+                }
+            }
+            Ok(parts.join(" "))
+        }
+        Some(_) => Err(AgentError::Tool(
+            "exec.command must be a string or array of strings".into(),
+        )),
+        None => Err(AgentError::Tool("missing 'command' argument".into())),
+    }
+}
+
 /// Map a built-in tool invocation to a permission Action for tier checking.
 /// Returns None for tools that don't map to a permission-checkable action
 /// (e.g., unknown MCP or Wasm tools are not subject to permission checks).
 pub fn tool_to_action(tool_name: &str, args: &serde_json::Value) -> Option<Action> {
     match tool_name {
         "exec" => {
-            let cmd = args.get("command").and_then(|c| c.as_str()).unwrap_or("");
+            // Normalize via the same extractor the dispatcher uses so
+            // tier classification never disagrees with execution about
+            // the command shape. A malformed payload yields an empty
+            // pattern and falls through to Tier 2; the dispatcher then
+            // rejects the call before it runs.
+            let cmd = extract_exec_command(args).unwrap_or_default();
             let pattern = cmd.split_whitespace().next().unwrap_or("").to_string();
             Some(Action::ShellExec { pattern })
         }


### PR DESCRIPTION
## Summary — security fix

`tool_to_action` in `crates/agent/src/tool.rs` extracted the `exec` tool's `command` argument with `as_str()` only. Any model that emitted the argument as a JSON array (e.g., OpenAI/Ollama tool format variants: `{"command": ["curl", "https://x"]}`) collapsed to `cmd = ""`, `pattern = ""`, `action_key = "shell:"`, which fell through to **Tier 2** instead of matching `HIGH_RISK_PREFIXES`. Every escalated-prefix command — `curl`, `wget`, `ssh`, `scp`, `sftp`, `sudo`, `su`, `doas`, `kubectl`, `helm`, `docker`, `podman`, `nc`, `ncat`, `socat`, `git` — was bypassable by prompting the model toward the array form.

Fix: centralize `command` extraction in a new `extract_exec_command(args) -> Result<String, AgentError>` that accepts string form or array-of-strings (space-joined), and errors on null, object, or array-with-non-string-elements. Both `tool_to_action` and the dispatcher `exec_command` call it, so tier classification and execution cannot disagree about the command shape.

## Verification — before / after from the audit log

Caught live with `qwen2.5:7b` emitting `command` as an array. Pre-fix run recorded:

```
permission_denied  action_key="shell:"  tier=tier2
```

for a `curl` call, which is the bypass. After the fix, the same prompt and same model against a fresh scratch gateway recorded (seqs 4–6 in `audit.db`):

```
[ 4] assistant_tool_calls
     call: exec({"command":"curl https://httpbin.org/get"})
[ 5] permission_denied
     action_key='shell:curl'  tier=tier3
[ 6] tool_result
     tool=exec success=False
     output:
       Permission denied: 'exec' requires tier3 approval. This action was not executed.
```

Hash-chained, same session.

## Test plan

New tests in `crates/agent/src/tests.rs`:

- [x] `tool_to_action_exec_array_form_curl_is_tier3` — `["curl", "..."]` → `action_key=shell:curl`, `tier=tier3`
- [x] `tool_to_action_exec_array_form_ssh_is_tier3` — `["ssh", "user@host", "uptime"]` → `shell:ssh`, `tier3`
- [x] `tool_to_action_exec_array_form_ls_is_tier2` — `["ls", "-la"]` → `shell:ls`, `tier2`
- [x] `extract_exec_command_rejects_malformed_shapes` — objects, null, `[..., 42]`, missing all error out; well-formed string and array round-trip correctly

Plus all pre-existing tests still pass:

- [x] `cargo test --workspace` — 484 passed, 0 failed
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace` clean

## Defense-in-depth

Even if a future `tool_to_action` path ever returns an `Action::ShellExec` with an empty pattern (any reason), `exec_command` now independently runs the same `extract_exec_command` and errors out on malformed input before anything reaches the sandbox. The tier check and the dispatcher are aligned on the same helper.