### PR TITLE
wizard + runtime: persist and resolve channel_overrides (closes #60)

### DIFF
--- a/crates/agent/src/factory.rs
+++ b/crates/agent/src/factory.rs
@@ -97,7 +97,7 @@ pub(crate) fn channel_from_session_id(session_id: &str) -> Option<&str> {
 /// instead name a vault slot (`"provider-api-key"` etc.) and let
 /// startup resolve the slot to the key material before constructing
 /// the `AgentStaticConfig`.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct ChannelOverride {
     pub llm_config: LlmConfig,
     pub api_key: Option<String>,

--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -291,6 +291,18 @@ pub async fn run(port: Option<u16>) -> Result<()> {
 
     // Create default agent for any unbound channels (backward compat with wirken setup)
     if !static_configs.contains_key("default") {
+        // Channel overrides from provider.json (closes #60). Optional;
+        // absent or empty map means "single-provider agent, pre-#60
+        // behavior." Each override entry names a vault slot for its
+        // api_key rather than carrying the key directly, so configs
+        // on disk stay key-free.
+        let channel_overrides = resolve_channel_overrides(
+            &provider_json,
+            &cfg.data_dir,
+            &cfg.vault_db_path(),
+            &vault_passphrase,
+        )?;
+
         let mut llm_config = LlmConfig::from_provider(provider, base_url, model);
         // Bedrock: extract region from provider.json or base_url
         if provider == "bedrock" {
@@ -349,7 +361,7 @@ pub async fn run(port: Option<u16>) -> Result<()> {
                 agent_id: "default".into(),
                 workspace,
                 llm_config,
-                channel_overrides: std::collections::HashMap::new(),
+                channel_overrides,
                 api_key,
                 skills,
                 wasm_skills: Vec::new(),
@@ -1190,4 +1202,235 @@ fn load_siem_config(cfg: &wirken_gateway::config::GatewayConfig) -> Option<SiemC
         service,
         environment,
     })
+}
+
+/// Parse the `channel_overrides` map from provider.json and resolve
+/// each override's declared vault slot into a raw api_key.
+///
+/// Expected shape in provider.json:
+///
+/// ```json
+/// {
+///   "provider": "anthropic",
+///   "model": "claude-sonnet-4-6",
+///   "base_url": "...",
+///   "channel_overrides": {
+///     "signal": {
+///       "provider": "privatemode",
+///       "model": "kimi-k2.5",
+///       "base_url": "http://localhost:8080/v1",
+///       "api_key_name": "privatemode-access-key"
+///     }
+///   }
+/// }
+/// ```
+///
+/// An absent / malformed `channel_overrides` key is treated as
+/// "no overrides" — the function returns an empty map and
+/// `AgentFactory::wake` falls through to the default for every
+/// channel. This matches the back-compat contract from #60.
+///
+/// `api_key_name` is looked up in the vault; the function is
+/// fail-closed on a configured-but-missing slot (an operator who
+/// named a slot that does not exist in the vault gets an early,
+/// clear error instead of a runtime failure on the first inbound
+/// message).
+fn resolve_channel_overrides(
+    provider_json: &serde_json::Value,
+    data_dir: &std::path::Path,
+    vault_db_path: &std::path::Path,
+    vault_passphrase: &str,
+) -> anyhow::Result<std::collections::HashMap<String, wirken_agent::ChannelOverride>> {
+    let raw = match provider_json.get("channel_overrides") {
+        Some(serde_json::Value::Object(m)) if !m.is_empty() => m,
+        _ => return Ok(std::collections::HashMap::new()),
+    };
+
+    // Open the vault once, not per-override. The passphrase is
+    // already collected earlier in run() for the default provider's
+    // key; reuse it verbatim.
+    let passphrase = vault_passphrase.to_string();
+    let keychain = probe_keychain(data_dir, move || passphrase.clone());
+    let store = CredentialStore::open(vault_db_path, keychain.as_ref())
+        .context("Failed to open credential store for channel_overrides")?;
+
+    let mut out = std::collections::HashMap::new();
+    for (channel, cfg) in raw {
+        let provider = cfg
+            .get("provider")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| {
+                anyhow::anyhow!("channel_overrides['{channel}'] missing 'provider' field")
+            })?;
+        let model = cfg.get("model").and_then(|v| v.as_str()).ok_or_else(|| {
+            anyhow::anyhow!("channel_overrides['{channel}'] missing 'model' field")
+        })?;
+        let base_url = cfg.get("base_url").and_then(|v| v.as_str()).unwrap_or("");
+
+        let api_key = match cfg.get("api_key_name").and_then(|v| v.as_str()) {
+            Some(slot) => {
+                let (secret, _) = store.retrieve(slot).with_context(|| {
+                    format!(
+                        "channel_overrides['{channel}'] names vault slot '{slot}', \
+                         but that slot is not present in the vault. \
+                         Run `wirken credentials add {slot}` to add it."
+                    )
+                })?;
+                Some(secret.expose().to_string())
+            }
+            None => None,
+        };
+
+        let llm_config = LlmConfig::from_provider(provider, base_url, model);
+        out.insert(
+            channel.clone(),
+            wirken_agent::ChannelOverride {
+                llm_config,
+                api_key,
+            },
+        );
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod channel_overrides_tests {
+    use super::resolve_channel_overrides;
+    use tempfile::TempDir;
+    use wirken_vault::{AgeFileKeychain, CredentialStore, VaultSecret};
+
+    fn vault_with(slot: &str, value: &str) -> (TempDir, std::path::PathBuf) {
+        let tmp = TempDir::new().unwrap();
+        let vault_path = tmp.path().join("vault.db");
+        let keychain = AgeFileKeychain::new(tmp.path().join("keychain"), "test-passphrase".into());
+        let store = CredentialStore::open(&vault_path, &keychain).unwrap();
+        store
+            .store(slot, "test", &VaultSecret::new(value.into()), None, None)
+            .unwrap();
+        (tmp, vault_path)
+    }
+
+    #[test]
+    fn missing_channel_overrides_returns_empty_map() {
+        let (tmp, vault_path) = vault_with("ignored-slot", "ignored");
+        let provider_json = serde_json::json!({
+            "provider": "anthropic",
+            "model": "claude-sonnet-4-6",
+            "base_url": "https://api.anthropic.com/v1",
+        });
+        let out =
+            resolve_channel_overrides(&provider_json, tmp.path(), &vault_path, "test-passphrase")
+                .unwrap();
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn empty_channel_overrides_object_returns_empty_map() {
+        let (tmp, vault_path) = vault_with("ignored-slot", "ignored");
+        let provider_json = serde_json::json!({
+            "provider": "anthropic",
+            "model": "claude",
+            "channel_overrides": {},
+        });
+        let out =
+            resolve_channel_overrides(&provider_json, tmp.path(), &vault_path, "test-passphrase")
+                .unwrap();
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn resolves_slot_to_key_and_constructs_override() {
+        let (tmp, vault_path) = vault_with("privatemode-access-key", "pm-secret");
+        let provider_json = serde_json::json!({
+            "provider": "anthropic",
+            "model": "claude",
+            "channel_overrides": {
+                "signal": {
+                    "provider": "privatemode",
+                    "model": "kimi-k2.5",
+                    "base_url": "http://localhost:8080/v1",
+                    "api_key_name": "privatemode-access-key"
+                }
+            }
+        });
+        let out =
+            resolve_channel_overrides(&provider_json, tmp.path(), &vault_path, "test-passphrase")
+                .unwrap();
+        let signal = out.get("signal").expect("signal override resolved");
+        assert_eq!(signal.llm_config.model, "kimi-k2.5");
+        assert_eq!(signal.api_key.as_deref(), Some("pm-secret"));
+    }
+
+    #[test]
+    fn missing_slot_in_vault_fails_closed_at_startup() {
+        // Operator named a vault slot that was never created. Refusing
+        // to start here beats a confusing runtime failure on the first
+        // message routed to the channel.
+        let (tmp, vault_path) = vault_with("some-other-slot", "irrelevant");
+        let provider_json = serde_json::json!({
+            "provider": "anthropic",
+            "model": "claude",
+            "channel_overrides": {
+                "signal": {
+                    "provider": "privatemode",
+                    "model": "kimi-k2.5",
+                    "api_key_name": "privatemode-access-key"
+                }
+            }
+        });
+        let err =
+            resolve_channel_overrides(&provider_json, tmp.path(), &vault_path, "test-passphrase")
+                .expect_err("missing slot must fail");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("privatemode-access-key"),
+            "error must name the missing slot, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn override_without_api_key_name_is_allowed() {
+        // Some provider configurations do not require a key (local
+        // Ollama, Privatemode proxy accepting any bearer). An override
+        // that omits api_key_name persists cleanly with api_key = None.
+        let (tmp, vault_path) = vault_with("ignored", "ignored");
+        let provider_json = serde_json::json!({
+            "provider": "anthropic",
+            "model": "claude",
+            "channel_overrides": {
+                "ollama-channel": {
+                    "provider": "ollama",
+                    "model": "llama3",
+                    "base_url": "http://localhost:11434/v1"
+                }
+            }
+        });
+        let out =
+            resolve_channel_overrides(&provider_json, tmp.path(), &vault_path, "test-passphrase")
+                .unwrap();
+        let ov = out.get("ollama-channel").unwrap();
+        assert_eq!(ov.llm_config.model, "llama3");
+        assert_eq!(ov.api_key, None);
+    }
+
+    #[test]
+    fn override_missing_provider_field_errors_with_channel_name() {
+        let (tmp, vault_path) = vault_with("ignored", "ignored");
+        let provider_json = serde_json::json!({
+            "provider": "anthropic",
+            "model": "claude",
+            "channel_overrides": {
+                "signal": { "model": "kimi-k2.5" }
+            }
+        });
+        let err =
+            resolve_channel_overrides(&provider_json, tmp.path(), &vault_path, "test-passphrase")
+                .expect_err("missing provider must fail");
+        let msg = format!("{err:#}");
+        assert!(msg.contains("signal"), "error must name the channel: {msg}");
+        assert!(
+            msg.contains("provider"),
+            "error must name the missing field: {msg}"
+        );
+    }
 }

--- a/crates/cli/src/commands/setup.rs
+++ b/crates/cli/src/commands/setup.rs
@@ -470,6 +470,16 @@ pub async fn run(install_service: bool, org_url: Option<String>) -> Result<()> {
 
     println!();
 
+    // --- Step 2b: Per-channel LLM overrides (closes #60) ---
+    //
+    // Skip silently when no channels were selected; the override
+    // question has no meaning without a channel to attach it to.
+    if !selected_channels.is_empty() {
+        configure_channel_overrides(&cfg, &data, &selected_channels).await?;
+    }
+
+    println!();
+
     // --- Step 3: Service installation ---
 
     let should_install = if install_service {
@@ -860,6 +870,138 @@ async fn setup_whatsapp_channel(
         .context("Failed to register WhatsApp adapter")?;
 
     println!("  whatsapp: credentials encrypted, adapter keypair generated, registered.");
+    Ok(())
+}
+
+/// #60: prompt the operator for optional per-channel LLM provider
+/// overrides and persist them into provider.json under a
+/// `channel_overrides` map. Each override is keyed by channel and
+/// carries provider + model + base_url + the vault slot name to read
+/// the API key from at runtime. The slot is not created here — the
+/// operator must have run `wirken credentials add <slot>` separately,
+/// or use the default-slot `<provider>-api-key` naming. The wizard
+/// validates that the slot exists in the vault before persisting.
+async fn configure_channel_overrides(
+    cfg: &wirken_gateway::config::GatewayConfig,
+    data: &std::path::Path,
+    selected_channels: &[&str],
+) -> Result<()> {
+    let wants_override = Confirm::new()
+        .with_prompt("  Configure a per-channel LLM provider override?")
+        .default(false)
+        .interact()?;
+    if !wants_override {
+        return Ok(());
+    }
+
+    // Load existing provider.json (main provider lands here first
+    // during setup, so the file exists by this point).
+    let provider_path = data.join("provider.json");
+    let mut provider_json: serde_json::Value = std::fs::read_to_string(&provider_path)
+        .ok()
+        .and_then(|s| serde_json::from_str(&s).ok())
+        .unwrap_or_else(|| serde_json::json!({}));
+
+    let mut overrides = provider_json
+        .get("channel_overrides")
+        .and_then(|v| v.as_object())
+        .cloned()
+        .unwrap_or_default();
+
+    // Open the vault once so we can validate slot names the
+    // operator picks for each override.
+    let keychain = wirken_vault::probe_keychain(data, || {
+        dialoguer::Password::new()
+            .with_prompt("  Vault passphrase")
+            .interact()
+            .unwrap_or_default()
+    });
+    let store = wirken_vault::CredentialStore::open(&cfg.vault_db_path(), keychain.as_ref())
+        .context("Failed to open credential store")?;
+
+    loop {
+        let channel_choices: Vec<String> =
+            selected_channels.iter().map(|s| s.to_string()).collect();
+        let ch_idx = Select::new()
+            .with_prompt("  Channel to override")
+            .items(&channel_choices)
+            .default(0)
+            .interact()?;
+        let channel = &channel_choices[ch_idx];
+
+        let providers = &[
+            ("openai", "https://api.openai.com/v1"),
+            ("anthropic", "https://api.anthropic.com/v1"),
+            ("ollama", "http://localhost:11434/v1"),
+            ("privatemode", "http://localhost:8080/v1"),
+            ("tinfoil", "https://api.tinfoil.sh/v1"),
+            ("bedrock", ""),
+            ("gemini", "https://generativelanguage.googleapis.com/v1beta"),
+            ("custom", ""),
+        ];
+        let provider_labels: Vec<&str> = providers.iter().map(|(p, _)| *p).collect();
+        let pidx = Select::new()
+            .with_prompt("  Provider for this channel")
+            .items(&provider_labels)
+            .default(0)
+            .interact()?;
+        let (provider_name, default_base_url) = providers[pidx];
+
+        let model: String = Input::new().with_prompt("  Model").interact_text()?;
+
+        let base_url: String = Input::new()
+            .with_prompt("  Base URL")
+            .default(default_base_url.to_string())
+            .interact_text()?;
+
+        // Per the #60 design: configs reference vault slots by name,
+        // the vault owns key material. The default slot name is
+        // `<provider>-api-key` (matching how `wirken setup` stores
+        // the main provider's key).
+        let default_slot = format!("{provider_name}-api-key");
+        let api_key_name: String = Input::new()
+            .with_prompt("  Vault slot for API key")
+            .default(default_slot.clone())
+            .interact_text()?;
+
+        // Validate early: refuse to persist a pointer at a slot
+        // that does not exist. Avoids a runtime failure on the
+        // first message routed to this channel.
+        if api_key_name.trim().is_empty() {
+            println!("  (no api_key_name provided — override will run without a key)");
+        } else if store.retrieve(&api_key_name).is_err() {
+            println!(
+                "  Warning: vault slot '{api_key_name}' does not exist yet. \
+                 Run `wirken credentials add {api_key_name}` before starting the gateway."
+            );
+        }
+
+        let entry = serde_json::json!({
+            "provider": provider_name,
+            "model": model,
+            "base_url": base_url,
+            "api_key_name": api_key_name,
+        });
+        overrides.insert(channel.clone(), entry);
+        println!(
+            "  Override recorded: {channel} -> {provider_name}/{model} (key slot: {api_key_name})"
+        );
+
+        if !Confirm::new()
+            .with_prompt("  Add another override?")
+            .default(false)
+            .interact()?
+        {
+            break;
+        }
+    }
+
+    provider_json["channel_overrides"] = serde_json::Value::Object(overrides);
+    std::fs::write(
+        &provider_path,
+        serde_json::to_string_pretty(&provider_json)?,
+    )
+    .context("Failed to write provider.json")?;
     Ok(())
 }
 

--- a/docs/reference/privatemode.md
+++ b/docs/reference/privatemode.md
@@ -125,7 +125,6 @@ Grounded in the Privatemode 2.0 launch email (2026-04-22) and the public release
 
 ## Gaps
 
-- Per-channel inference provider selection is not yet implemented.
 - Wirken does not verify Privatemode attestation independently; it trusts the proxy handshake.
 - No integration test against a real proxy in CI. Acceptance in #57 requires a proxy stub or recorded cassettes.
 


### PR DESCRIPTION
Wires per-channel LLM overrides through the user surface and runtime. Closes the remaining #60 acceptance criteria.

## Schema
``provider.json`` grows an optional ``channel_overrides`` map. Each entry names the target provider, model, base URL, and the **vault slot name** for its API key — keys never land in config files.

```json
{
  "provider": "anthropic",
  "model": "claude-sonnet-4-6",
  "base_url": "...",
  "channel_overrides": {
    "signal": {
      "provider": "privatemode",
      "model": "kimi-k2.5",
      "base_url": "http://localhost:8080/v1",
      "api_key_name": "privatemode-access-key"
    }
  }
}
```

## Wizard
``wirken setup`` offers an optional override step after the channel picker:
- Pick channel (from already-configured ones) → provider → model → base URL → vault slot name.
- Slot validated live: warns if the named slot does not yet exist, with the exact ``wirken credentials add SLOT`` command to fix it.
- Loops for multiple overrides. Appends to provider.json.

## Runtime
``wirken run`` reads ``channel_overrides`` at startup, resolves each slot→key from the vault, and constructs ``ChannelOverride { llm_config, api_key }`` records for the factory. **Fail-closed** on a configured-but-missing slot: refuses to start with a clear message rather than crashing the adapter at first message.

## Back-compat
Absent or empty ``channel_overrides`` behaves exactly as pre-#60.

## Test plan
- [x] 6 new tests covering the resolver: empty map, missing map, full round-trip (slot→key→ChannelOverride), missing-slot fail-closed, optional ``api_key_name``, and the named-field error on missing provider.
- [x] Factory, agent-side, and audit integration tests from prior PRs all still pass (181 agent tests).
- [x] ``cargo fmt --check``, ``cargo clippy --all-targets -- -D warnings``, ``cargo test`` — all green.
- [x] Drops the "per-channel inference provider selection is not yet implemented" gap bullet from ``docs/reference/privatemode.md``.