### PR TITLE
skills: rename metadata.openclaw to metadata.wirken

### DIFF
--- a/crates/agent/src/skill.rs
+++ b/crates/agent/src/skill.rs
@@ -149,12 +149,27 @@ fn parse_frontmatter(content: &str) -> Result<(SkillFrontmatter, String), AgentE
 }
 
 /// Extract required binary names from the metadata field.
-/// Handles the OpenClaw format: metadata.openclaw.requires.bins
+/// Primary key is `metadata.wirken.requires.bins`. `metadata.openclaw.*`
+/// is accepted as a deprecated alias for back-compat; a migration hint
+/// is logged when only the alias is present.
 fn extract_required_bins(fm: &SkillFrontmatter) -> Vec<String> {
-    fm.metadata
-        .as_ref()
-        .and_then(|m| m.get("openclaw"))
-        .and_then(|oc| oc.get("requires"))
+    let metadata = match fm.metadata.as_ref() {
+        Some(m) => m,
+        None => return Vec::new(),
+    };
+
+    let section = metadata.get("wirken").or_else(|| {
+        let openclaw = metadata.get("openclaw");
+        if openclaw.is_some() {
+            tracing::warn!(
+                "skill frontmatter uses deprecated 'openclaw' metadata key; rename to 'wirken'"
+            );
+        }
+        openclaw
+    });
+
+    section
+        .and_then(|s| s.get("requires"))
         .and_then(|req| req.get("bins"))
         .and_then(|bins| bins.as_array())
         .map(|arr| {

--- a/crates/agent/src/tests.rs
+++ b/crates/agent/src/tests.rs
@@ -125,7 +125,7 @@ fn load_skill_from_markdown() {
         r#"---
 name: weather
 description: "Get current weather via wttr.in"
-metadata: { "openclaw": { "emoji": "☔", "requires": { "bins": ["curl"] } } }
+metadata: { "wirken": { "emoji": "☔", "requires": { "bins": ["curl"] } } }
 ---
 
 # Weather Skill
@@ -201,7 +201,8 @@ description: "Needs a nonexistent binary"
 metadata: { "openclaw": { "requires": { "bins": ["nonexistent_binary_xyz_999"] } } }
 ---
 
-This skill requires a binary that doesn't exist.
+This skill requires a binary that doesn't exist, declared under the
+deprecated `openclaw` alias to exercise the back-compat path.
 "#,
     )
     .unwrap();

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -214,7 +214,7 @@ These skills have zero compilation and zero migration cost. Wirken's agent runti
 ---
 name: weather
 description: "Get current weather via wttr.in"
-metadata: { "openclaw": { "emoji": "☔", "requires": { "bins": ["curl"] } } }
+metadata: { "wirken": { "emoji": "☔", "requires": { "bins": ["curl"] } } }
 ---
 ```
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -10,7 +10,7 @@ OpenClaw's bundled skills are `SKILL.md` files — structured markdown with YAML
 cp -r ~/.openclaw/skills/* ~/.wirken/skills/
 ```
 
-Wirken reads the `name`, `description`, and `metadata.openclaw.requires.bins` fields from the frontmatter. The markdown body is injected verbatim into the agent's system prompt. Skills that require host binaries (e.g., `curl`, `gh`, `tmux`) work if those binaries are installed.
+Wirken reads the `name`, `description`, and `metadata.wirken.requires.bins` fields from the frontmatter. `metadata.openclaw.requires.bins` is accepted as a deprecated alias so OpenClaw-authored skills continue to load unmodified. The markdown body is injected verbatim into the agent's system prompt. Skills that require host binaries (e.g., `curl`, `gh`, `tmux`) work if those binaries are installed.
 
 No compilation step. No conversion. The files are identical.
 

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -13,7 +13,7 @@ Example (`~/.wirken/skills/weather/SKILL.md`):
 name: weather
 description: Get current weather and forecasts
 metadata:
-  openclaw:
+  wirken:
     requires:
       bins: [curl]
 ---
@@ -29,7 +29,7 @@ Get weather using wttr.in.
 The frontmatter fields:
 - `name`: Skill name (falls back to directory name)
 - `description`: One-line description
-- `metadata.openclaw.requires.bins`: Required binaries. The skill is marked unavailable if any are missing.
+- `metadata.wirken.requires.bins`: Required binaries. The skill is marked unavailable if any are missing. `metadata.openclaw.requires.bins` is accepted as a deprecated alias.
 
 Wirken ships with 15 bundled skills. They are installed to `~/.wirken/skills/` on first setup.
 

--- a/skills/docker/SKILL.md
+++ b/skills/docker/SKILL.md
@@ -2,7 +2,7 @@
 name: docker
 description: Docker container management
 metadata:
-  openclaw:
+  wirken:
     requires:
       bins: [docker]
 ---

--- a/skills/git/SKILL.md
+++ b/skills/git/SKILL.md
@@ -2,7 +2,7 @@
 name: git
 description: Git version control operations
 metadata:
-  openclaw:
+  wirken:
     requires:
       bins: [git]
 ---

--- a/skills/github/SKILL.md
+++ b/skills/github/SKILL.md
@@ -2,7 +2,7 @@
 name: github
 description: GitHub operations via the gh CLI
 metadata:
-  openclaw:
+  wirken:
     requires:
       bins: [gh]
 ---

--- a/skills/json-tools/SKILL.md
+++ b/skills/json-tools/SKILL.md
@@ -2,7 +2,7 @@
 name: json-tools
 description: Parse, query, and transform JSON data
 metadata:
-  openclaw:
+  wirken:
     requires:
       bins: [jq]
 ---

--- a/skills/ssh/SKILL.md
+++ b/skills/ssh/SKILL.md
@@ -2,7 +2,7 @@
 name: ssh
 description: SSH key management and remote connections
 metadata:
-  openclaw:
+  wirken:
     requires:
       bins: [ssh]
 ---

--- a/skills/tmux/SKILL.md
+++ b/skills/tmux/SKILL.md
@@ -2,7 +2,7 @@
 name: tmux
 description: Manage tmux terminal sessions
 metadata:
-  openclaw:
+  wirken:
     requires:
       bins: [tmux]
 ---

--- a/skills/weather/SKILL.md
+++ b/skills/weather/SKILL.md
@@ -2,7 +2,7 @@
 name: weather
 description: Get current weather and forecasts
 metadata:
-  openclaw:
+  wirken:
     requires:
       bins: [curl]
 ---

--- a/skills/web-fetch/SKILL.md
+++ b/skills/web-fetch/SKILL.md
@@ -2,7 +2,7 @@
 name: web-fetch
 description: Fetch and extract content from URLs
 metadata:
-  openclaw:
+  wirken:
     requires:
       bins: [curl]
 ---


### PR DESCRIPTION
Closes #27.

## Summary
- Parser prefers `metadata.wirken.requires.bins`; `metadata.openclaw.*` is accepted as a deprecated alias with a `tracing::warn` migration hint when seen on its own.
- Bundled `skills/*/SKILL.md` files migrated (8 skills that use the key).
- `docs/skills.md`, `docs/migration.md`, `docs/architecture.md` updated to describe the new primary key (alias documented for back-compat).
- Test coverage split: `load_skill_from_markdown` exercises the primary `wirken` key; `load_skill_missing_bin` retains the `openclaw` key to explicitly cover the alias path.

Follow-up (separate issue): drop the `openclaw` alias in a later version.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — all green