### PR TITLE
whatsapp: collect all four required fields in setup and channel-add

### DIFF
--- a/crates/cli/src/commands/channel.rs
+++ b/crates/cli/src/commands/channel.rs
@@ -8,20 +8,50 @@ use wirken_vault::{CredentialStore, VaultSecret, probe_keychain};
 
 use super::{config, data_dir};
 
-pub async fn add(channel: &str) -> Result<()> {
+/// Non-interactive flags for `wirken channel add`. Flags that are
+/// `None` fall through to the matching `WIRKEN_<CHANNEL>_*` env var
+/// (where applicable) and then to an interactive prompt. Validation
+/// runs on whichever source provided the value.
+#[derive(Debug, Default)]
+pub struct AddFlags {
+    pub token: Option<String>,
+    pub phone_number_id: Option<String>,
+    pub verify_token: Option<String>,
+    pub app_secret: Option<String>,
+}
+
+pub async fn add(channel: &str, flags: AddFlags) -> Result<()> {
     let cfg = config();
     let data = data_dir()?;
 
-    // Collect all tokens upfront before prompting for passphrase
-    let token = super::read_secret(&format!("  {channel} bot token: "))?;
-    let app_token = if channel == "slack" {
-        Some(super::read_secret("  Slack app token (xapp-...): ")?)
-    } else {
-        None
+    match channel {
+        "whatsapp" => add_whatsapp(&cfg, &data, flags).await,
+        "slack" => add_slack(&cfg, &data, flags).await,
+        _ => add_simple(channel, &cfg, &data, flags).await,
+    }
+}
+
+async fn add_simple(
+    channel: &str,
+    cfg: &GatewayConfig,
+    data: &std::path::Path,
+    flags: AddFlags,
+) -> Result<()> {
+    let token = resolve_token(channel, flags.token.as_deref(), true)?;
+    register_channel(channel, &token, cfg, data).await?;
+    println!("  Channel '{channel}' added.");
+    println!("  Start the adapter with: wirken adapter {channel}");
+    Ok(())
+}
+
+async fn add_slack(cfg: &GatewayConfig, data: &std::path::Path, flags: AddFlags) -> Result<()> {
+    let token = resolve_token("slack", flags.token.as_deref(), true)?;
+    let app_token = match std::env::var("WIRKEN_SLACK_APP_TOKEN") {
+        Ok(v) if !v.trim().is_empty() => v.trim().to_string(),
+        _ => super::read_secret("  Slack app token (xapp-...): ")?,
     };
 
-    // Open vault once
-    let keychain = probe_keychain(&data, || {
+    let keychain = probe_keychain(data, || {
         Password::new()
             .with_prompt("  Vault passphrase")
             .interact()
@@ -30,21 +60,161 @@ pub async fn add(channel: &str) -> Result<()> {
     let store = CredentialStore::open(&cfg.vault_db_path(), keychain.as_ref())
         .context("Failed to open credential store")?;
 
-    // Store bot token
-    let secret = VaultSecret::new(token);
     store
-        .store(&format!("{channel}-token"), channel, &secret, None, None)
-        .context("Failed to store channel token")?;
+        .store(
+            "slack-token",
+            "slack",
+            &VaultSecret::new(token.clone()),
+            None,
+            None,
+        )
+        .context("Failed to store Slack token")?;
+    store
+        .store(
+            "slack-app-token",
+            "slack",
+            &VaultSecret::new(app_token),
+            None,
+            None,
+        )
+        .context("Failed to store Slack app token")?;
 
-    // Store app token for Slack
-    if let Some(app_token) = app_token {
-        let secret = VaultSecret::new(app_token);
-        store
-            .store("slack-app-token", "slack", &secret, None, None)
-            .context("Failed to store Slack app token")?;
-    }
+    register_adapter_identity("slack", cfg, &store)?;
+    println!("  slack: tokens encrypted, adapter keypair generated, registered.");
+    println!("  Channel 'slack' added.");
+    println!("  Start the adapter with: wirken adapter slack");
+    Ok(())
+}
 
-    // Generate adapter keypair
+/// Collect and persist WhatsApp Cloud API credentials. The adapter
+/// needs four fields — access token, phone number ID, verify token,
+/// app secret — all in the vault before `wirken run` will start the
+/// listener. Values come from, in order: CLI flag, env var
+/// (`WIRKEN_WHATSAPP_*`), interactive prompt. Validation runs on
+/// whichever source supplied the value so a bad flag fails as loudly
+/// as a bad prompt entry.
+async fn add_whatsapp(cfg: &GatewayConfig, data: &std::path::Path, flags: AddFlags) -> Result<()> {
+    let creds = collect_whatsapp_creds(flags).context("Failed to collect WhatsApp credentials")?;
+
+    let keychain = probe_keychain(data, || {
+        Password::new()
+            .with_prompt("  Vault passphrase")
+            .interact()
+            .unwrap_or_default()
+    });
+    let store = CredentialStore::open(&cfg.vault_db_path(), keychain.as_ref())
+        .context("Failed to open credential store")?;
+
+    store_whatsapp_creds(&store, &creds)?;
+    register_adapter_identity("whatsapp", cfg, &store)?;
+    println!("  whatsapp: credentials encrypted, adapter keypair generated, registered.");
+    println!("  Channel 'whatsapp' added.");
+    println!("  Start the adapter with: wirken adapter whatsapp");
+    Ok(())
+}
+
+/// The four vault entries a WhatsApp adapter needs. Named to match
+/// the keys `crates/cli/src/commands/adapter.rs` already retrieves.
+#[derive(Debug, Clone)]
+pub struct WhatsAppCreds {
+    pub token: String,
+    pub phone_number_id: String,
+    pub verify_token: String,
+    pub app_secret: String,
+}
+
+/// Resolve the WhatsApp credential set from flags, env vars, and
+/// prompts. The collection order is the same for every field:
+/// CLI flag → `WIRKEN_WHATSAPP_*` env var → interactive prompt.
+/// Validation is applied to whichever source provided the value,
+/// and in the interactive case the user is re-prompted until a
+/// valid value lands or they abort. Pure in the non-interactive
+/// sense: if all four fields are supplied via flag or env and all
+/// pass validation, no prompt runs.
+pub fn collect_whatsapp_creds(flags: AddFlags) -> Result<WhatsAppCreds> {
+    let token = resolve_with_validation(
+        "WhatsApp access token",
+        flags.token,
+        "WIRKEN_WHATSAPP_TOKEN",
+        true,
+        validate_non_empty,
+    )?;
+    let phone_number_id = resolve_with_validation(
+        "WhatsApp phone number ID",
+        flags.phone_number_id,
+        "WIRKEN_WHATSAPP_PHONE_NUMBER_ID",
+        false,
+        validate_phone_number_id,
+    )?;
+    let verify_token = resolve_with_validation(
+        "WhatsApp verify token",
+        flags.verify_token,
+        "WIRKEN_WHATSAPP_VERIFY_TOKEN",
+        true,
+        validate_non_empty,
+    )?;
+    let app_secret = resolve_with_validation(
+        "WhatsApp app secret",
+        flags.app_secret,
+        "WIRKEN_WHATSAPP_APP_SECRET",
+        true,
+        validate_app_secret,
+    )?;
+    Ok(WhatsAppCreds {
+        token,
+        phone_number_id,
+        verify_token,
+        app_secret,
+    })
+}
+
+/// Write the four WhatsApp credentials to the vault under the keys
+/// the adapter reads in `crates/cli/src/commands/adapter.rs`.
+pub fn store_whatsapp_creds(store: &CredentialStore, creds: &WhatsAppCreds) -> Result<()> {
+    store
+        .store(
+            "whatsapp-token",
+            "whatsapp",
+            &VaultSecret::new(creds.token.clone()),
+            None,
+            None,
+        )
+        .context("Failed to store WhatsApp token")?;
+    store
+        .store(
+            "whatsapp-phone-number-id",
+            "whatsapp",
+            &VaultSecret::new(creds.phone_number_id.clone()),
+            None,
+            None,
+        )
+        .context("Failed to store WhatsApp phone number ID")?;
+    store
+        .store(
+            "whatsapp-verify-token",
+            "whatsapp",
+            &VaultSecret::new(creds.verify_token.clone()),
+            None,
+            None,
+        )
+        .context("Failed to store WhatsApp verify token")?;
+    store
+        .store(
+            "whatsapp-app-secret",
+            "whatsapp",
+            &VaultSecret::new(creds.app_secret.clone()),
+            None,
+            None,
+        )
+        .context("Failed to store WhatsApp app secret")?;
+    Ok(())
+}
+
+fn register_adapter_identity(
+    channel: &str,
+    cfg: &GatewayConfig,
+    store: &CredentialStore,
+) -> Result<()> {
     let identity = AdapterIdentity::generate(channel);
     let pub_key = identity.public_key_bytes();
 
@@ -53,26 +223,143 @@ pub async fn add(channel: &str) -> Result<()> {
         .iter()
         .map(|b| format!("{b:02x}"))
         .collect();
-    let sk_secret = VaultSecret::new(secret_key_hex);
     store
         .store(
             &format!("{channel}-adapter-key"),
             channel,
-            &sk_secret,
+            &VaultSecret::new(secret_key_hex),
             None,
             None,
         )
         .context("Failed to store adapter key")?;
 
-    // Register in adapter registry
     let registry = AdapterRegistry::open(&cfg.adapters_db_path())
         .context("Failed to open adapter registry")?;
-    registry.register(channel, &pub_key, channel)?;
+    let _ = registry.unregister(channel);
+    registry
+        .register(channel, &pub_key, channel)
+        .context("Failed to register adapter")?;
+    Ok(())
+}
 
-    println!("  {channel}: token encrypted, adapter keypair generated, registered.");
+fn resolve_token(channel: &str, flag: Option<&str>, secret: bool) -> Result<String> {
+    let env_var = format!("WIRKEN_{}_TOKEN", channel.to_uppercase().replace('-', "_"));
+    if let Some(t) = flag {
+        let t = t.trim().to_string();
+        validate_non_empty(&t)?;
+        return Ok(t);
+    }
+    if let Ok(v) = std::env::var(&env_var) {
+        let v = v.trim().to_string();
+        if !v.is_empty() {
+            return Ok(v);
+        }
+    }
+    let label = format!("  {channel} bot token");
+    loop {
+        let value = if secret {
+            super::read_secret(&format!("{label}: "))?
+        } else {
+            dialoguer::Input::<String>::new()
+                .with_prompt(&label)
+                .interact_text()?
+        };
+        match validate_non_empty(&value) {
+            Ok(()) => return Ok(value),
+            Err(e) => {
+                println!("  {e}");
+                continue;
+            }
+        }
+    }
+}
 
-    println!("  Channel '{channel}' added.");
-    println!("  Start the adapter with: wirken adapter {channel}");
+fn resolve_with_validation(
+    label: &str,
+    flag: Option<String>,
+    env_var: &str,
+    secret: bool,
+    validate: fn(&str) -> Result<()>,
+) -> Result<String> {
+    if let Some(v) = flag {
+        let v = v.trim().to_string();
+        validate(&v).with_context(|| format!("Invalid --{} flag", env_var))?;
+        return Ok(v);
+    }
+    if let Ok(v) = std::env::var(env_var) {
+        let v = v.trim().to_string();
+        if !v.is_empty() {
+            validate(&v).with_context(|| format!("Invalid {env_var} env var"))?;
+            return Ok(v);
+        }
+    }
+    loop {
+        let prompt_label = format!("  {label}");
+        let value = if secret {
+            super::read_secret(&format!("{prompt_label}: "))?
+        } else {
+            dialoguer::Input::<String>::new()
+                .with_prompt(&prompt_label)
+                .interact_text()?
+        };
+        match validate(&value) {
+            Ok(()) => return Ok(value),
+            Err(e) => {
+                println!("  {e}");
+                continue;
+            }
+        }
+    }
+}
+
+// -- Validators ---------------------------------------------------------
+
+/// A token / secret must have at least one non-whitespace character.
+/// The prompt helpers trim before calling, so this rejects the
+/// empty string and nothing else.
+pub fn validate_non_empty(s: &str) -> Result<()> {
+    if s.trim().is_empty() {
+        anyhow::bail!("value cannot be empty");
+    }
+    Ok(())
+}
+
+/// WhatsApp Cloud API phone-number-id: numeric, 15 or 16 digits.
+/// Meta's IDs are 64-bit-ish integers rendered decimal; we range-
+/// check length rather than parsing into u64 to keep the rejection
+/// message intelligible.
+pub fn validate_phone_number_id(s: &str) -> Result<()> {
+    let trimmed = s.trim();
+    if !(15..=16).contains(&trimmed.len()) {
+        anyhow::bail!(
+            "phone number ID must be 15-16 digits (got {} chars)",
+            trimmed.len()
+        );
+    }
+    if !trimmed.chars().all(|c| c.is_ascii_digit()) {
+        anyhow::bail!("phone number ID must be numeric");
+    }
+    Ok(())
+}
+
+/// Meta app secret as shown in the Meta Developer portal: 32
+/// characters, lowercase hex. Anything else is either a copy-paste
+/// mistake (leading whitespace, wrong field) or a mis-configured
+/// app. Fail at entry rather than at first webhook delivery.
+pub fn validate_app_secret(s: &str) -> Result<()> {
+    let trimmed = s.trim();
+    if trimmed.len() != 32 {
+        anyhow::bail!(
+            "app secret must be exactly 32 characters (got {})",
+            trimmed.len()
+        );
+    }
+    if !trimmed
+        .chars()
+        .all(|c| c.is_ascii_digit() || ('a'..='f').contains(&c))
+    {
+        anyhow::bail!("app secret must be lowercase hex (0-9, a-f)");
+    }
     Ok(())
 }
 
@@ -115,10 +402,22 @@ pub async fn remove(channel: &str) -> Result<()> {
         .unregister(channel)
         .context(format!("Failed to remove channel '{channel}'"))?;
 
-    // Remove credential
+    // Remove credential(s). WhatsApp has four keys; everything else
+    // uses one `<channel>-token` entry.
     let keychain = probe_keychain(&cfg.data_dir, String::new);
     if let Ok(store) = CredentialStore::open(&cfg.vault_db_path(), keychain.as_ref()) {
-        let _ = store.delete(&format!("{channel}-token"));
+        if channel == "whatsapp" {
+            for key in [
+                "whatsapp-token",
+                "whatsapp-phone-number-id",
+                "whatsapp-verify-token",
+                "whatsapp-app-secret",
+            ] {
+                let _ = store.delete(key);
+            }
+        } else {
+            let _ = store.delete(&format!("{channel}-token"));
+        }
     }
 
     println!("  Channel '{channel}' removed.");
@@ -148,38 +447,138 @@ pub async fn register_channel(
         .store(&format!("{channel}-token"), channel, &secret, None, None)
         .context("Failed to store channel token")?;
 
-    // Generate adapter Ed25519 keypair
-    let identity = AdapterIdentity::generate(channel);
-    let pub_key = identity.public_key_bytes();
-
-    // Store secret key in vault
-    let secret_key_hex: String = identity
-        .secret_key_bytes()
-        .iter()
-        .map(|b| format!("{b:02x}"))
-        .collect();
-    let sk_secret = VaultSecret::new(secret_key_hex);
-    store
-        .store(
-            &format!("{channel}-adapter-key"),
-            channel,
-            &sk_secret,
-            None,
-            None,
-        )
-        .context("Failed to store adapter key")?;
-
-    // Register in adapter registry
-    let registry = AdapterRegistry::open(&cfg.adapters_db_path())
-        .context("Failed to open adapter registry")?;
-
-    // Unregister first if already exists (re-registration)
-    let _ = registry.unregister(channel);
-
-    registry
-        .register(channel, &pub_key, channel)
-        .context("Failed to register adapter")?;
-
+    register_adapter_identity(channel, cfg, &store)?;
     println!("  {channel}: token encrypted, adapter keypair generated, registered.");
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -- Validators ---------------------------------------------------
+
+    #[test]
+    fn phone_number_id_accepts_15_and_16_digits() {
+        assert!(validate_phone_number_id("123456789012345").is_ok());
+        assert!(validate_phone_number_id("1234567890123456").is_ok());
+    }
+
+    #[test]
+    fn phone_number_id_rejects_wrong_length() {
+        assert!(validate_phone_number_id("12345678901234").is_err());
+        assert!(validate_phone_number_id("12345678901234567").is_err());
+        assert!(validate_phone_number_id("").is_err());
+    }
+
+    #[test]
+    fn phone_number_id_rejects_non_numeric() {
+        assert!(validate_phone_number_id("12345678901234a").is_err());
+        assert!(validate_phone_number_id("12345-67890123456").is_err());
+    }
+
+    #[test]
+    fn app_secret_accepts_32_lowercase_hex() {
+        assert!(validate_app_secret("0123456789abcdef0123456789abcdef").is_ok());
+        assert!(validate_app_secret("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa").is_ok());
+    }
+
+    #[test]
+    fn app_secret_rejects_wrong_length() {
+        assert!(validate_app_secret("0123456789abcdef").is_err());
+        assert!(validate_app_secret("0123456789abcdef0123456789abcdefa").is_err());
+    }
+
+    #[test]
+    fn app_secret_rejects_uppercase_and_non_hex() {
+        assert!(validate_app_secret("0123456789ABCDEF0123456789abcdef").is_err());
+        assert!(validate_app_secret("0123456789abcdef0123456789abcdeZ").is_err());
+    }
+
+    #[test]
+    fn non_empty_rejects_whitespace_only() {
+        assert!(validate_non_empty("").is_err());
+        assert!(validate_non_empty("   ").is_err());
+        assert!(validate_non_empty("\t\n").is_err());
+        assert!(validate_non_empty("x").is_ok());
+    }
+
+    // -- Non-interactive end-to-end -----------------------------------
+
+    fn good_flags() -> AddFlags {
+        AddFlags {
+            token: Some("EAAG_fake_token_value".into()),
+            phone_number_id: Some("123456789012345".into()),
+            verify_token: Some("my_verify_token".into()),
+            app_secret: Some("0123456789abcdef0123456789abcdef".into()),
+        }
+    }
+
+    #[test]
+    fn collect_whatsapp_creds_from_flags_succeeds() {
+        let creds = collect_whatsapp_creds(good_flags()).expect("flags should validate");
+        assert_eq!(creds.token, "EAAG_fake_token_value");
+        assert_eq!(creds.phone_number_id, "123456789012345");
+        assert_eq!(creds.verify_token, "my_verify_token");
+        assert_eq!(creds.app_secret, "0123456789abcdef0123456789abcdef");
+    }
+
+    #[test]
+    fn collect_whatsapp_creds_rejects_bad_phone_number_id_flag() {
+        let mut flags = good_flags();
+        flags.phone_number_id = Some("short".into());
+        let err = collect_whatsapp_creds(flags).expect_err("short id must fail");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("phone number ID"),
+            "error should name the field, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn collect_whatsapp_creds_rejects_bad_app_secret_flag() {
+        let mut flags = good_flags();
+        flags.app_secret = Some("not-hex-at-all".into());
+        let err = collect_whatsapp_creds(flags).expect_err("non-hex secret must fail");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("app secret") || msg.contains("APP_SECRET"),
+            "error should name the field, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn non_interactive_end_to_end_persists_all_four_vault_keys() {
+        // The full non-interactive path: flags in, validation passes,
+        // credentials land in the vault under the exact keys the
+        // adapter reads at startup.
+        use tempfile::TempDir;
+        use wirken_vault::{AgeFileKeychain, CredentialStore};
+
+        let tmp = TempDir::new().unwrap();
+        let vault_path = tmp.path().join("vault.db");
+
+        let keychain = AgeFileKeychain::new(tmp.path().join("keychain"), "test-passphrase".into());
+        let store = CredentialStore::open(&vault_path, &keychain).expect("open credential store");
+
+        let creds = collect_whatsapp_creds(good_flags()).expect("flags validate");
+        store_whatsapp_creds(&store, &creds).expect("store round-trip");
+
+        for key in [
+            "whatsapp-token",
+            "whatsapp-phone-number-id",
+            "whatsapp-verify-token",
+            "whatsapp-app-secret",
+        ] {
+            let (secret, _) = store
+                .retrieve(key)
+                .unwrap_or_else(|e| panic!("missing {key}: {e}"));
+            assert!(!secret.expose().is_empty(), "{key} round-tripped empty");
+        }
+
+        let (token, _) = store.retrieve("whatsapp-token").unwrap();
+        assert_eq!(token.expose(), "EAAG_fake_token_value");
+        let (phone, _) = store.retrieve("whatsapp-phone-number-id").unwrap();
+        assert_eq!(phone.expose(), "123456789012345");
+    }
 }

--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -377,6 +377,46 @@ pub async fn run(port: Option<u16>) -> Result<()> {
         .context(format!("Failed to bind UDS at {}", socket_path.display()))?;
     println!("  Socket: {}", socket_path.display());
 
+    // --- Pre-flight: validate per-adapter vault entries ---
+    //
+    // Each adapter binary will fail at startup if its vault keys are
+    // missing or malformed, but that failure surfaces as an adapter
+    // subprocess crash several hundred milliseconds after `wirken run`
+    // prints "Gateway running," which is a confusing failure mode for
+    // an operator. Check upfront. WhatsApp is the first channel with
+    // multiple required fields; extend this list as other channels
+    // grow mandatory secondary credentials.
+    {
+        let keychain = probe_keychain(&cfg.data_dir, String::new);
+        let vault = CredentialStore::open(&cfg.vault_db_path(), keychain.as_ref()).ok();
+        for adapter_entry in registry.lock().await.list() {
+            if adapter_entry.channel == "whatsapp"
+                && let Some(ref store) = vault
+            {
+                let required = [
+                    ("whatsapp-token", "access token"),
+                    ("whatsapp-phone-number-id", "phone number ID"),
+                    ("whatsapp-verify-token", "verify token"),
+                    ("whatsapp-app-secret", "app secret"),
+                ];
+                let missing: Vec<&str> = required
+                    .iter()
+                    .filter(|(key, _)| store.retrieve(key).is_err())
+                    .map(|(_, human)| *human)
+                    .collect();
+                if !missing.is_empty() {
+                    anyhow::bail!(
+                        "WhatsApp adapter is registered but the vault is missing: {}. \
+                         Re-run `wirken channel add whatsapp` or set WIRKEN_WHATSAPP_TOKEN, \
+                         WIRKEN_WHATSAPP_PHONE_NUMBER_ID, WIRKEN_WHATSAPP_VERIFY_TOKEN, and \
+                         WIRKEN_WHATSAPP_APP_SECRET before starting.",
+                        missing.join(", ")
+                    );
+                }
+            }
+        }
+    }
+
     // --- Spawn adapter processes ---
     let exe = std::env::current_exe()?;
     let mut adapter_handles = Vec::new();

--- a/crates/cli/src/commands/setup.rs
+++ b/crates/cli/src/commands/setup.rs
@@ -406,6 +406,7 @@ pub async fn run(install_service: bool, org_url: Option<String>) -> Result<()> {
         "Signal",
         "Google Chat",
         "iMessage (BlueBubbles)",
+        "WhatsApp (Cloud API)",
         "Skip for now",
     ];
     let mut selected_channels = Vec::new();
@@ -450,7 +451,11 @@ pub async fn run(install_service: bool, org_url: Option<String>) -> Result<()> {
                 setup_imessage_channel(&cfg, &data).await?;
                 selected_channels.push("imessage");
             }
-            8 => break,
+            8 => {
+                setup_whatsapp_channel(&cfg, &data).await?;
+                selected_channels.push("whatsapp");
+            }
+            9 => break,
             _ => unreachable!(),
         }
 
@@ -802,6 +807,59 @@ async fn setup_imessage_channel(
         .context("Failed to store server password")?;
 
     println!("  imessage: credentials encrypted.");
+    Ok(())
+}
+
+async fn setup_whatsapp_channel(
+    cfg: &wirken_gateway::config::GatewayConfig,
+    data: &std::path::Path,
+) -> Result<()> {
+    println!("  WhatsApp uses the Meta Cloud API. You need four values from your");
+    println!("  Meta app's WhatsApp product page:");
+    println!("    - Access token (permanent system-user token recommended)");
+    println!("    - Phone number ID (15-16 digit numeric)");
+    println!("    - Verify token (any string you chose when registering the webhook)");
+    println!("    - App secret (32-char hex from Meta app settings)");
+    println!("  See https://developers.facebook.com/docs/whatsapp/cloud-api");
+
+    // collect_whatsapp_creds honors WIRKEN_WHATSAPP_* env vars and
+    // otherwise prompts; passing default flags means the wizard is
+    // interactive but an operator can still pre-populate via env.
+    let creds = super::channel::collect_whatsapp_creds(super::channel::AddFlags::default())
+        .context("Failed to collect WhatsApp credentials")?;
+
+    let keychain = wirken_vault::probe_keychain(data, String::new);
+    let store = wirken_vault::CredentialStore::open(&cfg.vault_db_path(), keychain.as_ref())
+        .context("Failed to open credential store")?;
+    super::channel::store_whatsapp_creds(&store, &creds)?;
+
+    // The adapter registry identifies channels by name; register it
+    // the same way every other adapter does so the spawn loop in
+    // `wirken run` picks it up.
+    let identity = wirken_ipc::AdapterIdentity::generate("whatsapp");
+    let pub_key = identity.public_key_bytes();
+    let secret_key_hex: String = identity
+        .secret_key_bytes()
+        .iter()
+        .map(|b| format!("{b:02x}"))
+        .collect();
+    store
+        .store(
+            "whatsapp-adapter-key",
+            "whatsapp",
+            &wirken_vault::VaultSecret::new(secret_key_hex),
+            None,
+            None,
+        )
+        .context("Failed to store WhatsApp adapter key")?;
+    let registry = wirken_gateway::adapter_registry::AdapterRegistry::open(&cfg.adapters_db_path())
+        .context("Failed to open adapter registry")?;
+    let _ = registry.unregister("whatsapp");
+    registry
+        .register("whatsapp", &pub_key, "whatsapp")
+        .context("Failed to register WhatsApp adapter")?;
+
+    println!("  whatsapp: credentials encrypted, adapter keypair generated, registered.");
     Ok(())
 }
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -98,8 +98,23 @@ enum Commands {
 enum ChannelCommands {
     /// Add a new channel
     Add {
-        /// Channel type (telegram, discord, slack)
+        /// Channel type (telegram, discord, slack, whatsapp, etc.)
         channel: String,
+        /// Access/bot token. Reads WIRKEN_<CHANNEL>_TOKEN env var if not supplied.
+        #[arg(long)]
+        token: Option<String>,
+        /// WhatsApp: Cloud API phone number ID (15-16 digit numeric).
+        /// Reads WIRKEN_WHATSAPP_PHONE_NUMBER_ID if not supplied.
+        #[arg(long)]
+        phone_number_id: Option<String>,
+        /// WhatsApp: webhook verify token Meta calls with ?hub.verify_token=.
+        /// Reads WIRKEN_WHATSAPP_VERIFY_TOKEN if not supplied.
+        #[arg(long)]
+        verify_token: Option<String>,
+        /// WhatsApp: Meta app secret (32-char lowercase hex) for HMAC signature.
+        /// Reads WIRKEN_WHATSAPP_APP_SECRET if not supplied.
+        #[arg(long)]
+        app_secret: Option<String>,
     },
     /// List configured channels
     List,
@@ -381,7 +396,24 @@ async fn main() -> Result<()> {
         Commands::Adapter { channel } => commands::adapter::run(&channel).await,
         Commands::McpProxy => commands::mcp_proxy::run().await,
         Commands::Channel(cmd) => match cmd {
-            ChannelCommands::Add { channel } => commands::channel::add(&channel).await,
+            ChannelCommands::Add {
+                channel,
+                token,
+                phone_number_id,
+                verify_token,
+                app_secret,
+            } => {
+                commands::channel::add(
+                    &channel,
+                    commands::channel::AddFlags {
+                        token,
+                        phone_number_id,
+                        verify_token,
+                        app_secret,
+                    },
+                )
+                .await
+            }
             ChannelCommands::List => commands::channel::list().await,
             ChannelCommands::Remove { channel } => commands::channel::remove(&channel).await,
         },

--- a/crates/vault/src/lib.rs
+++ b/crates/vault/src/lib.rs
@@ -6,7 +6,7 @@ mod store;
 
 pub use crypto::{decrypt, encrypt};
 pub use error::VaultError;
-pub use keychain::{Keychain, KeychainKind, probe_keychain};
+pub use keychain::{AgeFileKeychain, Keychain, KeychainKind, probe_keychain};
 pub use secret::VaultSecret;
 pub use store::{CredentialMetadata, CredentialStore};
 


### PR DESCRIPTION
Closes #28.

## Summary
- ``wirken setup`` grows a WhatsApp menu entry that collects all four required fields (access token, phone number ID, verify token, app secret) and writes them to the vault under the exact keys the adapter reads at startup.
- ``wirken channel add whatsapp`` collects the same four fields, with CLI flags (``--token``, ``--phone-number-id``, ``--verify-token``, ``--app-secret``) and ``WIRKEN_WHATSAPP_*`` env-var fallbacks for non-interactive use. Precedence: flag → env → prompt.
- Validators: phone number ID must be 15–16 digit numeric; app secret must be 32-char lowercase hex; access token and verify token must be non-empty. Bad flag / env var fails as loudly as a bad prompt entry.
- ``wirken run`` does a pre-flight vault check for every registered WhatsApp adapter and aborts with a clear message naming every missing field — no more silent adapter crashes 500ms after "Gateway running" prints.
- ``wirken_vault`` re-exports ``AgeFileKeychain`` so the integration test can exercise the full non-interactive persist-and-retrieve round trip.

## Test plan
- [x] 11 new tests in ``channel.rs``: validator happy/sad paths for all three rules, non-interactive flag collection happy path, named-field error messages for each bad input, and the end-to-end test that threads flags through ``collect_whatsapp_creds`` → ``store_whatsapp_creds`` and asserts the four vault keys round-trip.
- [x] ``cargo fmt --check``
- [x] ``cargo clippy --workspace --all-targets -- -D warnings``
- [x] Full workspace test suite green