### PR TITLE
permissions: hard-fail on missing block; remove PermissionsSource enum

### DIFF
--- a/crates/agent/src/runtime.rs
+++ b/crates/agent/src/runtime.rs
@@ -473,9 +473,9 @@ impl Agent {
         skills: Vec<Skill>,
         wasm_skills: Vec<WasmSkill>,
     ) -> Result<(), AgentError> {
-        let sources: Vec<crate::skill_perms::PermissionsSource> =
+        let profiles: Vec<crate::skill_perms::PermissionProfile> =
             skills.iter().map(|s| s.permissions.clone()).collect();
-        let effective = crate::skill_perms::effective_for_skills(&sources)
+        let effective = crate::skill_perms::effective_for_skills(&profiles)
             .map_err(|e| AgentError::SkillLoad(format!("permissions merge: {e}")))?;
         // Expand the `<workspace>` token in filesystem paths now that we
         // know the workspace.

--- a/crates/agent/src/skill.rs
+++ b/crates/agent/src/skill.rs
@@ -2,7 +2,7 @@ use serde::Deserialize;
 use std::path::{Path, PathBuf};
 
 use crate::error::AgentError;
-use crate::skill_perms::{PermissionsBlock, PermissionsSource, resolve_block};
+use crate::skill_perms::{PermissionProfile, PermissionsBlock, resolve_block};
 
 /// A loaded markdown skill.
 #[derive(Debug, Clone)]
@@ -13,10 +13,12 @@ pub struct Skill {
     pub body: String,
     pub path: PathBuf,
     pub available: bool,
-    /// Per-skill permissions declared in the frontmatter `permissions:` block,
-    /// or `Legacy` if the block is absent. The agent merges declared profiles
-    /// from all loaded skills into one effective per-agent profile at init.
-    pub permissions: PermissionsSource,
+    /// Per-skill permissions declared in the frontmatter `permissions:`
+    /// block. Required since the migration window closed (#76); the
+    /// loader hard-fails on a missing block. The agent merges declared
+    /// profiles from all loaded skills into one effective per-agent
+    /// profile at `attach_skills` time.
+    pub permissions: PermissionProfile,
 }
 
 /// YAML frontmatter parsed from SKILL.md files.
@@ -91,20 +93,16 @@ impl SkillLoader {
         let skill_root = path.parent().unwrap_or_else(|| Path::new("."));
         let home = std::env::var("HOME").ok().map(PathBuf::from);
         let permissions = match frontmatter.permissions {
-            Some(block) => {
-                let profile = resolve_block(block, skill_root, home.as_deref()).map_err(|e| {
-                    AgentError::SkillLoad(format!("permissions block in {}: {e}", path.display()))
-                })?;
-                PermissionsSource::Explicit(profile)
-            }
+            Some(block) => resolve_block(block, skill_root, home.as_deref()).map_err(|e| {
+                AgentError::SkillLoad(format!("permissions block in {}: {e}", path.display()))
+            })?,
             None => {
-                tracing::warn!(
-                    "skill {} has no `permissions:` block; treating as legacy. \
-                     This will become a hard load failure in a future release. \
-                     See gebruder/wirken#76.",
+                return Err(AgentError::SkillLoad(format!(
+                    "skill at {} has no `permissions:` block; required since #76 \
+                     migration-window flip. See an existing bundled SKILL.md for \
+                     the schema.",
                     path.display()
-                );
-                PermissionsSource::Legacy
+                )));
             }
         };
 

--- a/crates/agent/src/skill_perms.rs
+++ b/crates/agent/src/skill_perms.rs
@@ -7,9 +7,10 @@
 //! - `inference` — which LLM providers this skill needs the agent to call.
 //!
 //! Enforcement is per-agent: the agent computes its effective profile at init
-//! as the union of all loaded skills' declared profiles. A skill with no
-//! `permissions:` block is treated as `Legacy` — the loader warns and the
-//! agent gets the full surface for that skill during the migration window.
+//! as the union of all loaded skills' declared profiles. Every skill must
+//! declare a `permissions:` block — the migration-window soft-warn closed
+//! with the hard-fail flip. The only path that produces
+//! `EffectiveProfile::Legacy` is the empty-attach case (no skills loaded).
 //!
 //! Wildcard `"*"` is supported on `tools`, `egress.domains`, and
 //! `inference.allow`. Filesystem wildcards are rejected: cap-std workspace
@@ -36,18 +37,6 @@ pub struct PermissionProfile {
     pub egress: EgressPolicy,
     pub filesystem: FilesystemPolicy,
     pub inference: InferencePolicy,
-}
-
-/// What the loader produces per-skill.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum PermissionsSource {
-    /// The skill declared a `permissions:` block (possibly empty). Empty
-    /// resolves to a fully default-deny profile.
-    Explicit(PermissionProfile),
-    /// The skill omitted the `permissions:` block. Transitional: agent gets
-    /// the full surface and the loader logs a deprecation warning. After the
-    /// migration window flips, missing block becomes a hard load failure.
-    Legacy,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -378,13 +367,13 @@ fn validate_host(s: &str) -> Result<(), PermissionsError> {
 
 /// Effective per-agent profile after attaching all skills. The agent's
 /// enforcement points consult this; `Legacy` short-circuits all checks
-/// (full surface) for the migration window.
+/// (full surface) and is only reachable when the agent has zero skills
+/// attached. Post-migration-window the loader hard-fails on a missing
+/// `permissions:` block, so every loaded skill carries a profile and
+/// any non-empty attach produces `Resolved`.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub enum EffectiveProfile {
-    /// Full surface, no checks. Used when no skills are attached, or when
-    /// any attached skill is `PermissionsSource::Legacy`. Once the migration
-    /// window closes, the loader hard-fails on Legacy and this variant is
-    /// only reachable when zero skills are attached.
+    /// Full surface, no checks. Reached only when zero skills are attached.
     #[default]
     Legacy,
     /// Union of declared profiles. Every enforcement point honors it.
@@ -493,20 +482,16 @@ fn path_under_any(path: &Path, allowed: &BTreeSet<PathBuf>) -> bool {
 }
 
 /// Compute the effective profile for a set of attached skills. Returns
-/// `Legacy` if any skill is `Legacy` or the slice is empty; otherwise
-/// returns `Resolved(merge(...))`. Propagates `inference.default` conflict.
-pub fn effective_for_skills(sources: &[PermissionsSource]) -> Result<EffectiveProfile, MergeError> {
-    if sources.is_empty() {
+/// `Legacy` for the empty case (no skills attached — no enforcement);
+/// otherwise returns `Resolved(merge(...))`. Propagates
+/// `inference.default` conflict.
+pub fn effective_for_skills(
+    profiles: &[PermissionProfile],
+) -> Result<EffectiveProfile, MergeError> {
+    if profiles.is_empty() {
         return Ok(EffectiveProfile::Legacy);
     }
-    let mut profiles = Vec::with_capacity(sources.len());
-    for s in sources {
-        match s {
-            PermissionsSource::Legacy => return Ok(EffectiveProfile::Legacy),
-            PermissionsSource::Explicit(p) => profiles.push(p.clone()),
-        }
-    }
-    Ok(EffectiveProfile::Resolved(merge(&profiles)?))
+    Ok(EffectiveProfile::Resolved(merge(profiles)?))
 }
 
 /// Union-merge a slice of declared per-skill profiles into one effective
@@ -840,22 +825,10 @@ inference:
     }
 
     #[test]
-    fn effective_any_legacy_skill_is_legacy() {
-        let p = profile_with(r#"tools: { allow: ["read_file"] }"#);
-        let sources = vec![PermissionsSource::Explicit(p), PermissionsSource::Legacy];
-        let eff = effective_for_skills(&sources).unwrap();
-        assert_eq!(eff, EffectiveProfile::Legacy);
-    }
-
-    #[test]
-    fn effective_all_explicit_resolves_to_merged() {
+    fn effective_resolves_for_any_non_empty_attach() {
         let a = profile_with(r#"tools: { allow: ["read_file"] }"#);
         let b = profile_with(r#"tools: { allow: ["write_file"] }"#);
-        let sources = vec![
-            PermissionsSource::Explicit(a),
-            PermissionsSource::Explicit(b),
-        ];
-        let eff = effective_for_skills(&sources).unwrap();
+        let eff = effective_for_skills(&[a, b]).unwrap();
         assert!(eff.allows_tool("read_file"));
         assert!(eff.allows_tool("write_file"));
         assert!(!eff.allows_tool("exec"));
@@ -971,11 +944,7 @@ inference:
   default: "privatemode"
 "#,
         );
-        let err = effective_for_skills(&[
-            PermissionsSource::Explicit(a),
-            PermissionsSource::Explicit(b),
-        ])
-        .unwrap_err();
+        let err = effective_for_skills(&[a, b]).unwrap_err();
         assert!(matches!(err, MergeError::DefaultConflict { .. }));
     }
 }

--- a/crates/agent/src/tests.rs
+++ b/crates/agent/src/tests.rs
@@ -126,6 +126,7 @@ fn load_skill_from_markdown() {
 name: weather
 description: "Get current weather via wttr.in"
 metadata: { "wirken": { "emoji": "☔", "requires": { "bins": ["curl"] } } }
+permissions: {}
 ---
 
 # Weather Skill
@@ -149,7 +150,12 @@ Use `curl wttr.in/{city}` to get current weather.
 }
 
 #[test]
-fn load_skill_no_frontmatter() {
+fn load_skill_no_frontmatter_fails_post_flip() {
+    // Pre-#76 hard-fail flip, a SKILL.md with no frontmatter loaded
+    // with directory-name fallback. Post-flip, every skill must declare
+    // a `permissions:` block, which requires frontmatter, so no-frontmatter
+    // skills no longer load. SkillLoader::load_dir logs and skips per-file
+    // errors, so the directory-level test sees an empty result.
     let tmp = TempDir::new().unwrap();
     let skill_dir = tmp.path().join("notes");
     std::fs::create_dir(&skill_dir).unwrap();
@@ -160,9 +166,7 @@ fn load_skill_no_frontmatter() {
     .unwrap();
 
     let skills = SkillLoader::load_dir(tmp.path()).unwrap();
-    assert_eq!(skills.len(), 1);
-    assert_eq!(skills[0].name, "notes"); // Falls back to directory name
-    assert!(skills[0].body.contains("Just a plain skill"));
+    assert!(skills.is_empty(), "no-frontmatter skill should be skipped");
 }
 
 #[test]
@@ -175,6 +179,7 @@ fn load_skill_no_required_bins() {
         r#"---
 name: summarize
 description: "Summarize text"
+permissions: {}
 ---
 
 Summarize the given text concisely.
@@ -199,6 +204,7 @@ fn load_skill_missing_bin() {
 name: impossible
 description: "Needs a nonexistent binary"
 metadata: { "openclaw": { "requires": { "bins": ["nonexistent_binary_xyz_999"] } } }
+permissions: {}
 ---
 
 This skill requires a binary that doesn't exist, declared under the
@@ -221,7 +227,9 @@ fn load_multiple_skills() {
         std::fs::create_dir(&dir).unwrap();
         std::fs::write(
             dir.join("SKILL.md"),
-            format!("---\nname: {name}\ndescription: skill {name}\n---\n\nBody of {name}."),
+            format!(
+                "---\nname: {name}\ndescription: skill {name}\npermissions: {{}}\n---\n\nBody of {name}."
+            ),
         )
         .unwrap();
     }
@@ -247,17 +255,14 @@ fn load_nonexistent_dir() {
     assert!(skills.is_empty());
 }
 
-/// #76 Phase 4 migration: every bundled SKILL.md must declare an
-/// explicit `permissions:` block. None of them should fall through to
-/// `PermissionsSource::Legacy` once the migration sweep is complete.
-/// Catches silent regressions if a future skill is added without a
-/// block, or if the loader stops parsing the block correctly.
+/// Every bundled SKILL.md must load successfully. Post-migration-flip
+/// (#76 follow-up), a missing `permissions:` block is a hard load
+/// error rather than a deprecation warning, so this test also catches
+/// any future bundled skill added without a block.
 #[test]
-fn every_bundled_skill_has_explicit_permissions() {
+fn every_bundled_skill_loads_with_a_permissions_block() {
     let tmp = TempDir::new().unwrap();
     crate::bundled_skills::install_bundled_skills(tmp.path()).unwrap();
-    // Per-skill load_file so a parse error names the failing skill
-    // rather than silently dropping it from the load_dir count.
     for entry in std::fs::read_dir(tmp.path()).unwrap() {
         let path = entry.unwrap().path();
         if !path.is_dir() {
@@ -267,23 +272,35 @@ fn every_bundled_skill_has_explicit_permissions() {
         if !skill_file.exists() {
             continue;
         }
-        let skill = SkillLoader::load_file(&skill_file).unwrap_or_else(|e| {
+        SkillLoader::load_file(&skill_file).unwrap_or_else(|e| {
             panic!(
                 "bundled skill at {} failed to load: {e}",
                 skill_file.display()
             )
         });
-        match &skill.permissions {
-            crate::skill_perms::PermissionsSource::Explicit(_) => {}
-            crate::skill_perms::PermissionsSource::Legacy => {
-                panic!(
-                    "bundled skill '{}' has no explicit permissions block — \
-                     migration sweep regression",
-                    skill.name
-                );
-            }
-        }
     }
+}
+
+/// Hard-fail flip (#76 follow-up): a SKILL.md without a `permissions:`
+/// block is a load error, not a deprecation warning. Regression test
+/// against future code that softens this back to a warning.
+#[test]
+fn skill_without_permissions_block_fails_to_load() {
+    let tmp = TempDir::new().unwrap();
+    let skill_dir = tmp.path().join("legacy_skill");
+    std::fs::create_dir_all(&skill_dir).unwrap();
+    let skill_file = skill_dir.join("SKILL.md");
+    std::fs::write(
+        &skill_file,
+        "---\nname: legacy_skill\ndescription: no permissions block\n---\n\nBody.\n",
+    )
+    .unwrap();
+    let err = SkillLoader::load_file(&skill_file).unwrap_err();
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("no `permissions:` block"),
+        "expected hard-fail message, got: {msg}"
+    );
 }
 
 /// Migrating to per-skill permissions must not break the merge step
@@ -295,15 +312,16 @@ fn bundled_skills_merge_into_a_resolved_effective_profile() {
     let tmp = TempDir::new().unwrap();
     crate::bundled_skills::install_bundled_skills(tmp.path()).unwrap();
     let skills = SkillLoader::load_dir(tmp.path()).unwrap();
-    let sources: Vec<_> = skills.iter().map(|s| s.permissions.clone()).collect();
-    let eff = crate::skill_perms::effective_for_skills(&sources)
+    let profiles: Vec<_> = skills.iter().map(|s| s.permissions.clone()).collect();
+    let eff = crate::skill_perms::effective_for_skills(&profiles)
         .expect("bundled skills should merge cleanly");
-    // None of the bundled skills declare Legacy, so the merge must
-    // produce Resolved, not Legacy.
     match eff {
         crate::skill_perms::EffectiveProfile::Resolved(_) => {}
         crate::skill_perms::EffectiveProfile::Legacy => {
-            panic!("bundled skills merged to Legacy — at least one missed migration")
+            panic!(
+                "bundled skills merged to Legacy — only the empty-attach case \
+                 should produce Legacy"
+            )
         }
     }
 }
@@ -318,7 +336,7 @@ fn skill_prompt_generation() {
             body: "Use curl wttr.in".into(),
             path: PathBuf::new(),
             available: true,
-            permissions: crate::skill_perms::PermissionsSource::Legacy,
+            permissions: crate::skill_perms::PermissionProfile::default(),
         },
         Skill {
             name: "unavailable".into(),
@@ -327,7 +345,7 @@ fn skill_prompt_generation() {
             body: "Should not appear".into(),
             path: PathBuf::new(),
             available: false,
-            permissions: crate::skill_perms::PermissionsSource::Legacy,
+            permissions: crate::skill_perms::PermissionProfile::default(),
         },
     ];
 
@@ -884,7 +902,7 @@ fn agent_loads_skills() {
     std::fs::create_dir(&weather).unwrap();
     std::fs::write(
         weather.join("SKILL.md"),
-        "---\nname: weather\ndescription: get weather\n---\nUse curl wttr.in",
+        "---\nname: weather\ndescription: get weather\npermissions: {}\n---\nUse curl wttr.in",
     )
     .unwrap();
 


### PR DESCRIPTION
Migration window closes. Follow-up to #81.

## What changes

- `SkillLoader::load_file` now returns `Err` when a SKILL.md omits the `permissions:` block, instead of warning and resolving to `Legacy`.
- `PermissionsSource` enum is removed. `Skill.permissions` is now `PermissionProfile` directly — there is no longer a Legacy-vs-Explicit distinction at the per-skill level because Legacy can no longer be produced.
- `EffectiveProfile::Legacy` is preserved for the only remaining case it covers: zero skills attached to the agent. Documented as such in the module docstring.
- `effective_for_skills` now takes `&[PermissionProfile]` instead of `&[PermissionsSource]` and returns `Resolved` for any non-empty input.

## Bypass invariant, restated post-flip

Per the rescoped #76 and the bypass invariant called out at the top of #81, the only path to bypass per-agent permission enforcement is **attach zero skills to the agent**. Every loaded skill carries a profile; every non-empty attach produces `EffectiveProfile::Resolved`; every enforcement point honors that profile.

There is no `--skip-permissions` flag, no environment-variable override, no debug-mode escape. The LLM cannot reach a tool that can read or modify the profile.

## Tests

- `every_bundled_skill_loads_with_a_permissions_block` — replaces the prior "explicit-not-Legacy" test; loads each bundled SKILL.md and confirms it loads without panic. The Explicit/Legacy match is gone because the type no longer exists.
- `skill_without_permissions_block_fails_to_load` — new regression test. Writes a SKILL.md without a `permissions:` block, asserts `SkillLoader::load_file` returns `Err` with a message naming the missing block. Catches future code that softens the loader back to a warning.
- `bundled_skills_merge_into_a_resolved_effective_profile` — tightened: panic message now states that only the empty-attach case should produce `Legacy`.
- `load_skill_no_frontmatter_fails_post_flip` — renamed and inverted from the prior "no-frontmatter loads with directory-name fallback" test. That fallback is incompatible with the hard-fail flip (no frontmatter = no permissions). The directory-level loader logs and skips per-file errors, so the directory-level load returns empty.
- Five test fixtures (`load_skill_from_markdown`, `load_skill_no_required_bins`, `load_skill_missing_bin`, `load_multiple_skills`, `agent_loads_skills`) get explicit `permissions: {}` blocks. Empty block is still a valid declaration — it resolves to a fully default-deny profile, which is fine for tests that aren't exercising permission enforcement.

230 agent unit tests pass. `cargo fmt --check` clean. `cargo clippy --workspace --tests -- -D warnings` clean.

## Compatibility

This is a breaking change for any out-of-tree custom skill that doesn't have a `permissions:` block. The migration is one line — adding `permissions: {}` to the frontmatter declares an empty default-deny block, which is functionally equivalent to having no permissions enforcement on a skill that doesn't actually use the gated capabilities. Skills that need `read_file`, `write_file`, `exec`, etc. need to declare those in their `permissions.tools.allow`.