### PR TITLE
permissions: per-skill block (tools, egress, fs, providers)

### DIFF
--- a/crates/agent/src/egress.rs
+++ b/crates/agent/src/egress.rs
@@ -1,0 +1,253 @@
+//! Egress allowlist enforcement at the HTTP transport layer.
+//!
+//! [`EgressClient`] wraps `reqwest::Client` and refuses requests whose host
+//! is not in the agent's effective `permissions.egress.domains` allow-set.
+//! The check is host-based, pre-flight, and runs before any TCP connection
+//! is opened — denied hosts cost zero bytes on the wire.
+//!
+//! ## Layering with future rate limiting
+//!
+//! Per the design discussion under #76 (the rescoped permissions block),
+//! a future per-host rate limiter ("Zirkel's `RateLimitedClient`") sits
+//! *between* this client and `reqwest::Client`, NOT outside it:
+//!
+//! ```text
+//! caller → EgressClient → RateLimitedClient → reqwest::Client
+//! ```
+//!
+//! This ordering matters: a request to a denied host short-circuits at
+//! the egress check and never enters the rate-limit budget. Reversing
+//! the layers would have rate-limit accounting paying for requests
+//! that egress was always going to deny.
+//!
+//! When `RateLimitedClient` lands, this module's `inner` field becomes
+//! the rate-limited transport; the public surface (the `get`/`post`
+//! methods) is unchanged.
+
+use std::collections::BTreeSet;
+use std::sync::{Arc, RwLock};
+
+use reqwest::RequestBuilder;
+use thiserror::Error;
+
+use crate::skill_perms::{AllowSet, EffectiveProfile, EgressMode};
+
+/// What the wrapper enforces. Computed by [`Agent::attach_skills`] from
+/// the effective permission profile and pushed into the client via
+/// [`EgressClient::set_enforcement`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EgressEnforcement {
+    /// Bypass — no checking. Used in `EffectiveProfile::Legacy` and as
+    /// the initial state before any skills are attached.
+    Unrestricted,
+    /// Reject everything. Used when the resolved profile is
+    /// `egress.mode = deny`.
+    DenyAll,
+    /// Allow exactly these hosts. Each entry is matched literally
+    /// (`api.example.com`) or as a leading-wildcard label
+    /// (`*.example.com`). The literal `"*"` global wildcard
+    /// short-circuits to allow-all.
+    Allowlist(BTreeSet<String>),
+    /// Global wildcard — allow any host. Used when an attached skill
+    /// declares `egress.domains: ["*"]` (and merge yields wildcard).
+    AllowAll,
+}
+
+impl EgressEnforcement {
+    pub fn from_profile(p: &EffectiveProfile) -> Self {
+        match p {
+            EffectiveProfile::Legacy => EgressEnforcement::Unrestricted,
+            EffectiveProfile::Resolved(prof) => match prof.egress.mode {
+                EgressMode::Deny => EgressEnforcement::DenyAll,
+                EgressMode::Allowlist => match &prof.egress.domains {
+                    AllowSet::Wildcard => EgressEnforcement::AllowAll,
+                    AllowSet::Set(s) => EgressEnforcement::Allowlist(s.clone()),
+                },
+            },
+        }
+    }
+
+    fn allows(&self, host: &str) -> bool {
+        match self {
+            EgressEnforcement::Unrestricted | EgressEnforcement::AllowAll => true,
+            EgressEnforcement::DenyAll => false,
+            EgressEnforcement::Allowlist(set) => set.iter().any(|pat| host_matches(host, pat)),
+        }
+    }
+}
+
+fn host_matches(host: &str, pattern: &str) -> bool {
+    if pattern == host {
+        return true;
+    }
+    if let Some(suffix) = pattern.strip_prefix("*.")
+        && let Some(idx) = host.find('.')
+    {
+        return &host[idx + 1..] == suffix;
+    }
+    false
+}
+
+/// Pre-flight host check around `reqwest::Client`. The wrapper holds
+/// the enforcement policy in shared state so the agent can update it
+/// after attaching skills without rebuilding the client.
+#[derive(Clone)]
+pub struct EgressClient {
+    inner: reqwest::Client,
+    enforcement: Arc<RwLock<EgressEnforcement>>,
+}
+
+impl EgressClient {
+    pub fn new() -> Self {
+        Self {
+            inner: reqwest::Client::new(),
+            enforcement: Arc::new(RwLock::new(EgressEnforcement::Unrestricted)),
+        }
+    }
+
+    /// Replace the enforcement policy. Called by the agent at
+    /// `attach_skills` time after computing the effective profile.
+    pub fn set_enforcement(&self, e: EgressEnforcement) {
+        if let Ok(mut guard) = self.enforcement.write() {
+            *guard = e;
+        }
+    }
+
+    /// Pre-flight check: extract host from `url`, return `Err` if not
+    /// allowed. Caller must use the returned `RequestBuilder` rather
+    /// than constructing one against the inner client.
+    pub fn get(&self, url: &str) -> Result<RequestBuilder, EgressDenied> {
+        self.check(url)?;
+        Ok(self.inner.get(url))
+    }
+
+    pub fn post(&self, url: &str) -> Result<RequestBuilder, EgressDenied> {
+        self.check(url)?;
+        Ok(self.inner.post(url))
+    }
+
+    fn check(&self, url: &str) -> Result<(), EgressDenied> {
+        let host = url::Url::parse(url)
+            .ok()
+            .and_then(|u| u.host_str().map(|s| s.to_string()))
+            .ok_or_else(|| EgressDenied {
+                host: format!("<unparseable url: {url}>"),
+            })?;
+        let guard = self
+            .enforcement
+            .read()
+            .map_err(|_| EgressDenied { host: host.clone() })?;
+        if guard.allows(&host) {
+            Ok(())
+        } else {
+            Err(EgressDenied { host })
+        }
+    }
+}
+
+impl Default for EgressClient {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
+#[error(
+    "egress denied: host '{host}' is not in the agent's effective skill permissions egress allow-set"
+)]
+pub struct EgressDenied {
+    pub host: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::skill_perms::{AllowSet, EgressMode, EgressPolicy, PermissionProfile};
+
+    fn profile_with_egress(mode: EgressMode, domains: AllowSet) -> PermissionProfile {
+        PermissionProfile {
+            egress: EgressPolicy { mode, domains },
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn legacy_profile_is_unrestricted() {
+        let e = EgressEnforcement::from_profile(&EffectiveProfile::Legacy);
+        assert_eq!(e, EgressEnforcement::Unrestricted);
+        assert!(e.allows("anything.example.com"));
+    }
+
+    #[test]
+    fn resolved_deny_mode_blocks_all() {
+        let p = profile_with_egress(EgressMode::Deny, AllowSet::default());
+        let e = EgressEnforcement::from_profile(&EffectiveProfile::Resolved(p));
+        assert_eq!(e, EgressEnforcement::DenyAll);
+        assert!(!e.allows("foo.com"));
+    }
+
+    #[test]
+    fn resolved_wildcard_allows_anything() {
+        let p = profile_with_egress(EgressMode::Allowlist, AllowSet::Wildcard);
+        let e = EgressEnforcement::from_profile(&EffectiveProfile::Resolved(p));
+        assert_eq!(e, EgressEnforcement::AllowAll);
+        assert!(e.allows("anything.example.com"));
+    }
+
+    #[test]
+    fn resolved_specific_allowlist_matches_literal() {
+        let mut domains = BTreeSet::new();
+        domains.insert("api.example.com".to_string());
+        let p = profile_with_egress(EgressMode::Allowlist, AllowSet::Set(domains));
+        let e = EgressEnforcement::from_profile(&EffectiveProfile::Resolved(p));
+        assert!(e.allows("api.example.com"));
+        assert!(!e.allows("other.example.com"));
+    }
+
+    #[test]
+    fn resolved_specific_allowlist_matches_wildcard_label() {
+        let mut domains = BTreeSet::new();
+        domains.insert("*.example.com".to_string());
+        let p = profile_with_egress(EgressMode::Allowlist, AllowSet::Set(domains));
+        let e = EgressEnforcement::from_profile(&EffectiveProfile::Resolved(p));
+        assert!(e.allows("api.example.com"));
+        assert!(e.allows("foo.example.com"));
+        assert!(!e.allows("example.com"));
+        assert!(!e.allows("api.other.com"));
+    }
+
+    #[test]
+    fn client_get_denies_when_host_not_allowed() {
+        let c = EgressClient::new();
+        c.set_enforcement(EgressEnforcement::Allowlist(BTreeSet::from([
+            "allowed.example.com".to_string(),
+        ])));
+        let err = c.get("https://denied.example.com/foo").unwrap_err();
+        assert_eq!(err.host, "denied.example.com");
+    }
+
+    #[test]
+    fn client_get_allows_when_host_is_in_allowlist() {
+        let c = EgressClient::new();
+        c.set_enforcement(EgressEnforcement::Allowlist(BTreeSet::from([
+            "allowed.example.com".to_string(),
+        ])));
+        assert!(c.get("https://allowed.example.com/foo").is_ok());
+    }
+
+    #[test]
+    fn client_default_state_is_unrestricted() {
+        let c = EgressClient::new();
+        assert!(c.get("https://anywhere.example.com/foo").is_ok());
+    }
+
+    #[test]
+    fn unparseable_url_is_denied() {
+        let c = EgressClient::new();
+        c.set_enforcement(EgressEnforcement::Allowlist(BTreeSet::from([
+            "ok.example.com".to_string(),
+        ])));
+        let err = c.get("not a url").unwrap_err();
+        assert!(err.host.starts_with("<unparseable"));
+    }
+}

--- a/crates/agent/src/error.rs
+++ b/crates/agent/src/error.rs
@@ -87,4 +87,14 @@ pub enum AgentError {
     /// `status: "rounds_exceeded"` in the `SubagentResult` envelope.
     #[error("subagent rounds budget exceeded after {rounds} rounds")]
     RoundsExceeded { rounds: usize },
+
+    /// #76 Phase 2.2: a built-in tool tried to reach a host that the
+    /// agent's effective skill permissions egress allow-set rejects.
+    /// The agent's dispatcher catches this variant, emits a
+    /// `SkillPermissionDenied` audit event, and returns a non-success
+    /// `ToolResult` to the LLM rather than propagating the error up.
+    #[error(
+        "egress denied: host '{host}' is not in the agent's effective skill permissions egress allow-set"
+    )]
+    EgressDenied { host: String },
 }

--- a/crates/agent/src/factory.rs
+++ b/crates/agent/src/factory.rs
@@ -310,7 +310,7 @@ impl AgentFactory {
             cfg.sandbox.clone(),
         )?;
         // Inject the per-agent shared resources.
-        agent.attach_skills(cfg.skills.clone(), cfg.wasm_skills.clone());
+        agent.attach_skills(cfg.skills.clone(), cfg.wasm_skills.clone())?;
         if let Some(perms) = &self.permissions {
             agent.set_permissions(perms.clone());
         }

--- a/crates/agent/src/lib.rs
+++ b/crates/agent/src/lib.rs
@@ -12,6 +12,7 @@ pub mod runtime;
 pub mod sandbox;
 pub(crate) mod sigv4;
 pub mod skill;
+pub mod skill_perms;
 pub mod tool;
 pub mod wasm_sandbox;
 

--- a/crates/agent/src/lib.rs
+++ b/crates/agent/src/lib.rs
@@ -2,6 +2,7 @@ pub mod attestation;
 pub mod bundled_skills;
 pub mod context;
 pub mod conversation;
+pub mod egress;
 pub mod error;
 pub mod factory;
 pub mod identity;

--- a/crates/agent/src/runtime.rs
+++ b/crates/agent/src/runtime.rs
@@ -22,6 +22,16 @@ use wirken_gateway::permissions::{PermissionCheck, PermissionStore, PermissionTi
 /// Maximum tool call rounds per turn to prevent infinite loops.
 const MAX_TOOL_ROUNDS: usize = 20;
 
+/// Which side of the filesystem axis a built-in tool call exercises.
+/// Used by [`Agent::fs_axis_for_call`] and the dispatch gate (#76 Phase
+/// 2.3). `read_file` / `list_files` are read; `write_file` /
+/// `generate_image` are write.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FsAxis {
+    Read,
+    Write,
+}
+
 /// Item 6 slice 1 — hard cap on the depth of `spawn_subagent` calls,
 /// independent of any per-ceiling configuration. Even with badly
 /// configured ceilings the harness refuses to nest deeper than this.
@@ -480,11 +490,54 @@ impl Agent {
                  skill permissions inference.allow set"
             )));
         }
+        // Push the egress enforcement to the tool registry's HTTP client
+        // so built-in tools (web_search, generate_image) honor the agent's
+        // effective egress allow-set (#76 Phase 2.2).
+        self.tools
+            .set_egress_enforcement(crate::egress::EgressEnforcement::from_profile(&effective));
         self.effective_permissions = effective;
         self.skills = skills;
         self.wasm_skills = wasm_skills;
         self.rebuild_system_prompt();
         Ok(())
+    }
+
+    /// Map a tool call to a (filesystem axis, absolutized requested path)
+    /// pair when the tool is a built-in file tool. Returns `None` for tool
+    /// calls that don't touch the filesystem in a path-addressable way
+    /// (`exec`, `web_search`, MCP, Wasm, etc. — `exec` shells out and is
+    /// gated by the tools axis instead). The path is absolutized against
+    /// the agent's workspace so the comparison against the (already
+    /// workspace-expanded) allow-set is apples to apples.
+    fn fs_axis_for_call(&self, name: &str, arguments: &str) -> Option<(FsAxis, PathBuf)> {
+        let axis = match name {
+            "read_file" | "list_files" => FsAxis::Read,
+            "write_file" => FsAxis::Write,
+            // generate_image writes an output file under the workspace.
+            "generate_image" => FsAxis::Write,
+            _ => return None,
+        };
+        let args: serde_json::Value = serde_json::from_str(arguments).ok()?;
+        // `list_files` may omit `path` (defaults to workspace root).
+        // `generate_image` uses `filename` not `path` and writes inside
+        // the workspace; treat the workspace as the requested path so a
+        // skill that allow-listed `<workspace>` can still call it.
+        let raw_path: Option<&str> = match name {
+            "generate_image" => None,
+            _ => args.get("path").and_then(|v| v.as_str()),
+        };
+        let absolute = match raw_path {
+            None => self.tools.workspace().to_path_buf(),
+            Some(p) => {
+                let candidate = PathBuf::from(p);
+                if candidate.is_absolute() {
+                    candidate
+                } else {
+                    self.tools.workspace().join(candidate)
+                }
+            }
+        };
+        Some((axis, absolute))
     }
 
     /// Defence-in-depth gate emitted before each LLM dispatch (#76 Phase
@@ -1484,6 +1537,47 @@ impl Agent {
             });
         }
 
+        // Filesystem gate (#76 Phase 2.3): inner tighter check on top of
+        // the cap-std workspace scope. cap-std refuses absolute paths and
+        // parent traversal at the syscall layer; this gate enforces the
+        // skill-declared `filesystem.{read,write}_paths` allowlist on top
+        // of that. Two-layer defense — cap-std is the outer guarantee,
+        // the permission profile is the inner allowlist. `Legacy`
+        // short-circuits.
+        if let Some((axis, requested)) = self.fs_axis_for_call(name, arguments) {
+            let allowed = match axis {
+                FsAxis::Read => self.effective_permissions.allows_read_path(&requested),
+                FsAxis::Write => self.effective_permissions.allows_write_path(&requested),
+            };
+            if !allowed {
+                let axis_str = match axis {
+                    FsAxis::Read => "filesystem.read",
+                    FsAxis::Write => "filesystem.write",
+                };
+                self.log_event(
+                    TrustLevel::System,
+                    SessionEvent::SkillPermissionDenied {
+                        axis: axis_str.to_string(),
+                        requested: requested.display().to_string(),
+                        agent_id: self.id.clone(),
+                        trigger: self.current_trigger.clone(),
+                    },
+                )?;
+                return Ok(crate::tool::ToolResult {
+                    output: format!(
+                        "{} on path '{}' is not in the agent's effective skill permissions {} allow-set",
+                        match axis {
+                            FsAxis::Read => "read",
+                            FsAxis::Write => "write",
+                        },
+                        requested.display(),
+                        axis_str,
+                    ),
+                    success: false,
+                });
+            }
+        }
+
         // Org-level allow/deny check: applied before the tier
         // permission check so a blocked tool never goes to the
         // approval prompt, never touches the sandbox, and never
@@ -1606,7 +1700,32 @@ impl Agent {
         }
 
         // Otherwise, built-in tools.
-        self.tools.execute(name, arguments).await
+        match self.tools.execute(name, arguments).await {
+            Ok(r) => Ok(r),
+            // #76 Phase 2.2: egress denial bubbles up from the
+            // wrapped HTTP client. Emit the audit event here, then
+            // surface a non-success ToolResult to the LLM rather
+            // than propagating the error out of the agent.
+            Err(AgentError::EgressDenied { host }) => {
+                self.log_event(
+                    TrustLevel::System,
+                    SessionEvent::SkillPermissionDenied {
+                        axis: "egress".to_string(),
+                        requested: host.clone(),
+                        agent_id: self.id.clone(),
+                        trigger: self.current_trigger.clone(),
+                    },
+                )?;
+                Ok(crate::tool::ToolResult {
+                    output: format!(
+                        "egress denied: host '{host}' is not in the agent's \
+                         effective skill permissions egress allow-set"
+                    ),
+                    success: false,
+                })
+            }
+            Err(e) => Err(e),
+        }
     }
 
     /// Execute a single tool call and handle permission denials.

--- a/crates/agent/src/runtime.rs
+++ b/crates/agent/src/runtime.rs
@@ -156,6 +156,13 @@ pub struct Agent {
     /// of the spawn call's `tools` field and the ceiling's
     /// `tool_allowlist`. `None` means no narrowing.
     restrict_tools: Option<BTreeSet<String>>,
+    /// Effective per-skill permissions for this agent, computed at
+    /// `attach_skills` time as the union of every loaded skill's
+    /// declared `permissions:` block. `EffectiveProfile::Legacy` when
+    /// no skills are attached or any attached skill is `Legacy`
+    /// (transitional during the migration window). Enforcement is
+    /// per-agent, not per-skill — see gebruder/wirken#76.
+    effective_permissions: crate::skill_perms::EffectiveProfile,
 }
 
 impl Agent {
@@ -227,6 +234,7 @@ impl Agent {
             subagent_depth: 0,
             auto_deny_above_tier: None,
             restrict_tools: None,
+            effective_permissions: crate::skill_perms::EffectiveProfile::Legacy,
         })
     }
 
@@ -304,6 +312,7 @@ impl Agent {
             subagent_depth: 0,
             auto_deny_above_tier: None,
             restrict_tools: None,
+            effective_permissions: crate::skill_perms::EffectiveProfile::Legacy,
         })
     }
 
@@ -449,10 +458,59 @@ impl Agent {
     /// [`crate::factory::AgentFactory`] to inject per-agent skills
     /// loaded once at startup, then rebuild the system prompt to
     /// include them.
-    pub fn attach_skills(&mut self, skills: Vec<Skill>, wasm_skills: Vec<WasmSkill>) {
+    pub fn attach_skills(
+        &mut self,
+        skills: Vec<Skill>,
+        wasm_skills: Vec<WasmSkill>,
+    ) -> Result<(), AgentError> {
+        let sources: Vec<crate::skill_perms::PermissionsSource> =
+            skills.iter().map(|s| s.permissions.clone()).collect();
+        let effective = crate::skill_perms::effective_for_skills(&sources)
+            .map_err(|e| AgentError::SkillLoad(format!("permissions merge: {e}")))?;
+        // Expand the `<workspace>` token in filesystem paths now that we
+        // know the workspace.
+        let effective = effective.expand_workspace(self.tools.workspace());
+        // Static check (#76 Phase 2.4): the agent's configured inference
+        // provider must satisfy the merged inference allow-set.
+        // `Legacy` short-circuits — admits any provider.
+        let provider = self.llm.config().provider.clone();
+        if !effective.allows_provider(&provider) {
+            return Err(AgentError::SkillLoad(format!(
+                "agent's inference provider '{provider}' is not in the effective \
+                 skill permissions inference.allow set"
+            )));
+        }
+        self.effective_permissions = effective;
         self.skills = skills;
         self.wasm_skills = wasm_skills;
         self.rebuild_system_prompt();
+        Ok(())
+    }
+
+    /// Defence-in-depth gate emitted before each LLM dispatch (#76 Phase
+    /// 2.4). Redundant with the static check in `attach_skills` for the
+    /// current architecture (the agent's provider is fixed at
+    /// construction), but the spec calls for a per-request check and the
+    /// cost is one method call. If the provider is rejected, an audit
+    /// event is emitted and the call short-circuits.
+    fn check_inference_or_deny(&self) -> Result<(), AgentError> {
+        let provider = &self.llm.config().provider;
+        if self.effective_permissions.allows_provider(provider) {
+            return Ok(());
+        }
+        self.log_event(
+            TrustLevel::System,
+            SessionEvent::SkillPermissionDenied {
+                axis: "inference".to_string(),
+                requested: provider.clone(),
+                agent_id: self.id.clone(),
+                trigger: self.current_trigger.clone(),
+            },
+        )?;
+        Err(AgentError::PermissionDenied(format!(
+            "inference provider '{provider}' is not in the agent's effective \
+             skill permissions inference.allow set"
+        )))
     }
 
     /// Attach a signing identity for session attestation. Item 8
@@ -660,6 +718,7 @@ impl Agent {
             tool_calls: None,
         }];
 
+        self.check_inference_or_deny()?;
         match self
             .llm
             .complete(&messages, &[], self.api_key.as_deref())
@@ -1007,6 +1066,7 @@ impl Agent {
                 },
             )?;
 
+            self.check_inference_or_deny()?;
             let started = std::time::Instant::now();
             let response = self
                 .llm
@@ -1221,6 +1281,7 @@ impl Agent {
             // Create a per-round channel for streaming events
             let (round_tx, mut round_rx) = tokio::sync::mpsc::channel(64);
 
+            self.check_inference_or_deny()?;
             // Spawn streaming in background, forward text deltas to caller
             let started = std::time::Instant::now();
             let response = {
@@ -1397,6 +1458,28 @@ impl Agent {
         {
             return Ok(crate::tool::ToolResult {
                 output: format!("tool '{name}' is not in this subagent's allowed tool set"),
+                success: false,
+            });
+        }
+
+        // Per-skill permission profile (#76): the agent's effective
+        // `permissions.tools.allow` filters every tool call. The LLM is
+        // shown only the allowed tools (see `snapshot_tool_defs`), but
+        // we re-check at dispatch in case the LLM ignores the surface.
+        // `EffectiveProfile::Legacy` short-circuits — agents with no
+        // skills attached, or with any Legacy skill, retain full surface.
+        if !self.effective_permissions.allows_tool(name) {
+            self.log_event(
+                TrustLevel::System,
+                SessionEvent::SkillPermissionDenied {
+                    axis: "tools".to_string(),
+                    requested: name.to_string(),
+                    agent_id: self.id.clone(),
+                    trigger: self.current_trigger.clone(),
+                },
+            )?;
+            return Ok(crate::tool::ToolResult {
+                output: format!("tool '{name}' is not in the agent's effective skill permissions"),
                 success: false,
             });
         }
@@ -2263,6 +2346,9 @@ impl Agent {
         } else {
             Vec::new()
         };
+        // Per-skill permission profile (#76): only surface tools the
+        // effective profile allows. `Legacy` admits everything.
+        defs.retain(|d| self.effective_permissions.allows_tool(&d.name));
         defs.sort_by(|a, b| a.name.cmp(&b.name));
         defs
     }

--- a/crates/agent/src/skill.rs
+++ b/crates/agent/src/skill.rs
@@ -2,6 +2,7 @@ use serde::Deserialize;
 use std::path::{Path, PathBuf};
 
 use crate::error::AgentError;
+use crate::skill_perms::{PermissionsBlock, PermissionsSource, resolve_block};
 
 /// A loaded markdown skill.
 #[derive(Debug, Clone)]
@@ -12,6 +13,10 @@ pub struct Skill {
     pub body: String,
     pub path: PathBuf,
     pub available: bool,
+    /// Per-skill permissions declared in the frontmatter `permissions:` block,
+    /// or `Legacy` if the block is absent. The agent merges declared profiles
+    /// from all loaded skills into one effective per-agent profile at init.
+    pub permissions: PermissionsSource,
 }
 
 /// YAML frontmatter parsed from SKILL.md files.
@@ -22,6 +27,8 @@ struct SkillFrontmatter {
     description: Option<String>,
     #[serde(default)]
     metadata: Option<serde_json::Value>,
+    #[serde(default)]
+    permissions: Option<PermissionsBlock>,
 }
 
 /// Loads SKILL.md files from a directory.
@@ -81,6 +88,26 @@ impl SkillLoader {
             .unwrap_or("unknown")
             .to_string();
 
+        let skill_root = path.parent().unwrap_or_else(|| Path::new("."));
+        let home = std::env::var("HOME").ok().map(PathBuf::from);
+        let permissions = match frontmatter.permissions {
+            Some(block) => {
+                let profile = resolve_block(block, skill_root, home.as_deref()).map_err(|e| {
+                    AgentError::SkillLoad(format!("permissions block in {}: {e}", path.display()))
+                })?;
+                PermissionsSource::Explicit(profile)
+            }
+            None => {
+                tracing::warn!(
+                    "skill {} has no `permissions:` block; treating as legacy. \
+                     This will become a hard load failure in a future release. \
+                     See gebruder/wirken#76.",
+                    path.display()
+                );
+                PermissionsSource::Legacy
+            }
+        };
+
         Ok(Skill {
             name: frontmatter.name.unwrap_or(dir_name),
             description: frontmatter.description.unwrap_or_default(),
@@ -88,6 +115,7 @@ impl SkillLoader {
             body,
             path: path.to_path_buf(),
             available,
+            permissions,
         })
     }
 
@@ -128,6 +156,7 @@ fn parse_frontmatter(content: &str) -> Result<(SkillFrontmatter, String), AgentE
                 name: None,
                 description: None,
                 metadata: None,
+                permissions: None,
             },
             content.to_string(),
         ));

--- a/crates/agent/src/skill_perms.rs
+++ b/crates/agent/src/skill_perms.rs
@@ -324,10 +324,11 @@ fn resolve_paths(
             }
             return Err(PermissionsError::FilesystemWildcard);
         }
-        if entry == WORKSPACE_TOKEN {
-            // Kept as-is; the agent expands the token at `attach_skills`
-            // time when the workspace path is known.
-            out.insert(PathBuf::from(WORKSPACE_TOKEN));
+        // `<workspace>` and `<workspace>/<rel>` are kept as-is; the agent
+        // expands the leading token at `attach_skills` time when the
+        // workspace path is known.
+        if entry == WORKSPACE_TOKEN || entry.starts_with(&format!("{WORKSPACE_TOKEN}/")) {
+            out.insert(PathBuf::from(entry));
             continue;
         }
         let expanded = expand_home(entry, home);
@@ -455,7 +456,12 @@ fn expand_workspace_set(set: BTreeSet<PathBuf>, workspace: &Path) -> BTreeSet<Pa
     set.into_iter()
         .map(|p| {
             if p == Path::new(WORKSPACE_TOKEN) {
-                workspace.to_path_buf()
+                return workspace.to_path_buf();
+            }
+            // Strip the leading `<workspace>` component when present and
+            // re-anchor on the actual workspace path.
+            if let Ok(rest) = p.strip_prefix(WORKSPACE_TOKEN) {
+                workspace.join(rest)
             } else {
                 p
             }
@@ -906,6 +912,47 @@ inference:
         assert!(eff.allows_write_path(Path::new("/home/x/work/sub/dir/file.txt")));
         assert!(!eff.allows_write_path(Path::new("/home/x/other/")));
         assert!(!eff.allows_write_path(Path::new("/home/x/")));
+    }
+
+    #[test]
+    fn workspace_token_paths_round_trip_through_parse() {
+        let yaml = r#"
+filesystem:
+  read_paths: ["<workspace>"]
+  write_paths: ["<workspace>/.lyrik", "<workspace>/notes"]
+"#;
+        let p = parse_block(yaml, &root(), home()).unwrap();
+        assert!(
+            p.filesystem
+                .read_paths
+                .contains(&PathBuf::from("<workspace>"))
+        );
+        assert!(
+            p.filesystem
+                .write_paths
+                .contains(&PathBuf::from("<workspace>/.lyrik"))
+        );
+        assert!(
+            p.filesystem
+                .write_paths
+                .contains(&PathBuf::from("<workspace>/notes"))
+        );
+    }
+
+    #[test]
+    fn workspace_token_expands_to_real_workspace() {
+        let yaml = r#"
+filesystem:
+  read_paths: ["<workspace>"]
+  write_paths: ["<workspace>/.lyrik"]
+"#;
+        let p = parse_block(yaml, &root(), home()).unwrap();
+        let workspace = Path::new("/home/x/code/repo");
+        let eff = EffectiveProfile::Resolved(p).expand_workspace(workspace);
+        assert!(eff.allows_read_path(Path::new("/home/x/code/repo/foo.rs")));
+        assert!(eff.allows_write_path(Path::new("/home/x/code/repo/.lyrik/rubric.md")));
+        assert!(!eff.allows_write_path(Path::new("/home/x/code/repo/elsewhere/foo")));
+        assert!(!eff.allows_read_path(Path::new("/some/other/path")));
     }
 
     #[test]

--- a/crates/agent/src/skill_perms.rs
+++ b/crates/agent/src/skill_perms.rs
@@ -1,0 +1,689 @@
+//! Per-skill permission profile parsed from SKILL.md frontmatter.
+//!
+//! Four axes, default-deny on every one:
+//! - `tools` — which tool names this skill needs the agent to expose.
+//! - `egress` — which network hosts this skill needs the agent to reach.
+//! - `filesystem` — which paths this skill needs the agent to read or write.
+//! - `inference` — which LLM providers this skill needs the agent to call.
+//!
+//! Enforcement is per-agent: the agent computes its effective profile at init
+//! as the union of all loaded skills' declared profiles. A skill with no
+//! `permissions:` block is treated as `Legacy` — the loader warns and the
+//! agent gets the full surface for that skill during the migration window.
+//!
+//! Wildcard `"*"` is supported on `tools`, `egress.domains`, and
+//! `inference.allow`. Filesystem wildcards are rejected: cap-std workspace
+//! is the outer bound and `"*"` for paths is meaningless inside it.
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+
+use serde::Deserialize;
+use thiserror::Error;
+
+const WILDCARD: &str = "*";
+
+/// Resolved profile after parse + validation.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct PermissionProfile {
+    pub tools: ToolPolicy,
+    pub egress: EgressPolicy,
+    pub filesystem: FilesystemPolicy,
+    pub inference: InferencePolicy,
+}
+
+/// What the loader produces per-skill.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PermissionsSource {
+    /// The skill declared a `permissions:` block (possibly empty). Empty
+    /// resolves to a fully default-deny profile.
+    Explicit(PermissionProfile),
+    /// The skill omitted the `permissions:` block. Transitional: agent gets
+    /// the full surface and the loader logs a deprecation warning. After the
+    /// migration window flips, missing block becomes a hard load failure.
+    Legacy,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AllowSet {
+    Wildcard,
+    Set(BTreeSet<String>),
+}
+
+impl Default for AllowSet {
+    fn default() -> Self {
+        AllowSet::Set(BTreeSet::new())
+    }
+}
+
+impl AllowSet {
+    pub fn allows(&self, name: &str) -> bool {
+        match self {
+            AllowSet::Wildcard => true,
+            AllowSet::Set(set) => set.contains(name),
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        matches!(self, AllowSet::Set(s) if s.is_empty())
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ToolPolicy {
+    pub allow: AllowSet,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EgressPolicy {
+    pub mode: EgressMode,
+    pub domains: AllowSet,
+}
+
+impl Default for EgressPolicy {
+    fn default() -> Self {
+        Self {
+            mode: EgressMode::Deny,
+            domains: AllowSet::default(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EgressMode {
+    Allowlist,
+    Deny,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct FilesystemPolicy {
+    pub write_paths: BTreeSet<PathBuf>,
+    pub read_paths: BTreeSet<PathBuf>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct InferencePolicy {
+    pub allow: AllowSet,
+    pub default: Option<String>,
+}
+
+/// On-disk YAML shape under the `permissions:` key.
+#[derive(Debug, Clone, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
+pub struct PermissionsBlock {
+    #[serde(default)]
+    pub tools: Option<ToolsRaw>,
+    #[serde(default)]
+    pub egress: Option<EgressRaw>,
+    #[serde(default)]
+    pub filesystem: Option<FilesystemRaw>,
+    #[serde(default)]
+    pub inference: Option<InferenceRaw>,
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
+pub struct ToolsRaw {
+    #[serde(default)]
+    pub allow: Vec<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct EgressRaw {
+    #[serde(default = "default_egress_mode")]
+    pub mode: String,
+    #[serde(default)]
+    pub domains: Vec<String>,
+}
+
+fn default_egress_mode() -> String {
+    "deny".to_string()
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
+pub struct FilesystemRaw {
+    #[serde(default)]
+    pub write_paths: Vec<String>,
+    #[serde(default)]
+    pub read_paths: Vec<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
+pub struct InferenceRaw {
+    #[serde(default)]
+    pub allow: Vec<String>,
+    #[serde(default)]
+    pub default: Option<String>,
+}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum PermissionsError {
+    #[error("invalid YAML in permissions block: {0}")]
+    Yaml(String),
+    #[error("invalid egress mode '{0}' (expected 'allowlist' or 'deny')")]
+    InvalidEgressMode(String),
+    #[error("wildcard '*' not allowed for filesystem paths")]
+    FilesystemWildcard,
+    #[error("permissions.{axis}.allow mixes wildcard '*' with specific entries")]
+    MixedWildcard { axis: String },
+    #[error("filesystem.write_paths entry '{0}' is inside skill bundle root")]
+    WritePathInsideSkillRoot(PathBuf),
+    #[error("filesystem path '{0}' must be absolute (use '~/' for home-relative)")]
+    NonAbsolutePath(PathBuf),
+    #[error("invalid host pattern: '{0}'")]
+    InvalidHost(String),
+    #[error("inference.default '{0}' is not in inference.allow")]
+    DefaultNotInAllow(String),
+    #[error("egress.mode is 'deny' but domains is non-empty")]
+    DenyWithDomains,
+}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum MergeError {
+    #[error("skills declare conflicting inference.default values: {found:?}")]
+    DefaultConflict { found: BTreeSet<String> },
+}
+
+/// Parse + validate a `permissions:` block from a YAML string.
+///
+/// `skill_root` is the directory containing SKILL.md; used to reject
+/// `write_paths` entries inside the bundle. `home` is the user's home for
+/// `~/` expansion; `None` keeps `~`-prefixed paths literal (and they will
+/// fail the absolute-path check downstream).
+pub fn parse_block(
+    yaml: &str,
+    skill_root: &Path,
+    home: Option<&Path>,
+) -> Result<PermissionProfile, PermissionsError> {
+    let block: PermissionsBlock =
+        serde_yaml::from_str(yaml).map_err(|e| PermissionsError::Yaml(e.to_string()))?;
+    resolve_block(block, skill_root, home)
+}
+
+/// Validate and convert a deserialized block to a resolved profile.
+pub fn resolve_block(
+    block: PermissionsBlock,
+    skill_root: &Path,
+    home: Option<&Path>,
+) -> Result<PermissionProfile, PermissionsError> {
+    let tools = match block.tools {
+        Some(t) => ToolPolicy {
+            allow: resolve_allow(&t.allow, "tools")?,
+        },
+        None => ToolPolicy::default(),
+    };
+
+    let egress = match block.egress {
+        Some(e) => {
+            let mode = match e.mode.as_str() {
+                "allowlist" => EgressMode::Allowlist,
+                "deny" => EgressMode::Deny,
+                other => return Err(PermissionsError::InvalidEgressMode(other.to_string())),
+            };
+            let domains = resolve_allow(&e.domains, "egress")?;
+            if matches!(mode, EgressMode::Deny) && !domains.is_empty() {
+                return Err(PermissionsError::DenyWithDomains);
+            }
+            for d in iter_set(&domains) {
+                validate_host(d)?;
+            }
+            EgressPolicy { mode, domains }
+        }
+        None => EgressPolicy::default(),
+    };
+
+    let filesystem = match block.filesystem {
+        Some(f) => {
+            let write_paths = resolve_paths(&f.write_paths, home, /*allow_wildcard=*/ false)?;
+            let read_paths = resolve_paths(&f.read_paths, home, /*allow_wildcard=*/ false)?;
+            let canonical_root = canonicalize_or(skill_root);
+            for p in &write_paths {
+                if p.starts_with(&canonical_root) {
+                    return Err(PermissionsError::WritePathInsideSkillRoot(p.clone()));
+                }
+            }
+            FilesystemPolicy {
+                write_paths,
+                read_paths,
+            }
+        }
+        None => FilesystemPolicy::default(),
+    };
+
+    let inference = match block.inference {
+        Some(i) => {
+            let allow = resolve_allow(&i.allow, "inference")?;
+            if let Some(ref d) = i.default {
+                if !allow.allows(d) {
+                    return Err(PermissionsError::DefaultNotInAllow(d.clone()));
+                }
+            }
+            InferencePolicy {
+                allow,
+                default: i.default,
+            }
+        }
+        None => InferencePolicy::default(),
+    };
+
+    Ok(PermissionProfile {
+        tools,
+        egress,
+        filesystem,
+        inference,
+    })
+}
+
+fn resolve_allow(items: &[String], axis: &str) -> Result<AllowSet, PermissionsError> {
+    let has_wildcard = items.iter().any(|s| s == WILDCARD);
+    let specifics: BTreeSet<String> = items
+        .iter()
+        .filter(|s| s.as_str() != WILDCARD)
+        .cloned()
+        .collect();
+
+    if has_wildcard && !specifics.is_empty() {
+        return Err(PermissionsError::MixedWildcard {
+            axis: axis.to_string(),
+        });
+    }
+
+    if has_wildcard {
+        Ok(AllowSet::Wildcard)
+    } else {
+        Ok(AllowSet::Set(specifics))
+    }
+}
+
+fn iter_set(allow: &AllowSet) -> Box<dyn Iterator<Item = &String> + '_> {
+    match allow {
+        AllowSet::Wildcard => Box::new(std::iter::empty()),
+        AllowSet::Set(s) => Box::new(s.iter()),
+    }
+}
+
+fn resolve_paths(
+    raw: &[String],
+    home: Option<&Path>,
+    allow_wildcard: bool,
+) -> Result<BTreeSet<PathBuf>, PermissionsError> {
+    let mut out = BTreeSet::new();
+    for entry in raw {
+        if entry == WILDCARD {
+            if allow_wildcard {
+                continue;
+            }
+            return Err(PermissionsError::FilesystemWildcard);
+        }
+        let expanded = expand_home(entry, home);
+        if !expanded.is_absolute() {
+            return Err(PermissionsError::NonAbsolutePath(expanded));
+        }
+        out.insert(expanded);
+    }
+    Ok(out)
+}
+
+fn expand_home(entry: &str, home: Option<&Path>) -> PathBuf {
+    if let Some(rest) = entry.strip_prefix("~/")
+        && let Some(home) = home
+    {
+        return home.join(rest);
+    }
+    if entry == "~"
+        && let Some(home) = home
+    {
+        return home.to_path_buf();
+    }
+    PathBuf::from(entry)
+}
+
+fn canonicalize_or(p: &Path) -> PathBuf {
+    p.canonicalize().unwrap_or_else(|_| p.to_path_buf())
+}
+
+fn validate_host(s: &str) -> Result<(), PermissionsError> {
+    if s.is_empty() {
+        return Err(PermissionsError::InvalidHost(s.to_string()));
+    }
+    // Reject schemes, paths, and credentials. Hosts are bare authorities:
+    // `example.com`, `api.example.com`, `*.example.com`.
+    if s.contains("://") || s.contains('/') || s.contains('@') || s.contains(':') || s.contains(' ')
+    {
+        return Err(PermissionsError::InvalidHost(s.to_string()));
+    }
+    // Each label is letters/digits/hyphen/dot; leading wildcard label allowed.
+    let allowed = |c: char| c.is_ascii_alphanumeric() || c == '-' || c == '.' || c == '*';
+    if !s.chars().all(allowed) {
+        return Err(PermissionsError::InvalidHost(s.to_string()));
+    }
+    Ok(())
+}
+
+/// Union-merge a slice of declared per-skill profiles into one effective
+/// agent profile. Set-typed fields are unioned; wildcards win. The single
+/// scalar field (`inference.default`) must be unanimous among the skills
+/// that declare it; conflict is an attach-time error.
+pub fn merge(profiles: &[PermissionProfile]) -> Result<PermissionProfile, MergeError> {
+    let mut tools = AllowSet::Set(BTreeSet::new());
+    let mut egress_mode = EgressMode::Deny;
+    let mut egress_domains = AllowSet::Set(BTreeSet::new());
+    let mut write_paths = BTreeSet::new();
+    let mut read_paths = BTreeSet::new();
+    let mut inference_allow = AllowSet::Set(BTreeSet::new());
+    let mut inference_defaults = BTreeSet::new();
+
+    for p in profiles {
+        tools = union_allow(tools, p.tools.allow.clone());
+        if matches!(p.egress.mode, EgressMode::Allowlist) {
+            egress_mode = EgressMode::Allowlist;
+        }
+        egress_domains = union_allow(egress_domains, p.egress.domains.clone());
+        write_paths.extend(p.filesystem.write_paths.iter().cloned());
+        read_paths.extend(p.filesystem.read_paths.iter().cloned());
+        inference_allow = union_allow(inference_allow, p.inference.allow.clone());
+        if let Some(ref d) = p.inference.default {
+            inference_defaults.insert(d.clone());
+        }
+    }
+
+    let inference_default = match inference_defaults.len() {
+        0 => None,
+        1 => inference_defaults.into_iter().next(),
+        _ => {
+            return Err(MergeError::DefaultConflict {
+                found: inference_defaults,
+            });
+        }
+    };
+
+    Ok(PermissionProfile {
+        tools: ToolPolicy { allow: tools },
+        egress: EgressPolicy {
+            mode: egress_mode,
+            domains: egress_domains,
+        },
+        filesystem: FilesystemPolicy {
+            write_paths,
+            read_paths,
+        },
+        inference: InferencePolicy {
+            allow: inference_allow,
+            default: inference_default,
+        },
+    })
+}
+
+fn union_allow(a: AllowSet, b: AllowSet) -> AllowSet {
+    match (a, b) {
+        (AllowSet::Wildcard, _) | (_, AllowSet::Wildcard) => AllowSet::Wildcard,
+        (AllowSet::Set(mut x), AllowSet::Set(y)) => {
+            x.extend(y);
+            AllowSet::Set(x)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn root() -> PathBuf {
+        PathBuf::from("/tmp/test-skill-root-does-not-exist")
+    }
+
+    fn home() -> Option<&'static Path> {
+        Some(Path::new("/home/testuser"))
+    }
+
+    #[test]
+    fn empty_block_is_default_deny() {
+        let p = parse_block("{}", &root(), home()).unwrap();
+        assert_eq!(p, PermissionProfile::default());
+        assert!(matches!(p.tools.allow, AllowSet::Set(ref s) if s.is_empty()));
+        assert!(matches!(p.egress.mode, EgressMode::Deny));
+        assert!(p.filesystem.write_paths.is_empty());
+        assert!(matches!(p.inference.allow, AllowSet::Set(ref s) if s.is_empty()));
+    }
+
+    #[test]
+    fn full_block_round_trips() {
+        let yaml = r#"
+tools:
+  allow: ["read_file", "write_file"]
+egress:
+  mode: allowlist
+  domains: ["api.example.com", "export.arxiv.org"]
+filesystem:
+  write_paths: ["~/.wirken/zirkel/"]
+  read_paths: ["~/.wirken/zirkel/", "/etc/hosts"]
+inference:
+  allow: ["ollama", "privatemode"]
+  default: "ollama"
+"#;
+        let p = parse_block(yaml, &root(), home()).unwrap();
+        assert!(p.tools.allow.allows("read_file"));
+        assert!(p.tools.allow.allows("write_file"));
+        assert!(!p.tools.allow.allows("exec"));
+        assert_eq!(p.egress.mode, EgressMode::Allowlist);
+        assert!(p.egress.domains.allows("api.example.com"));
+        assert!(
+            p.filesystem
+                .write_paths
+                .contains(&PathBuf::from("/home/testuser/.wirken/zirkel/"))
+        );
+        assert!(
+            p.filesystem
+                .read_paths
+                .contains(&PathBuf::from("/etc/hosts"))
+        );
+        assert_eq!(p.inference.default.as_deref(), Some("ollama"));
+    }
+
+    #[test]
+    fn wildcard_tools_passes_anything() {
+        let p = parse_block(r#"tools: { allow: ["*"] }"#, &root(), home()).unwrap();
+        assert!(matches!(p.tools.allow, AllowSet::Wildcard));
+        assert!(p.tools.allow.allows("anything_at_all"));
+    }
+
+    #[test]
+    fn mixed_wildcard_rejected() {
+        let yaml = r#"tools: { allow: ["*", "read_file"] }"#;
+        let err = parse_block(yaml, &root(), home()).unwrap_err();
+        assert!(matches!(err, PermissionsError::MixedWildcard { .. }));
+    }
+
+    #[test]
+    fn invalid_egress_mode_rejected() {
+        let yaml = r#"egress: { mode: "foo" }"#;
+        let err = parse_block(yaml, &root(), home()).unwrap_err();
+        assert!(matches!(err, PermissionsError::InvalidEgressMode(_)));
+    }
+
+    #[test]
+    fn deny_with_domains_rejected() {
+        let yaml = r#"egress: { mode: "deny", domains: ["foo.com"] }"#;
+        let err = parse_block(yaml, &root(), home()).unwrap_err();
+        assert!(matches!(err, PermissionsError::DenyWithDomains));
+    }
+
+    #[test]
+    fn filesystem_wildcard_rejected() {
+        let yaml = r#"filesystem: { write_paths: ["*"] }"#;
+        let err = parse_block(yaml, &root(), home()).unwrap_err();
+        assert!(matches!(err, PermissionsError::FilesystemWildcard));
+    }
+
+    #[test]
+    fn relative_filesystem_path_rejected() {
+        let yaml = r#"filesystem: { write_paths: ["relative/path"] }"#;
+        let err = parse_block(yaml, &root(), home()).unwrap_err();
+        assert!(matches!(err, PermissionsError::NonAbsolutePath(_)));
+    }
+
+    #[test]
+    fn invalid_host_rejected() {
+        let yaml = r#"egress: { mode: "allowlist", domains: ["http://foo.com"] }"#;
+        let err = parse_block(yaml, &root(), home()).unwrap_err();
+        assert!(matches!(err, PermissionsError::InvalidHost(_)));
+
+        let yaml = r#"egress: { mode: "allowlist", domains: ["foo.com:8080"] }"#;
+        let err = parse_block(yaml, &root(), home()).unwrap_err();
+        assert!(matches!(err, PermissionsError::InvalidHost(_)));
+    }
+
+    #[test]
+    fn wildcard_host_label_accepted() {
+        let yaml = r#"egress: { mode: "allowlist", domains: ["*.example.com"] }"#;
+        let p = parse_block(yaml, &root(), home()).unwrap();
+        // Wildcard label is treated as a literal entry; matching is
+        // string-equality at this layer. The HTTP wrapper does the
+        // glob matching itself.
+        assert!(p.egress.domains.allows("*.example.com"));
+    }
+
+    #[test]
+    fn write_path_inside_skill_root_rejected() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        let inside = format!(
+            "filesystem: {{ write_paths: [\"{}/inside\"] }}",
+            root.display()
+        );
+        let err = parse_block(&inside, root, None).unwrap_err();
+        assert!(matches!(err, PermissionsError::WritePathInsideSkillRoot(_)));
+    }
+
+    #[test]
+    fn default_not_in_allow_rejected() {
+        let yaml = r#"
+inference:
+  allow: ["ollama"]
+  default: "openai"
+"#;
+        let err = parse_block(yaml, &root(), home()).unwrap_err();
+        assert!(matches!(err, PermissionsError::DefaultNotInAllow(_)));
+    }
+
+    #[test]
+    fn default_with_wildcard_allow_passes() {
+        let yaml = r#"
+inference:
+  allow: ["*"]
+  default: "anything"
+"#;
+        let p = parse_block(yaml, &root(), home()).unwrap();
+        assert_eq!(p.inference.default.as_deref(), Some("anything"));
+    }
+
+    #[test]
+    fn unknown_field_rejected() {
+        let yaml = r#"unknown_axis: { foo: bar }"#;
+        let err = parse_block(yaml, &root(), home()).unwrap_err();
+        assert!(matches!(err, PermissionsError::Yaml(_)));
+    }
+
+    fn profile_with(yaml: &str) -> PermissionProfile {
+        parse_block(yaml, &root(), home()).unwrap()
+    }
+
+    #[test]
+    fn merge_unions_tool_sets() {
+        let a = profile_with(r#"tools: { allow: ["read_file"] }"#);
+        let b = profile_with(r#"tools: { allow: ["write_file"] }"#);
+        let merged = merge(&[a, b]).unwrap();
+        assert!(merged.tools.allow.allows("read_file"));
+        assert!(merged.tools.allow.allows("write_file"));
+    }
+
+    #[test]
+    fn merge_wildcard_wins() {
+        let a = profile_with(r#"tools: { allow: ["read_file"] }"#);
+        let b = profile_with(r#"tools: { allow: ["*"] }"#);
+        let merged = merge(&[a, b]).unwrap();
+        assert!(matches!(merged.tools.allow, AllowSet::Wildcard));
+    }
+
+    #[test]
+    fn merge_egress_mode_allowlist_if_any_skill_declares() {
+        let a = profile_with(r#"egress: { mode: "deny" }"#);
+        let b = profile_with(r#"egress: { mode: "allowlist", domains: ["foo.com"] }"#);
+        let merged = merge(&[a, b]).unwrap();
+        assert_eq!(merged.egress.mode, EgressMode::Allowlist);
+        assert!(merged.egress.domains.allows("foo.com"));
+    }
+
+    #[test]
+    fn merge_filesystem_paths_union() {
+        let a = profile_with(r#"filesystem: { write_paths: ["/a"] }"#);
+        let b = profile_with(r#"filesystem: { write_paths: ["/b"] }"#);
+        let merged = merge(&[a, b]).unwrap();
+        assert!(merged.filesystem.write_paths.contains(&PathBuf::from("/a")));
+        assert!(merged.filesystem.write_paths.contains(&PathBuf::from("/b")));
+    }
+
+    #[test]
+    fn merge_inference_default_unanimous_passes() {
+        let a = profile_with(
+            r#"
+inference:
+  allow: ["ollama"]
+  default: "ollama"
+"#,
+        );
+        let b = profile_with(
+            r#"
+inference:
+  allow: ["ollama"]
+  default: "ollama"
+"#,
+        );
+        let merged = merge(&[a, b]).unwrap();
+        assert_eq!(merged.inference.default.as_deref(), Some("ollama"));
+    }
+
+    #[test]
+    fn merge_inference_default_one_declarer_passes() {
+        let a = profile_with(
+            r#"
+inference:
+  allow: ["ollama"]
+  default: "ollama"
+"#,
+        );
+        let b = profile_with(r#"inference: { allow: ["ollama"] }"#);
+        let merged = merge(&[a, b]).unwrap();
+        assert_eq!(merged.inference.default.as_deref(), Some("ollama"));
+    }
+
+    #[test]
+    fn merge_inference_default_conflict_rejected() {
+        let a = profile_with(
+            r#"
+inference:
+  allow: ["ollama"]
+  default: "ollama"
+"#,
+        );
+        let b = profile_with(
+            r#"
+inference:
+  allow: ["privatemode"]
+  default: "privatemode"
+"#,
+        );
+        let err = merge(&[a, b]).unwrap_err();
+        assert!(matches!(err, MergeError::DefaultConflict { .. }));
+    }
+
+    #[test]
+    fn merge_empty_returns_default_deny() {
+        let merged = merge(&[]).unwrap();
+        assert_eq!(merged, PermissionProfile::default());
+    }
+}

--- a/crates/agent/src/skill_perms.rs
+++ b/crates/agent/src/skill_perms.rs
@@ -22,6 +22,12 @@ use serde::Deserialize;
 use thiserror::Error;
 
 const WILDCARD: &str = "*";
+/// Token in `filesystem.{read,write}_paths` that resolves to the agent's
+/// workspace at attach time. Skills that need general workspace access
+/// (the common case for general-purpose skills) declare
+/// `read_paths: ["<workspace>"]` rather than hard-coding a per-user path
+/// that the skill bundle cannot know.
+pub const WORKSPACE_TOKEN: &str = "<workspace>";
 
 /// Resolved profile after parse + validation.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
@@ -318,6 +324,12 @@ fn resolve_paths(
             }
             return Err(PermissionsError::FilesystemWildcard);
         }
+        if entry == WORKSPACE_TOKEN {
+            // Kept as-is; the agent expands the token at `attach_skills`
+            // time when the workspace path is known.
+            out.insert(PathBuf::from(WORKSPACE_TOKEN));
+            continue;
+        }
         let expanded = expand_home(entry, home);
         if !expanded.is_absolute() {
             return Err(PermissionsError::NonAbsolutePath(expanded));
@@ -361,6 +373,134 @@ fn validate_host(s: &str) -> Result<(), PermissionsError> {
         return Err(PermissionsError::InvalidHost(s.to_string()));
     }
     Ok(())
+}
+
+/// Effective per-agent profile after attaching all skills. The agent's
+/// enforcement points consult this; `Legacy` short-circuits all checks
+/// (full surface) for the migration window.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub enum EffectiveProfile {
+    /// Full surface, no checks. Used when no skills are attached, or when
+    /// any attached skill is `PermissionsSource::Legacy`. Once the migration
+    /// window closes, the loader hard-fails on Legacy and this variant is
+    /// only reachable when zero skills are attached.
+    #[default]
+    Legacy,
+    /// Union of declared profiles. Every enforcement point honors it.
+    Resolved(PermissionProfile),
+}
+
+impl EffectiveProfile {
+    pub fn allows_tool(&self, name: &str) -> bool {
+        match self {
+            EffectiveProfile::Legacy => true,
+            EffectiveProfile::Resolved(p) => p.tools.allow.allows(name),
+        }
+    }
+
+    pub fn allows_host(&self, host: &str) -> bool {
+        match self {
+            EffectiveProfile::Legacy => true,
+            EffectiveProfile::Resolved(p) => match p.egress.mode {
+                EgressMode::Allowlist => host_in_set(host, &p.egress.domains),
+                EgressMode::Deny => false,
+            },
+        }
+    }
+
+    pub fn allows_provider(&self, name: &str) -> bool {
+        match self {
+            EffectiveProfile::Legacy => true,
+            EffectiveProfile::Resolved(p) => p.inference.allow.allows(name),
+        }
+    }
+
+    pub fn allows_read_path(&self, path: &Path) -> bool {
+        match self {
+            EffectiveProfile::Legacy => true,
+            EffectiveProfile::Resolved(p) => path_under_any(path, &p.filesystem.read_paths),
+        }
+    }
+
+    pub fn allows_write_path(&self, path: &Path) -> bool {
+        match self {
+            EffectiveProfile::Legacy => true,
+            EffectiveProfile::Resolved(p) => path_under_any(path, &p.filesystem.write_paths),
+        }
+    }
+
+    pub fn inference_default(&self) -> Option<&str> {
+        match self {
+            EffectiveProfile::Legacy => None,
+            EffectiveProfile::Resolved(p) => p.inference.default.as_deref(),
+        }
+    }
+
+    /// Replace every literal `<workspace>` token in filesystem paths with
+    /// the agent's actual workspace. No-op for `Legacy`.
+    pub fn expand_workspace(self, workspace: &Path) -> Self {
+        match self {
+            EffectiveProfile::Legacy => EffectiveProfile::Legacy,
+            EffectiveProfile::Resolved(mut p) => {
+                p.filesystem.write_paths =
+                    expand_workspace_set(p.filesystem.write_paths, workspace);
+                p.filesystem.read_paths = expand_workspace_set(p.filesystem.read_paths, workspace);
+                EffectiveProfile::Resolved(p)
+            }
+        }
+    }
+}
+
+fn expand_workspace_set(set: BTreeSet<PathBuf>, workspace: &Path) -> BTreeSet<PathBuf> {
+    set.into_iter()
+        .map(|p| {
+            if p == Path::new(WORKSPACE_TOKEN) {
+                workspace.to_path_buf()
+            } else {
+                p
+            }
+        })
+        .collect()
+}
+
+fn host_in_set(host: &str, domains: &AllowSet) -> bool {
+    match domains {
+        AllowSet::Wildcard => true,
+        AllowSet::Set(set) => set.iter().any(|pat| host_matches(host, pat)),
+    }
+}
+
+fn host_matches(host: &str, pattern: &str) -> bool {
+    if pattern == host {
+        return true;
+    }
+    if let Some(suffix) = pattern.strip_prefix("*.") {
+        if let Some(dotidx) = host.find('.') {
+            return &host[dotidx + 1..] == suffix;
+        }
+    }
+    false
+}
+
+fn path_under_any(path: &Path, allowed: &BTreeSet<PathBuf>) -> bool {
+    allowed.iter().any(|root| path.starts_with(root))
+}
+
+/// Compute the effective profile for a set of attached skills. Returns
+/// `Legacy` if any skill is `Legacy` or the slice is empty; otherwise
+/// returns `Resolved(merge(...))`. Propagates `inference.default` conflict.
+pub fn effective_for_skills(sources: &[PermissionsSource]) -> Result<EffectiveProfile, MergeError> {
+    if sources.is_empty() {
+        return Ok(EffectiveProfile::Legacy);
+    }
+    let mut profiles = Vec::with_capacity(sources.len());
+    for s in sources {
+        match s {
+            PermissionsSource::Legacy => return Ok(EffectiveProfile::Legacy),
+            PermissionsSource::Explicit(p) => profiles.push(p.clone()),
+        }
+    }
+    Ok(EffectiveProfile::Resolved(merge(&profiles)?))
 }
 
 /// Union-merge a slice of declared per-skill profiles into one effective
@@ -685,5 +825,110 @@ inference:
     fn merge_empty_returns_default_deny() {
         let merged = merge(&[]).unwrap();
         assert_eq!(merged, PermissionProfile::default());
+    }
+
+    #[test]
+    fn effective_no_skills_is_legacy() {
+        let eff = effective_for_skills(&[]).unwrap();
+        assert_eq!(eff, EffectiveProfile::Legacy);
+    }
+
+    #[test]
+    fn effective_any_legacy_skill_is_legacy() {
+        let p = profile_with(r#"tools: { allow: ["read_file"] }"#);
+        let sources = vec![PermissionsSource::Explicit(p), PermissionsSource::Legacy];
+        let eff = effective_for_skills(&sources).unwrap();
+        assert_eq!(eff, EffectiveProfile::Legacy);
+    }
+
+    #[test]
+    fn effective_all_explicit_resolves_to_merged() {
+        let a = profile_with(r#"tools: { allow: ["read_file"] }"#);
+        let b = profile_with(r#"tools: { allow: ["write_file"] }"#);
+        let sources = vec![
+            PermissionsSource::Explicit(a),
+            PermissionsSource::Explicit(b),
+        ];
+        let eff = effective_for_skills(&sources).unwrap();
+        assert!(eff.allows_tool("read_file"));
+        assert!(eff.allows_tool("write_file"));
+        assert!(!eff.allows_tool("exec"));
+    }
+
+    #[test]
+    fn legacy_allows_everything() {
+        let eff = EffectiveProfile::Legacy;
+        assert!(eff.allows_tool("anything"));
+        assert!(eff.allows_host("anywhere.example.com"));
+        assert!(eff.allows_provider("any_provider"));
+        assert!(eff.allows_read_path(Path::new("/tmp/anything")));
+        assert!(eff.allows_write_path(Path::new("/tmp/anywhere")));
+    }
+
+    #[test]
+    fn resolved_egress_deny_mode_blocks_everything() {
+        let p = profile_with("{}"); // default-deny
+        let eff = EffectiveProfile::Resolved(p);
+        assert!(!eff.allows_host("foo.com"));
+    }
+
+    #[test]
+    fn resolved_egress_allowlist_with_specific_host() {
+        let p = profile_with(r#"egress: { mode: "allowlist", domains: ["api.example.com"] }"#);
+        let eff = EffectiveProfile::Resolved(p);
+        assert!(eff.allows_host("api.example.com"));
+        assert!(!eff.allows_host("other.example.com"));
+    }
+
+    #[test]
+    fn resolved_egress_wildcard_label_matches_subdomains() {
+        let p = profile_with(r#"egress: { mode: "allowlist", domains: ["*.example.com"] }"#);
+        let eff = EffectiveProfile::Resolved(p);
+        assert!(eff.allows_host("api.example.com"));
+        assert!(eff.allows_host("foo.example.com"));
+        assert!(!eff.allows_host("example.com"));
+        assert!(!eff.allows_host("api.other.com"));
+    }
+
+    #[test]
+    fn resolved_egress_global_wildcard_matches_anything() {
+        let p = profile_with(r#"egress: { mode: "allowlist", domains: ["*"] }"#);
+        let eff = EffectiveProfile::Resolved(p);
+        assert!(eff.allows_host("anywhere.example.com"));
+    }
+
+    #[test]
+    fn resolved_filesystem_paths_match_under_root() {
+        let p = profile_with(r#"filesystem: { write_paths: ["/home/x/work/"] }"#);
+        let eff = EffectiveProfile::Resolved(p);
+        assert!(eff.allows_write_path(Path::new("/home/x/work/")));
+        assert!(eff.allows_write_path(Path::new("/home/x/work/file.txt")));
+        assert!(eff.allows_write_path(Path::new("/home/x/work/sub/dir/file.txt")));
+        assert!(!eff.allows_write_path(Path::new("/home/x/other/")));
+        assert!(!eff.allows_write_path(Path::new("/home/x/")));
+    }
+
+    #[test]
+    fn effective_propagates_default_conflict() {
+        let a = profile_with(
+            r#"
+inference:
+  allow: ["ollama"]
+  default: "ollama"
+"#,
+        );
+        let b = profile_with(
+            r#"
+inference:
+  allow: ["privatemode"]
+  default: "privatemode"
+"#,
+        );
+        let err = effective_for_skills(&[
+            PermissionsSource::Explicit(a),
+            PermissionsSource::Explicit(b),
+        ])
+        .unwrap_err();
+        assert!(matches!(err, MergeError::DefaultConflict { .. }));
     }
 }

--- a/crates/agent/src/tests.rs
+++ b/crates/agent/src/tests.rs
@@ -247,6 +247,67 @@ fn load_nonexistent_dir() {
     assert!(skills.is_empty());
 }
 
+/// #76 Phase 4 migration: every bundled SKILL.md must declare an
+/// explicit `permissions:` block. None of them should fall through to
+/// `PermissionsSource::Legacy` once the migration sweep is complete.
+/// Catches silent regressions if a future skill is added without a
+/// block, or if the loader stops parsing the block correctly.
+#[test]
+fn every_bundled_skill_has_explicit_permissions() {
+    let tmp = TempDir::new().unwrap();
+    crate::bundled_skills::install_bundled_skills(tmp.path()).unwrap();
+    // Per-skill load_file so a parse error names the failing skill
+    // rather than silently dropping it from the load_dir count.
+    for entry in std::fs::read_dir(tmp.path()).unwrap() {
+        let path = entry.unwrap().path();
+        if !path.is_dir() {
+            continue;
+        }
+        let skill_file = path.join("SKILL.md");
+        if !skill_file.exists() {
+            continue;
+        }
+        let skill = SkillLoader::load_file(&skill_file).unwrap_or_else(|e| {
+            panic!(
+                "bundled skill at {} failed to load: {e}",
+                skill_file.display()
+            )
+        });
+        match &skill.permissions {
+            crate::skill_perms::PermissionsSource::Explicit(_) => {}
+            crate::skill_perms::PermissionsSource::Legacy => {
+                panic!(
+                    "bundled skill '{}' has no explicit permissions block — \
+                     migration sweep regression",
+                    skill.name
+                );
+            }
+        }
+    }
+}
+
+/// Migrating to per-skill permissions must not break the merge step
+/// when every bundled skill is loaded together. Detects, in particular,
+/// inference.default conflicts that would block any agent that loads
+/// the full bundle.
+#[test]
+fn bundled_skills_merge_into_a_resolved_effective_profile() {
+    let tmp = TempDir::new().unwrap();
+    crate::bundled_skills::install_bundled_skills(tmp.path()).unwrap();
+    let skills = SkillLoader::load_dir(tmp.path()).unwrap();
+    let sources: Vec<_> = skills.iter().map(|s| s.permissions.clone()).collect();
+    let eff = crate::skill_perms::effective_for_skills(&sources)
+        .expect("bundled skills should merge cleanly");
+    // None of the bundled skills declare Legacy, so the merge must
+    // produce Resolved, not Legacy.
+    match eff {
+        crate::skill_perms::EffectiveProfile::Resolved(_) => {}
+        crate::skill_perms::EffectiveProfile::Legacy => {
+            panic!("bundled skills merged to Legacy — at least one missed migration")
+        }
+    }
+}
+
 #[test]
 fn skill_prompt_generation() {
     let skills = vec![

--- a/crates/agent/src/tests.rs
+++ b/crates/agent/src/tests.rs
@@ -257,6 +257,7 @@ fn skill_prompt_generation() {
             body: "Use curl wttr.in".into(),
             path: PathBuf::new(),
             available: true,
+            permissions: crate::skill_perms::PermissionsSource::Legacy,
         },
         Skill {
             name: "unavailable".into(),
@@ -265,6 +266,7 @@ fn skill_prompt_generation() {
             body: "Should not appear".into(),
             path: PathBuf::new(),
             available: false,
+            permissions: crate::skill_perms::PermissionsSource::Legacy,
         },
     ];
 

--- a/crates/agent/src/tool.rs
+++ b/crates/agent/src/tool.rs
@@ -53,7 +53,13 @@ pub struct ToolRegistry {
     /// `resolve_path_for_write` / `symlink_metadata` leaf check.
     workspace_dir: Arc<cap_std::fs::Dir>,
     tools: HashMap<String, ToolDef>,
-    http: reqwest::Client,
+    /// HTTP client used by built-in tools that touch the network
+    /// (`web_search`, `generate_image`). Wrapped with the egress
+    /// allowlist enforcement (#76 Phase 2.2). The agent updates the
+    /// enforcement at `attach_skills` time. A future per-host
+    /// rate limiter sits between this wrapper and `reqwest::Client`,
+    /// not outside it — see [`crate::egress`].
+    http: crate::egress::EgressClient,
     config: ToolConfig,
     /// Lazily provisioned on first use of a sandboxed tool. The outer
     /// `OnceCell` is set exactly once; the inner `Option` records whether
@@ -218,7 +224,7 @@ impl ToolRegistry {
             workspace,
             workspace_dir,
             tools,
-            http: reqwest::Client::new(),
+            http: crate::egress::EgressClient::new(),
             config,
             sandbox: tokio::sync::OnceCell::new(),
             sandbox_config,
@@ -306,6 +312,12 @@ impl ToolRegistry {
     /// expand the `<workspace>` token in skill permission paths.
     pub fn workspace(&self) -> &Path {
         &self.workspace
+    }
+
+    /// Update the egress enforcement policy on the registry's HTTP
+    /// client. Called by the agent at `attach_skills` time.
+    pub fn set_egress_enforcement(&self, enforcement: crate::egress::EgressEnforcement) {
+        self.http.set_enforcement(enforcement);
     }
 
     /// Execute a tool by name with the given JSON arguments.
@@ -522,6 +534,7 @@ impl ToolRegistry {
         let resp = self
             .http
             .post("https://html.duckduckgo.com/html/")
+            .map_err(|e| AgentError::EgressDenied { host: e.host })?
             .header("User-Agent", "Wirken/1.0")
             .header("Content-Type", "application/x-www-form-urlencoded")
             .body(format!("q={}", urlencoding_encode(query)))
@@ -620,6 +633,7 @@ impl ToolRegistry {
         let resp = self
             .http
             .post(&url)
+            .map_err(|e| AgentError::EgressDenied { host: e.host })?
             .header("Authorization", format!("Bearer {api_key}"))
             .json(&body)
             .send()

--- a/crates/agent/src/tool.rs
+++ b/crates/agent/src/tool.rs
@@ -2,7 +2,7 @@ use base64::Engine;
 use cap_std::ambient_authority;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::sync::Arc;
 
@@ -39,7 +39,9 @@ pub struct ToolRegistry {
     /// Path form of the workspace. Kept for the `exec` tool's
     /// current-dir and sandbox bind-mount; those paths still go
     /// through the OS by filename. All file tools use
-    /// [`Self::workspace_dir`] instead.
+    /// [`Self::workspace_dir`] instead. Also surfaced via
+    /// [`Self::workspace`] so the agent's `attach_skills` can expand
+    /// the `<workspace>` token in filesystem permission paths.
     workspace: PathBuf,
     /// Capability-based handle to the agent workspace. File tools
     /// (`read_file`, `write_file`, `list_files`, `generate_image`)
@@ -298,6 +300,12 @@ impl ToolRegistry {
     /// Get all tool definitions (for sending to the LLM).
     pub fn definitions(&self) -> Vec<ToolDef> {
         self.tools.values().cloned().collect()
+    }
+
+    /// Workspace directory in OS path form. The agent uses this to
+    /// expand the `<workspace>` token in skill permission paths.
+    pub fn workspace(&self) -> &Path {
+        &self.workspace
     }
 
     /// Execute a tool by name with the given JSON arguments.

--- a/crates/audit/src/session_log.rs
+++ b/crates/audit/src/session_log.rs
@@ -243,6 +243,22 @@ pub enum SessionEvent {
         agent_id: String,
         trigger: Option<String>,
     },
+    /// Skill-permission-block denial recorded by the harness. Distinct
+    /// from `PermissionDenied` (which is tier-based, operator-approval
+    /// shaped). This event fires when an agent's effective per-skill
+    /// `permissions:` profile rejects a request: a tool not in
+    /// `tools.allow`, a host not in `egress.domains`, a path not in
+    /// `filesystem.{read,write}_paths`, or a provider not in
+    /// `inference.allow`. `axis` names which axis fired; `requested`
+    /// is the bare resource string (tool name, hostname, path,
+    /// provider name); the agent's identity and the surrounding
+    /// trigger message are kept for post-hoc audit.
+    SkillPermissionDenied {
+        axis: String,
+        requested: String,
+        agent_id: String,
+        trigger: Option<String>,
+    },
     /// Sandbox lazily provisioned (item 3 emits this once at first
     /// use).
     SandboxProvisioned { name: String, mode: String },

--- a/skills/calculator/SKILL.md
+++ b/skills/calculator/SKILL.md
@@ -1,6 +1,13 @@
 ---
 name: calculator
 description: Math calculations and unit conversions
+permissions:
+  tools:
+    allow: [exec]
+  egress:
+    mode: deny
+  inference:
+    allow: ["*"]
 ---
 
 # Calculator

--- a/skills/csv-tools/SKILL.md
+++ b/skills/csv-tools/SKILL.md
@@ -1,6 +1,13 @@
 ---
 name: csv-tools
 description: Parse and analyze CSV data
+permissions:
+  tools:
+    allow: [exec]
+  egress:
+    mode: deny
+  inference:
+    allow: ["*"]
 ---
 
 # CSV Tools

--- a/skills/disk-usage/SKILL.md
+++ b/skills/disk-usage/SKILL.md
@@ -1,6 +1,13 @@
 ---
 name: disk-usage
 description: Analyze disk usage and find large files
+permissions:
+  tools:
+    allow: [exec]
+  egress:
+    mode: deny
+  inference:
+    allow: ["*"]
 ---
 
 # Disk Usage

--- a/skills/docker/SKILL.md
+++ b/skills/docker/SKILL.md
@@ -5,6 +5,13 @@ metadata:
   wirken:
     requires:
       bins: [docker]
+permissions:
+  tools:
+    allow: [exec]
+  egress:
+    mode: deny
+  inference:
+    allow: ["*"]
 ---
 
 # Docker

--- a/skills/file-search/SKILL.md
+++ b/skills/file-search/SKILL.md
@@ -1,6 +1,13 @@
 ---
 name: file-search
 description: Find files and search content across directories
+permissions:
+  tools:
+    allow: [exec]
+  egress:
+    mode: deny
+  inference:
+    allow: ["*"]
 ---
 
 # File Search

--- a/skills/git/SKILL.md
+++ b/skills/git/SKILL.md
@@ -5,6 +5,13 @@ metadata:
   wirken:
     requires:
       bins: [git]
+permissions:
+  tools:
+    allow: [exec]
+  egress:
+    mode: deny
+  inference:
+    allow: ["*"]
 ---
 
 # Git

--- a/skills/github/SKILL.md
+++ b/skills/github/SKILL.md
@@ -5,6 +5,13 @@ metadata:
   wirken:
     requires:
       bins: [gh]
+permissions:
+  tools:
+    allow: [exec]
+  egress:
+    mode: deny
+  inference:
+    allow: ["*"]
 ---
 
 # GitHub

--- a/skills/json-tools/SKILL.md
+++ b/skills/json-tools/SKILL.md
@@ -5,6 +5,13 @@ metadata:
   wirken:
     requires:
       bins: [jq]
+permissions:
+  tools:
+    allow: [exec]
+  egress:
+    mode: deny
+  inference:
+    allow: ["*"]
 ---
 
 # JSON Tools

--- a/skills/lyrik/SKILL.md
+++ b/skills/lyrik/SKILL.md
@@ -1,6 +1,16 @@
 ---
 name: lyrik
 description: Security assessment of a codebase — red team, pentest, variant hunt, regression check
+permissions:
+  tools:
+    allow: [exec, read_file, write_file, list_files]
+  egress:
+    mode: deny
+  filesystem:
+    read_paths: ["<workspace>"]
+    write_paths: ["<workspace>/.lyrik"]
+  inference:
+    allow: ["*"]
 ---
 
 # Lyrik

--- a/skills/notes/SKILL.md
+++ b/skills/notes/SKILL.md
@@ -1,6 +1,16 @@
 ---
 name: notes
 description: Create and manage text notes in the workspace
+permissions:
+  tools:
+    allow: [exec, read_file, write_file, list_files]
+  egress:
+    mode: deny
+  filesystem:
+    read_paths: ["<workspace>"]
+    write_paths: ["<workspace>"]
+  inference:
+    allow: ["*"]
 ---
 
 # Notes

--- a/skills/process-manager/SKILL.md
+++ b/skills/process-manager/SKILL.md
@@ -1,6 +1,13 @@
 ---
 name: process-manager
 description: Monitor and manage system processes
+permissions:
+  tools:
+    allow: [exec]
+  egress:
+    mode: deny
+  inference:
+    allow: ["*"]
 ---
 
 # Process Manager

--- a/skills/ssh/SKILL.md
+++ b/skills/ssh/SKILL.md
@@ -5,6 +5,13 @@ metadata:
   wirken:
     requires:
       bins: [ssh]
+permissions:
+  tools:
+    allow: [exec]
+  egress:
+    mode: deny
+  inference:
+    allow: ["*"]
 ---
 
 # SSH

--- a/skills/system-info/SKILL.md
+++ b/skills/system-info/SKILL.md
@@ -1,6 +1,13 @@
 ---
 name: system-info
 description: System information and monitoring
+permissions:
+  tools:
+    allow: [exec]
+  egress:
+    mode: deny
+  inference:
+    allow: ["*"]
 ---
 
 # System Info

--- a/skills/tmux/SKILL.md
+++ b/skills/tmux/SKILL.md
@@ -5,6 +5,13 @@ metadata:
   wirken:
     requires:
       bins: [tmux]
+permissions:
+  tools:
+    allow: [exec]
+  egress:
+    mode: deny
+  inference:
+    allow: ["*"]
 ---
 
 # Tmux

--- a/skills/weather/SKILL.md
+++ b/skills/weather/SKILL.md
@@ -5,6 +5,13 @@ metadata:
   wirken:
     requires:
       bins: [curl]
+permissions:
+  tools:
+    allow: [exec]
+  egress:
+    mode: deny
+  inference:
+    allow: ["*"]
 ---
 
 # Weather

--- a/skills/web-fetch/SKILL.md
+++ b/skills/web-fetch/SKILL.md
@@ -5,6 +5,13 @@ metadata:
   wirken:
     requires:
       bins: [curl]
+permissions:
+  tools:
+    allow: [exec]
+  egress:
+    mode: deny
+  inference:
+    allow: ["*"]
 ---
 
 # Web Fetch


### PR DESCRIPTION
Implements the rescoped #76 — single `permissions:` block in SKILL.md frontmatter, four axes (tools / egress / filesystem / inference), default-deny on every axis, signed as part of the existing SKILL.md signing flow.

## Bypass invariant

Once this PR lands and the follow-up Legacy hard-fail PR flips, **the only path to bypass per-agent permission enforcement is to attach zero skills to the agent.**

Concretely, post-flip:

- No skill can omit `permissions:` and load.
- No skill can declare wildcards on filesystem (rejected at parse).
- No skill can declare `egress.mode = deny` with a non-empty `domains` list (rejected at parse).
- No skill can declare an `inference.default` outside its own `inference.allow` (rejected at parse).
- No multi-skill bundle can have conflicting `inference.default` values (rejected at attach).
- The agent's enforcement is checked at every tool dispatch (LLM-visible surface filter + dispatch-time gate), every LLM request (provider gate), every file tool call (read/write path gate against the resolved allow-set), and every Rust-level HTTP request from the wrapped client (egress allowlist).

**No bypass: no `--skip-permissions` flag, no environment-variable override, no debug-mode escape.** The LLM cannot reach a tool that can read or modify the profile.

`EffectiveProfile::Legacy` is the migration-window short-circuit; it fires only when zero skills are attached or any attached skill omits its `permissions:` block. The follow-up flip PR removes the second case.

## Per-agent, per-skill declared

Each skill declares minimum needs in its frontmatter. The agent computes its effective profile at `attach_skills` time as the union of all loaded skills' profiles. `inference.default` is the one scalar that cannot be unioned cleanly; conflicts among declaring skills are an attach-time error — the small piece that keeps union from collapsing into "anything goes."

## Commits

- `2b2105e` — Phase 1: types, parser, validation, merge in `crates/agent/src/skill_perms.rs`. Loader wired to read the block from frontmatter; missing block emits a deprecation warning and resolves to `Legacy`.
- `9414842` — Phase 2.1 (tool gate at dispatch + LLM surface filtering) + Phase 2.4 (LlmClient provider gate, static at attach + runtime defense-in-depth) + Phase 3 (`SkillPermissionDenied` audit event variant) + workspace-token plumbing.
- `3931c41` — Phase 2.3 (filesystem path gate, two-layer with cap-std as outer guarantee + permission profile as inner allowlist) + Phase 2.2 (egress wrapper around `reqwest::Client`, with the layering for future rate limiting documented in code).
- `5ac27d8` — Phase 4: 16 SKILL.md migrations with explicit `permissions:` blocks; workspace token supports subpaths; bundled-skill loader regression test.

## Layering note on egress

The egress wrapper documents the layering order explicitly so it isn't accidentally reversed later:

```
caller → EgressClient → RateLimitedClient → reqwest::Client
```

A future per-host rate limiter sits between the egress check and the underlying transport — denied hosts short-circuit at egress and never enter the rate-limit budget. Reversing the layers would have rate-limit accounting paying for requests egress was always going to deny.

## Two-layer filesystem defense

```
agent dispatch → effective filesystem allow-set check → cap-std workspace scope → kernel
```

cap-std is the outer guarantee (rejects absolute paths and parent traversal at the syscall layer via `openat2(RESOLVE_BENEATH)` on Linux). The new per-skill allow-set is the inner tighter check — a skill that declares `write_paths: ["<workspace>/.lyrik"]` cannot use `write_file` to write outside that subdirectory even though cap-std would allow it anywhere in the workspace.

## Migration choices (the precedent the next 100 skills will copy)

- 14 skills get `tools=[exec], egress=deny, inference=*`. They shell out via `exec` for everything, make no Rust-level HTTP calls, and don't need `read_file`/`write_file`/`list_files`. This is the right shape **for the 14 skills that already work this way** — not a recommendation for new skills to copy without thinking. The per-skill thinking is what makes the next two different.
- `notes` adds broad workspace filesystem access (the skill genuinely needs to read and write notes anywhere in the workspace).
- `lyrik` adds workspace *read* but scopes *write* to `<workspace>/.lyrik` — tighter than "anywhere in the workspace" because the skill's contract is that it writes only to its config/state subdirectory.

If anyone copies the 14-skill shape without thinking, they get strictly better enforcement than today's no-permissions state — `tools` is filtered, `egress` blocks any future Rust-level HTTP, `filesystem` admits nothing (the skill doesn't touch the workspace via tools), `inference` allows any provider. The default is safe; the per-skill thinking is what makes `notes` and `lyrik` different.

## Tests

230 agent unit tests pass. New tests cover:

- Parser behavior for each axis (full block, empty block, missing block, wildcards, mixed wildcards, invalid hosts, paths inside skill root, default not in allow, deny mode with domains).
- Merge semantics (union, wildcard wins, default conflict, single-declarer pass-through).
- `EffectiveProfile` axis-specific allow checks (legacy vs. resolved, deny mode blocks, allowlist with literal + wildcard label + global wildcard).
- Workspace token round-trip through parse and expansion at attach time.
- `EgressClient` host matching (literal, wildcard label, global, unparseable URL).
- Regression test that loads every bundled SKILL.md and verifies each declares an explicit `permissions:` block (catches accidental Legacy regression in future skill additions).

`cargo fmt --check` clean. `cargo clippy --workspace --tests -- -D warnings` clean.

## Next steps after merge

1. Hard-fail flip PR — one-file mechanical change: loader rejects missing `permissions:` block. Closes the migration window.
2. Quick analysis on #79 (`disable-model-invocation` frontmatter) — short read posted on that thread to confirm or refute that it's a different axis (skill *invocation* / prompt construction) from this PR's `tools.allow` (tool *visibility* / dispatch). [Posted: #79.]
3. Zirkel preset implementation begins — this PR is the keystone the preset waits on.