### PR TITLE
chore: refresh gimli to unyanked 0.33.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1643,9 +1643,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.33.1"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19e16c5073773ccf057c282be832a59ee53ef5ff98db3aeff7f8314f52ffc196"
+checksum = "0bf7f043f89559805f8c7cacc432749b2fa0d0a0a9ee46ce47164ed5ba7f126c"
 dependencies = [
  "fnv",
  "hashbrown 0.16.1",


### PR DESCRIPTION
## Summary
- `gimli 0.33.1` was yanked from crates.io; `cargo-deny`'s advisories check now fails on every PR that exercises it (e.g. Dependabot PRs #19, #20).
- Runs `cargo update -p gimli`, which resolves to the latest unyanked version, `0.33.0`. Pulled in transitively via `addr2line` → `wasmtime`.
- No manifest changes; lockfile only.

## Test plan
- [ ] CI green (Deny advisories passes)
- [ ] Rebase Dependabot PRs #19 and #20 once merged and confirm their Deny jobs pass
