### PR TITLE
credentials add: support --stdin and --value-file for non-interactive use

### DIFF
--- a/crates/cli/src/commands/credential.rs
+++ b/crates/cli/src/commands/credential.rs
@@ -63,10 +63,39 @@ pub async fn list() -> Result<()> {
     Ok(())
 }
 
-pub async fn add(name: &str, channel: Option<&str>) -> Result<()> {
+/// Where the credential value comes from. The CLI layer converts
+/// `--stdin` / `--value-file` flags into this enum so the command
+/// body doesn't need to know about clap.
+pub enum ValueSource {
+    /// Prompt on stderr. Default when neither flag is given.
+    Prompt,
+    /// Read the value from stdin, stripping a single trailing
+    /// newline. Matches `echo "$SECRET" | wirken credentials add`.
+    Stdin,
+    /// Read the value from a file, stripping a single trailing
+    /// newline. Meant for ops flows that drop a secret file via
+    /// configuration management.
+    File(std::path::PathBuf),
+}
+
+impl ValueSource {
+    /// Build from the two mutually exclusive clap flags. Both false
+    /// and file=None means interactive prompt; clap's
+    /// `conflicts_with` makes the "both true" case a parse error,
+    /// so this method does not need to defend against it.
+    pub fn from_flags(stdin: bool, file: Option<std::path::PathBuf>) -> Self {
+        match (stdin, file) {
+            (true, _) => Self::Stdin,
+            (_, Some(p)) => Self::File(p),
+            _ => Self::Prompt,
+        }
+    }
+}
+
+pub async fn add(name: &str, channel: Option<&str>, source: ValueSource) -> Result<()> {
     let cfg = config();
 
-    let value = super::read_secret(&format!("  Value for '{name}': "))?;
+    let value = read_credential_value(name, source)?;
     if value.is_empty() {
         anyhow::bail!("empty value");
     }
@@ -88,6 +117,43 @@ pub async fn add(name: &str, channel: Option<&str>) -> Result<()> {
 
     println!("  Credential '{name}' stored.");
     Ok(())
+}
+
+/// Obtain the raw credential value from the requested source. Public
+/// in-crate so the non-interactive paths can be unit-tested without
+/// mocking clap or a TTY.
+pub(crate) fn read_credential_value(name: &str, source: ValueSource) -> Result<String> {
+    match source {
+        ValueSource::Prompt => super::read_secret(&format!("  Value for '{name}': ")),
+        ValueSource::Stdin => {
+            use std::io::Read;
+            let mut buf = String::new();
+            std::io::stdin()
+                .read_to_string(&mut buf)
+                .context("Failed to read value from stdin")?;
+            Ok(strip_one_trailing_newline(buf))
+        }
+        ValueSource::File(path) => {
+            let raw = std::fs::read_to_string(&path)
+                .with_context(|| format!("Failed to read value file {}", path.display()))?;
+            Ok(strip_one_trailing_newline(raw))
+        }
+    }
+}
+
+/// Trim exactly one trailing `\n` (and an optional preceding `\r`).
+/// `echo` and most text-file writers add a single newline; stripping
+/// it matches operator intent while preserving secrets that
+/// intentionally contain whitespace or multiline content. `trim_end`
+/// would discard too much.
+fn strip_one_trailing_newline(mut s: String) -> String {
+    if s.ends_with('\n') {
+        s.pop();
+        if s.ends_with('\r') {
+            s.pop();
+        }
+    }
+    s
 }
 
 pub async fn rotate(name: &str) -> Result<()> {
@@ -114,4 +180,97 @@ pub async fn rotate(name: &str) -> Result<()> {
 
     println!("  Credential '{name}' rotated. Next rotation due in 90 days.");
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+    use wirken_vault::{AgeFileKeychain, CredentialStore};
+
+    #[test]
+    fn value_source_from_flags_default_is_prompt() {
+        assert!(matches!(
+            ValueSource::from_flags(false, None),
+            ValueSource::Prompt
+        ));
+    }
+
+    #[test]
+    fn value_source_from_flags_stdin_wins() {
+        assert!(matches!(
+            ValueSource::from_flags(true, None),
+            ValueSource::Stdin
+        ));
+    }
+
+    #[test]
+    fn value_source_from_flags_file() {
+        let p = std::path::PathBuf::from("/tmp/example");
+        match ValueSource::from_flags(false, Some(p.clone())) {
+            ValueSource::File(path) => assert_eq!(path, p),
+            _ => panic!("expected File"),
+        }
+    }
+
+    #[test]
+    fn strip_trailing_newline_keeps_internal_whitespace() {
+        assert_eq!(strip_one_trailing_newline("secret\n".into()), "secret");
+        assert_eq!(strip_one_trailing_newline("secret\r\n".into()), "secret");
+        assert_eq!(strip_one_trailing_newline("secret".into()), "secret");
+        assert_eq!(strip_one_trailing_newline("a\nb\n".into()), "a\nb");
+        // Only one newline stripped.
+        assert_eq!(strip_one_trailing_newline("s\n\n".into()), "s\n");
+        // Empty stays empty.
+        assert_eq!(strip_one_trailing_newline("".into()), "");
+    }
+
+    #[test]
+    fn read_credential_value_from_file_strips_trailing_newline() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("secret");
+        std::fs::write(&path, "my-mcp-token\n").unwrap();
+        let value =
+            read_credential_value("name", ValueSource::File(path.clone())).expect("read file");
+        assert_eq!(value, "my-mcp-token");
+    }
+
+    #[test]
+    fn read_credential_value_from_file_propagates_missing_file() {
+        let tmp = TempDir::new().unwrap();
+        let missing = tmp.path().join("nope");
+        let err = read_credential_value("name", ValueSource::File(missing.clone()))
+            .expect_err("missing file must fail");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains(&missing.display().to_string()),
+            "error should name the path, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn file_backed_credential_persists_to_vault() {
+        // The full non-interactive path: --value-file hands us a
+        // secret; it lands in the vault under the requested name
+        // and retrieves with the same bytes minus the single
+        // trailing newline.
+        let tmp = TempDir::new().unwrap();
+        let secret_path = tmp.path().join("mcp-token");
+        std::fs::write(&secret_path, "hunter2\n").unwrap();
+
+        let value = read_credential_value("my-mcp-token", ValueSource::File(secret_path))
+            .expect("read value");
+        assert!(!value.is_empty());
+        assert_eq!(value, "hunter2");
+
+        let vault_path = tmp.path().join("vault.db");
+        let keychain = AgeFileKeychain::new(tmp.path().join("keychain"), "test-passphrase".into());
+        let store = CredentialStore::open(&vault_path, &keychain).expect("open vault");
+        store
+            .store("my-mcp-token", "mcp", &VaultSecret::new(value), None, None)
+            .expect("store");
+
+        let (retrieved, _) = store.retrieve("my-mcp-token").expect("retrieve");
+        assert_eq!(retrieved.expose(), "hunter2");
+    }
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -336,6 +336,15 @@ enum CredentialCommands {
         /// Optional channel/category tag for `wirken credentials list`
         #[arg(long)]
         channel: Option<String>,
+        /// Read the value from stdin instead of prompting. A single
+        /// trailing newline is stripped. Useful for piping:
+        /// `echo "$SECRET" | wirken credentials add NAME --stdin`.
+        #[arg(long, conflicts_with = "value_file")]
+        stdin: bool,
+        /// Read the value from a file. A single trailing newline is
+        /// stripped. Mutually exclusive with --stdin.
+        #[arg(long, conflicts_with = "stdin")]
+        value_file: Option<std::path::PathBuf>,
     },
     /// Rotate a credential
     Rotate {
@@ -446,8 +455,18 @@ async fn main() -> Result<()> {
         },
         Commands::Credentials(cmd) => match cmd {
             CredentialCommands::List => commands::credential::list().await,
-            CredentialCommands::Add { name, channel } => {
-                commands::credential::add(&name, channel.as_deref()).await
+            CredentialCommands::Add {
+                name,
+                channel,
+                stdin,
+                value_file,
+            } => {
+                commands::credential::add(
+                    &name,
+                    channel.as_deref(),
+                    commands::credential::ValueSource::from_flags(stdin, value_file),
+                )
+                .await
             }
             CredentialCommands::Rotate { name } => commands::credential::rotate(&name).await,
         },


### PR DESCRIPTION
Closes #29.

The command already existed but only prompted on stderr. This adds two mutually exclusive non-interactive sources so ops flows can feed credentials into the vault without a TTY:

```
echo "$SECRET" | wirken credentials add NAME --stdin
wirken credentials add NAME --value-file /run/secrets/token
```

## Notes
- Both sources strip exactly one trailing newline (and an optional preceding CR), so a plain ``echo`` or a config-management-written file does not round-trip extra whitespace. Secrets that intentionally contain internal whitespace or multiple lines are preserved.
- ``--stdin`` and ``--value-file`` are marked ``conflicts_with`` at the clap layer.
- The write path is unchanged: values go through the same ``CredentialStore`` every adapter reads from.

## Test plan
- [x] 7 new tests: ``ValueSource::from_flags`` truth table, newline-stripping edge cases (trailing CR/LF, empty, multi-newline), file read + strip, missing-file error propagation, and a full non-interactive round-trip (file → read_credential_value → CredentialStore → retrieve).
- [x] Full workspace ``cargo fmt --check``, ``cargo clippy --all-targets -- -D warnings``, ``cargo test``