### PR TITLE
org policy: enforce allowed_tools and blocked_tools

### DIFF
--- a/crates/agent/src/factory.rs
+++ b/crates/agent/src/factory.rs
@@ -44,6 +44,7 @@ use lru::LruCache;
 use tokio::sync::Mutex as AsyncMutex;
 use wirken_audit::SessionLog;
 use wirken_gateway::agent_config::SubagentCeiling;
+use wirken_gateway::org::OrgPermissions;
 use wirken_gateway::permissions::PermissionStore;
 
 use crate::error::AgentError;
@@ -132,6 +133,10 @@ pub struct AgentFactory {
     static_configs: HashMap<String, AgentStaticConfig>,
     session_log: Arc<dyn SessionLog>,
     permissions: Option<Arc<StdMutex<PermissionStore>>>,
+    /// Org-level tool allow/deny policy, applied before the per-tier
+    /// permission check. Shared across every waked Agent because org
+    /// policy is a gateway-wide setting, not a per-agent one.
+    org_permissions: Option<Arc<OrgPermissions>>,
     cache: StdMutex<LruCache<String, Arc<AsyncMutex<Agent>>>>,
     cache_mode: CacheMode,
     /// `Weak<Self>` of this very factory, captured at construction
@@ -157,6 +162,7 @@ impl AgentFactory {
             static_configs,
             session_log,
             permissions,
+            None,
             CacheMode::Cached,
             DEFAULT_CACHE_CAPACITY,
         )
@@ -174,6 +180,7 @@ impl AgentFactory {
         static_configs: HashMap<String, AgentStaticConfig>,
         session_log: Arc<dyn SessionLog>,
         permissions: Option<Arc<StdMutex<PermissionStore>>>,
+        org_permissions: Option<Arc<OrgPermissions>>,
         cache_mode: CacheMode,
         cache_capacity: usize,
     ) -> Arc<Self> {
@@ -186,6 +193,7 @@ impl AgentFactory {
             static_configs,
             session_log,
             permissions,
+            org_permissions,
             cache: StdMutex::new(LruCache::new(capacity)),
             cache_mode,
             self_weak: weak.clone(),
@@ -248,6 +256,9 @@ impl AgentFactory {
         agent.attach_skills(cfg.skills.clone(), cfg.wasm_skills.clone());
         if let Some(perms) = &self.permissions {
             agent.set_permissions(perms.clone());
+        }
+        if let Some(org) = &self.org_permissions {
+            agent.set_org_permissions(org.clone());
         }
         if let Some(mcp) = &cfg.mcp_client {
             agent.attach_mcp(mcp.clone());

--- a/crates/agent/src/runtime.rs
+++ b/crates/agent/src/runtime.rs
@@ -89,6 +89,12 @@ pub struct Agent {
     /// Optional permission store for checking tool execution permissions.
     /// When None, all tools execute without permission checks (standalone mode).
     permissions: Option<Arc<std::sync::Mutex<PermissionStore>>>,
+    /// Optional org-level tool allow/deny policy. Evaluated before
+    /// the tier permission check: `blocked_tools` short-circuits to
+    /// denial; a non-empty `allowed_tools` acts as an allowlist.
+    /// None means no org policy applies (the local permission store
+    /// is authoritative).
+    org_permissions: Option<Arc<wirken_gateway::org::OrgPermissions>>,
     /// The current user message that triggered this processing round.
     /// Captured in process_message() for inclusion in denial audit events.
     current_trigger: Option<String>,
@@ -209,6 +215,7 @@ impl Agent {
             system_prompt,
             api_key,
             permissions: None,
+            org_permissions: None,
             current_trigger: None,
             session_log,
             session_handle,
@@ -285,6 +292,7 @@ impl Agent {
             system_prompt,
             api_key,
             permissions: None,
+            org_permissions: None,
             current_trigger: None,
             session_log,
             session_handle,
@@ -368,6 +376,14 @@ impl Agent {
     /// before execution. Denials are collected in the `ProcessResult`.
     pub fn set_permissions(&mut self, store: Arc<std::sync::Mutex<PermissionStore>>) {
         self.permissions = Some(store);
+    }
+
+    /// Attach the org-level tool allow/deny policy. See
+    /// `OrgPermissions` for the shape. Checked before the tier
+    /// permission check in `execute_tool`, fail-closed with a
+    /// denial event written to the session log.
+    pub fn set_org_permissions(&mut self, org: Arc<wirken_gateway::org::OrgPermissions>) {
+        self.org_permissions = Some(org);
     }
 
     /// Connect to the out-of-process MCP proxy and load this agent's
@@ -1340,7 +1356,7 @@ impl Agent {
 
     /// Execute a tool call, trying built-in tools, then MCP, then Wasm skills.
     /// Permission checks are applied when a PermissionStore is configured.
-    async fn execute_tool(
+    pub(crate) async fn execute_tool(
         &mut self,
         name: &str,
         arguments: &str,
@@ -1366,6 +1382,47 @@ impl Agent {
                 output: format!("tool '{name}' is not in this subagent's allowed tool set"),
                 success: false,
             });
+        }
+
+        // Org-level allow/deny check: applied before the tier
+        // permission check so a blocked tool never goes to the
+        // approval prompt, never touches the sandbox, and never
+        // reaches the tool dispatcher. `blocked_tools` is absolute.
+        // `allowed_tools`, when non-empty, acts as an allowlist:
+        // any tool not in it is treated as blocked. `spawn_subagent`
+        // is handled earlier in this function via a dedicated
+        // intercept and is out of scope for org policy (subagent
+        // ceilings already govern spawning).
+        if let Some(ref org) = self.org_permissions {
+            let blocked = org.blocked_tools.iter().any(|t| t == name);
+            let outside_allowlist =
+                !org.allowed_tools.is_empty() && !org.allowed_tools.iter().any(|t| t == name);
+            if blocked || outside_allowlist {
+                let reason = if blocked {
+                    format!("tool '{name}' is blocked by org policy")
+                } else {
+                    format!("tool '{name}' is not in the org allowed_tools list")
+                };
+                let args: serde_json::Value =
+                    serde_json::from_str(arguments).unwrap_or(serde_json::Value::Null);
+                let action_key = tool_to_action(name, &args)
+                    .map(|a| a.approval_key())
+                    .unwrap_or_else(|| name.to_string());
+                self.log_event(
+                    TrustLevel::System,
+                    SessionEvent::PermissionDenied {
+                        tool: name.to_string(),
+                        action_key,
+                        tier: "org_policy".to_string(),
+                        agent_id: self.id.clone(),
+                        trigger: self.current_trigger.clone(),
+                    },
+                )?;
+                return Ok(crate::tool::ToolResult {
+                    output: reason,
+                    success: false,
+                });
+            }
         }
 
         // Permission check before execution

--- a/crates/agent/src/tests.rs
+++ b/crates/agent/src/tests.rs
@@ -1470,7 +1470,7 @@ mod wake {
                 sandbox: Default::default(),
             },
         );
-        let factory = AgentFactory::with_options(configs, log, None, CacheMode::Drop, 64);
+        let factory = AgentFactory::with_options(configs, log, None, None, CacheMode::Drop, 64);
 
         let session = "agent-drop/test/conv-1";
         let a = factory.wake("agent-drop", session).unwrap();
@@ -4322,5 +4322,166 @@ mod system_prompt_event {
         let mut conv = Conversation::new(100_000);
         conv.replay_from_log(&*log, &h).unwrap();
         assert_eq!(conv.messages()[0].content, "second");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Org-level tool allow/deny policy (closes #32)
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod org_tool_policy {
+    use super::*;
+    use crate::factory::{AgentFactory, AgentStaticConfig, CacheMode};
+    use crate::llm::LlmConfig;
+    use std::sync::Arc;
+    use wirken_audit::SqliteSessionLog;
+    use wirken_gateway::org::OrgPermissions;
+
+    async fn make_agent_with_policy(
+        org: Option<OrgPermissions>,
+    ) -> (Arc<tokio::sync::Mutex<crate::runtime::Agent>>, TempDir) {
+        let tmp = TempDir::new().unwrap();
+        let log: Arc<dyn SessionLog> = Arc::new(SqliteSessionLog::open_in_memory().unwrap());
+        let mut configs = std::collections::HashMap::new();
+        configs.insert(
+            "a1".to_string(),
+            AgentStaticConfig {
+                agent_id: "a1".to_string(),
+                workspace: tmp.path().to_path_buf(),
+                llm_config: LlmConfig::ollama("test"),
+                api_key: None,
+                skills: Vec::new(),
+                wasm_skills: Vec::new(),
+                mcp_client: None,
+                identity: None,
+                allowed_subagents: Default::default(),
+                sandbox: Default::default(),
+            },
+        );
+        let factory =
+            AgentFactory::with_options(configs, log, None, org.map(Arc::new), CacheMode::Drop, 4);
+        let arc = factory.wake("a1", "a1/test/conv-1").unwrap();
+        (arc, tmp)
+    }
+
+    #[tokio::test]
+    async fn blocked_tool_fails_before_dispatch() {
+        let org = OrgPermissions {
+            sandbox_mode: None,
+            allowed_tools: vec![],
+            blocked_tools: vec!["read_file".into()],
+        };
+        let (agent, _tmp) = make_agent_with_policy(Some(org)).await;
+        let mut a = agent.lock().await;
+        let result = a
+            .execute_tool("read_file", r#"{"path":"anything"}"#)
+            .await
+            .unwrap();
+        assert!(!result.success);
+        assert!(
+            result.output.contains("blocked by org policy"),
+            "expected blocked-by-org message, got: {}",
+            result.output
+        );
+    }
+
+    #[tokio::test]
+    async fn non_allowlisted_tool_fails_when_allowlist_non_empty() {
+        let org = OrgPermissions {
+            sandbox_mode: None,
+            allowed_tools: vec!["read_file".into()],
+            blocked_tools: vec![],
+        };
+        let (agent, _tmp) = make_agent_with_policy(Some(org)).await;
+        let mut a = agent.lock().await;
+        let result = a
+            .execute_tool("web_search", r#"{"query":"x"}"#)
+            .await
+            .unwrap();
+        assert!(!result.success);
+        assert!(
+            result.output.contains("not in the org allowed_tools list"),
+            "expected not-in-allowlist message, got: {}",
+            result.output
+        );
+    }
+
+    #[tokio::test]
+    async fn allowlisted_tool_reaches_dispatch() {
+        // read_file will fail at dispatch because the target file
+        // doesn't exist, but it must get past the org check first.
+        // The failure surface tells us which gate rejected it.
+        let org = OrgPermissions {
+            sandbox_mode: None,
+            allowed_tools: vec!["read_file".into()],
+            blocked_tools: vec![],
+        };
+        let (agent, _tmp) = make_agent_with_policy(Some(org)).await;
+        let mut a = agent.lock().await;
+        let result = a
+            .execute_tool("read_file", r#"{"path":"missing.txt"}"#)
+            .await;
+        // Should NOT be "not in the org allowed_tools list" — either
+        // it succeeds (file exists) or the dispatcher returns a
+        // read-specific error. Either way the gate didn't reject it.
+        match result {
+            Ok(r) => assert!(!r.output.contains("not in the org allowed_tools list")),
+            Err(e) => assert!(!format!("{e}").contains("not in the org allowed_tools list")),
+        }
+    }
+
+    #[tokio::test]
+    async fn empty_allowlist_does_not_act_as_deny_all() {
+        let org = OrgPermissions {
+            sandbox_mode: None,
+            allowed_tools: vec![],
+            blocked_tools: vec![],
+        };
+        let (agent, _tmp) = make_agent_with_policy(Some(org)).await;
+        let mut a = agent.lock().await;
+        let result = a
+            .execute_tool("read_file", r#"{"path":"missing.txt"}"#)
+            .await;
+        // An empty allowed_tools list means "no allowlist restriction,"
+        // not "deny everything." The call should reach dispatch and fail
+        // for a dispatch-level reason (file not found), never for org policy.
+        if let Ok(r) = result {
+            assert!(!r.output.contains("not in the org allowed_tools list"));
+            assert!(!r.output.contains("blocked by org policy"));
+        }
+    }
+
+    #[tokio::test]
+    async fn blocked_takes_precedence_over_allowlist() {
+        // A tool on both lists is blocked. This matters if an operator
+        // mis-configures both fields: the safer gate wins.
+        let org = OrgPermissions {
+            sandbox_mode: None,
+            allowed_tools: vec!["read_file".into()],
+            blocked_tools: vec!["read_file".into()],
+        };
+        let (agent, _tmp) = make_agent_with_policy(Some(org)).await;
+        let mut a = agent.lock().await;
+        let result = a
+            .execute_tool("read_file", r#"{"path":"anything"}"#)
+            .await
+            .unwrap();
+        assert!(!result.success);
+        assert!(result.output.contains("blocked by org policy"));
+    }
+
+    #[tokio::test]
+    async fn no_policy_attached_preserves_default_behavior() {
+        let (agent, _tmp) = make_agent_with_policy(Option::<OrgPermissions>::None).await;
+        let mut a = agent.lock().await;
+        let result = a
+            .execute_tool("read_file", r#"{"path":"missing.txt"}"#)
+            .await;
+        // With no org policy set, the call goes straight to dispatch.
+        if let Ok(r) = result {
+            assert!(!r.output.contains("blocked by org policy"));
+            assert!(!r.output.contains("not in the org allowed_tools list"));
+        }
     }
 }

--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -512,10 +512,26 @@ pub async fn run(port: Option<u16>) -> Result<()> {
         .and_then(|s| s.parse::<usize>().ok())
         .filter(|n| *n > 0)
         .unwrap_or(64);
+    let org_tool_policy =
+        wirken_gateway::org::load_tool_policy(&cfg.data_dir).map(std::sync::Arc::new);
+    if let Some(ref policy) = org_tool_policy {
+        let allowed = if policy.allowed_tools.is_empty() {
+            "any".to_string()
+        } else {
+            policy.allowed_tools.join(", ")
+        };
+        let blocked = if policy.blocked_tools.is_empty() {
+            "none".to_string()
+        } else {
+            policy.blocked_tools.join(", ")
+        };
+        println!("  Org tool policy: allowed={allowed}; blocked={blocked}");
+    }
     let factory = AgentFactory::with_options(
         static_configs,
         session_log.clone(),
         Some(permissions.clone()),
+        org_tool_policy,
         cache_mode,
         cache_capacity,
     );

--- a/crates/cli/src/commands/session.rs
+++ b/crates/cli/src/commands/session.rs
@@ -199,7 +199,7 @@ pub async fn verify(session_id: &str, strict: bool) -> Result<()> {
         },
     );
     let factory =
-        AgentFactory::with_options(configs, session_log.clone(), None, CacheMode::Drop, 1);
+        AgentFactory::with_options(configs, session_log.clone(), None, None, CacheMode::Drop, 1);
 
     let agent_arc = factory
         .wake(&agent_id, session_id)

--- a/crates/gateway/src/org.rs
+++ b/crates/gateway/src/org.rs
@@ -199,7 +199,52 @@ pub fn apply_org_config(
         }
     }
 
+    // Tool allow/deny policy. Persisted to `tool_policy.json` on the
+    // same principle as `sandbox.json`: a single-purpose file the
+    // gateway reads on every start. Absent or empty lists disable
+    // the corresponding check in `crates/agent/src/runtime.rs::execute_tool`.
+    if let Some(ref perms) = org.permissions
+        && (!perms.allowed_tools.is_empty() || !perms.blocked_tools.is_empty())
+    {
+        let path = data_dir.join("tool_policy.json");
+        if force || !path.exists() {
+            let body = serde_json::json!({
+                "allowed_tools": perms.allowed_tools,
+                "blocked_tools": perms.blocked_tools,
+            });
+            std::fs::write(
+                &path,
+                serde_json::to_string_pretty(&body).unwrap_or_default(),
+            )
+            .map_err(|e| format!("write tool_policy.json: {e}"))?;
+            applied.push("tool_policy".into());
+        }
+    }
+
     Ok(applied)
+}
+
+/// Read `tool_policy.json` from the gateway data directory and
+/// return it as an [`OrgPermissions`] carrying only the allow/deny
+/// lists (sandbox_mode is None — sandbox is already loaded separately).
+/// Returns `None` if the file is absent or unreadable; malformed
+/// JSON is logged and treated as absent (fail-open on policy load is
+/// intentional: a corrupted policy file should not brick the
+/// gateway, but the operator sees a warning).
+pub fn load_tool_policy(data_dir: &Path) -> Option<OrgPermissions> {
+    let path = data_dir.join("tool_policy.json");
+    let body = std::fs::read_to_string(&path).ok()?;
+    match serde_json::from_str::<OrgPermissions>(&body) {
+        Ok(perms) => Some(perms),
+        Err(e) => {
+            tracing::warn!(
+                "tool_policy.json at {} is malformed: {e}; \
+                 continuing with no org tool policy",
+                path.display()
+            );
+            None
+        }
+    }
 }
 
 #[cfg(test)]
@@ -231,6 +276,53 @@ mod tests {
         let applied = apply_org_config(tmp.path(), &org, true).unwrap();
         assert!(!applied.contains(&"sandbox".to_string()));
         assert!(!tmp.path().join("sandbox.json").exists());
+    }
+
+    #[test]
+    fn apply_org_config_writes_tool_policy_when_lists_non_empty() {
+        let tmp = TempDir::new().unwrap();
+        let org = OrgConfig {
+            permissions: Some(OrgPermissions {
+                sandbox_mode: None,
+                allowed_tools: vec!["read_file".into(), "web_search".into()],
+                blocked_tools: vec!["exec".into()],
+            }),
+            ..Default::default()
+        };
+        let applied = apply_org_config(tmp.path(), &org, true).unwrap();
+        assert!(applied.contains(&"tool_policy".to_string()));
+        let loaded = load_tool_policy(tmp.path()).unwrap();
+        assert_eq!(loaded.allowed_tools, vec!["read_file", "web_search"]);
+        assert_eq!(loaded.blocked_tools, vec!["exec"]);
+    }
+
+    #[test]
+    fn apply_org_config_skips_tool_policy_when_both_lists_empty() {
+        let tmp = TempDir::new().unwrap();
+        let org = OrgConfig {
+            permissions: Some(OrgPermissions {
+                sandbox_mode: Some("gvisor".into()),
+                allowed_tools: vec![],
+                blocked_tools: vec![],
+            }),
+            ..Default::default()
+        };
+        let applied = apply_org_config(tmp.path(), &org, true).unwrap();
+        assert!(!applied.contains(&"tool_policy".to_string()));
+        assert!(!tmp.path().join("tool_policy.json").exists());
+    }
+
+    #[test]
+    fn load_tool_policy_returns_none_for_missing_file() {
+        let tmp = TempDir::new().unwrap();
+        assert!(load_tool_policy(tmp.path()).is_none());
+    }
+
+    #[test]
+    fn load_tool_policy_returns_none_for_malformed_json() {
+        let tmp = TempDir::new().unwrap();
+        std::fs::write(tmp.path().join("tool_policy.json"), "{ not json").unwrap();
+        assert!(load_tool_policy(tmp.path()).is_none());
     }
 
     #[test]

--- a/docs/enterprise.md
+++ b/docs/enterprise.md
@@ -54,7 +54,7 @@ On every `wirken run`, the org config refreshes automatically.
 }
 ```
 
-All fields are optional. Only provided fields are applied. The `provider`, `api_key_name`, `siem`, `mcp`, and `skills` fields are wired through. The `permissions` block (`sandbox_mode`, `allowed_tools`, `blocked_tools`) is deserialized into `OrgPermissions` and then dropped: no consumer reads the values. Do not rely on these fields for enforcement today. Tracked in `BACKLOG.md` under "Org-level tool allow/deny lists."
+All fields are optional. Only provided fields are applied. The `provider`, `api_key_name`, `siem`, `mcp`, `skills`, and `permissions` fields are wired through. `permissions.sandbox_mode` drives `sandbox.json`; `permissions.allowed_tools` and `permissions.blocked_tools` drive `tool_policy.json`, which `wirken run` loads and enforces in the agent's tool dispatcher ahead of the tier permission check. See [Permissions and identity](permissions-and-identity.md) for enforcement details.
 
 ## SIEM integration
 

--- a/docs/permissions-and-identity.md
+++ b/docs/permissions-and-identity.md
@@ -72,12 +72,12 @@ wirken agents allow-subagent parent child --tools "read_file,web_search" --max-t
 
 The ceiling is stored as JSON in the `agents.allowed_subagents` column.
 
-### Org-level tool policy (partially enforced)
+### Org-level tool policy
 
-The pulled org config (`wirken setup --org <url>`) deserializes `permissions.allowed_tools`, `permissions.blocked_tools`, and `permissions.sandbox_mode` into `OrgPermissions`. Of these:
+The pulled org config (`wirken setup --org <url>`) deserializes `permissions.allowed_tools`, `permissions.blocked_tools`, and `permissions.sandbox_mode` into `OrgPermissions`. All three are enforced:
 
-- `sandbox_mode` is enforced. When present on the pulled config, `apply_org_config` writes `sandbox.json` in the data directory, and `wirken run` re-reads it on every gateway start. Valid values are `off`, `exec-only`, and `gvisor`; unknown values fall back to the default (`exec-only`) with a warning.
-- `allowed_tools` and `blocked_tools` are still parsed but not read by the permission check. A config that sets `blocked_tools: ["generate_image"]` will not prevent the agent from invoking `generate_image`. Tracked in `BACKLOG.md` under "Org-level tool allow/deny lists."
+- `sandbox_mode`. `apply_org_config` writes `sandbox.json` in the data directory; `wirken run` re-reads it on every gateway start. Valid values are `off`, `exec-only`, and `gvisor`; unknown values fall back to the default (`exec-only`) with a warning.
+- `allowed_tools` and `blocked_tools`. Persisted to `tool_policy.json` in the data directory when at least one list is non-empty. `wirken run` loads the file and injects it into every waked agent. The check sits in `crates/agent/src/runtime.rs::execute_tool` ahead of the tier permission check: a call to a name in `blocked_tools` fails before dispatch; a call to a name not in `allowed_tools` fails before dispatch when `allowed_tools` is non-empty; `blocked_tools` wins when a name appears in both. Denials are written to the session log as `PermissionDenied` events with `tier: "org_policy"`.
 
 ### Channel process isolation
 


### PR DESCRIPTION
Closes #32.

Implements option 1 from the issue: wire `OrgPermissions.allowed_tools` and `OrgPermissions.blocked_tools` into the permission check so a tool call against a blocked tool fails before execution, and a tool call outside a non-empty allowlist fails before execution.

## Summary
- New org-policy gate in `Agent::execute_tool` (ahead of the tier permission check).
- `blocked_tools` wins when a name appears in both lists.
- Denials are written to the session log as ``PermissionDenied { tier: \"org_policy\" }``.
- Persistence follows the `sandbox.json` pattern: `apply_org_config` writes `tool_policy.json` when either list is non-empty; `wirken run` loads it on startup via new `load_tool_policy` helper and injects into the `AgentFactory`.
- Malformed `tool_policy.json` logs a warning and is treated as no policy (fail-open on load so a corrupt file does not brick the gateway).
- Docs updated to drop the 'parsed but not enforced' caveats.

## Test plan
- [x] 6 new agent tests: blocked-denies, allowlist-denies-non-member, allowlisted-tool-passes-gate, empty-allowlist-is-no-op, blocked-takes-precedence, no-policy-preserves-default
- [x] 4 new gateway tests: apply writes tool_policy.json when lists non-empty, skip when both empty, load returns None for missing, load returns None for malformed
- [x] Full workspace `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` green