### PR TITLE
skills: disable-model-invocation frontmatter + slash command invocation surface

### DIFF
--- a/crates/agent/src/error.rs
+++ b/crates/agent/src/error.rs
@@ -97,4 +97,10 @@ pub enum AgentError {
         "egress denied: host '{host}' is not in the agent's effective skill permissions egress allow-set"
     )]
     EgressDenied { host: String },
+
+    /// #79: user typed `/<name>` as a slash invocation but no loaded
+    /// skill has that name. Surfaced to the channel so the user can
+    /// retry with a correct skill name.
+    #[error("unknown skill '/{name}'; loaded skills: {}", known.join(", "))]
+    UnknownSlashSkill { name: String, known: Vec<String> },
 }

--- a/crates/agent/src/lib.rs
+++ b/crates/agent/src/lib.rs
@@ -14,6 +14,7 @@ pub mod sandbox;
 pub(crate) mod sigv4;
 pub mod skill;
 pub mod skill_perms;
+pub mod slash;
 pub mod tool;
 pub mod wasm_sandbox;
 

--- a/crates/agent/src/runtime.rs
+++ b/crates/agent/src/runtime.rs
@@ -473,6 +473,41 @@ impl Agent {
         skills: Vec<Skill>,
         wasm_skills: Vec<WasmSkill>,
     ) -> Result<(), AgentError> {
+        // Coherence checks (#79):
+        // - Skill names are unique among the loaded set, else `/<name>`
+        //   slash invocation is ambiguous.
+        // - A `disable-model-invocation: true` skill with an empty
+        //   `tools.allow` set is unreachable: slash invocation would
+        //   hand the LLM a skill body and zero tools to use. Fail at
+        //   attach so a permissions edit doesn't silently break
+        //   invocation.
+        let mut seen = BTreeSet::new();
+        for s in &skills {
+            if !seen.insert(s.name.clone()) {
+                return Err(AgentError::SkillLoad(format!(
+                    "duplicate skill name '{}' — `/<name>` slash invocation \
+                     would be ambiguous",
+                    s.name
+                )));
+            }
+        }
+        for s in &skills {
+            if s.disable_model_invocation {
+                let empty = matches!(
+                    &s.permissions.tools.allow,
+                    crate::skill_perms::AllowSet::Set(set) if set.is_empty()
+                );
+                if empty {
+                    return Err(AgentError::SkillLoad(format!(
+                        "skill '{}' is `disable-model-invocation: true` but has \
+                         an empty `permissions.tools.allow` — slash invocation \
+                         would reach a skill with no tools",
+                        s.name
+                    )));
+                }
+            }
+        }
+
         let profiles: Vec<crate::skill_perms::PermissionProfile> =
             skills.iter().map(|s| s.permissions.clone()).collect();
         let effective = crate::skill_perms::effective_for_skills(&profiles)
@@ -538,6 +573,25 @@ impl Agent {
             }
         };
         Some((axis, absolute))
+    }
+
+    /// #79: rewrite a slash-invoked user message so the LLM sees the
+    /// invoked skill's body before the user's actual request. Returns
+    /// the original message unchanged when no slash prefix is present.
+    /// Returns `Err(AgentError::UnknownSlashSkill)` when the prefix
+    /// names a skill that isn't loaded — the channel surfaces this
+    /// back to the user so they can correct the typo.
+    fn preprocess_slash_invocation(&self, message: &str) -> Result<String, AgentError> {
+        match crate::slash::parse(message, &self.skills) {
+            crate::slash::SlashResult::None => Ok(message.to_string()),
+            crate::slash::SlashResult::Invoked { skill, remainder } => {
+                Ok(crate::slash::rewrite_with_skill_body(skill, &remainder))
+            }
+            crate::slash::SlashResult::UnknownSkill { name } => {
+                let known: Vec<String> = self.skills.iter().map(|s| s.name.clone()).collect();
+                Err(AgentError::UnknownSlashSkill { name, known })
+            }
+        }
     }
 
     /// Defence-in-depth gate emitted before each LLM dispatch (#76 Phase
@@ -1018,12 +1072,17 @@ impl Agent {
         // exact conversation prefix that was hashed into LlmRequest.
         self.maybe_log_system_prompt()?;
 
-        self.current_trigger = Some(user_message.to_string());
-        self.conversation.add_user_message(user_message);
+        // #79: detect `/<skill-name>` slash invocation and inline the
+        // named skill's body so the LLM has its instructions for this
+        // turn even though the skill is excluded from the auto-pickable
+        // system prompt.
+        let user_message = self.preprocess_slash_invocation(user_message)?;
+        self.current_trigger = Some(user_message.clone());
+        self.conversation.add_user_message(&user_message);
         self.log_event(
             TrustLevel::User,
             SessionEvent::UserMessage {
-                content: user_message.to_string(),
+                content: user_message,
                 inbound_id: Some(inbound_id),
             },
         )?;
@@ -1256,12 +1315,16 @@ impl Agent {
         // Item 10 follow-up — see process_message_inner.
         self.maybe_log_system_prompt()?;
 
-        self.current_trigger = Some(user_message.to_string());
-        self.conversation.add_user_message(user_message);
+        // #79: same slash-invocation pre-processing as the non-streaming
+        // path. Done before adding to the conversation so the recorded
+        // user message reflects what the LLM actually saw.
+        let user_message = self.preprocess_slash_invocation(user_message)?;
+        self.current_trigger = Some(user_message.clone());
+        self.conversation.add_user_message(&user_message);
         self.log_event(
             TrustLevel::User,
             SessionEvent::UserMessage {
-                content: user_message.to_string(),
+                content: user_message,
                 inbound_id: Some(inbound_id),
             },
         )?;

--- a/crates/agent/src/skill.rs
+++ b/crates/agent/src/skill.rs
@@ -19,6 +19,13 @@ pub struct Skill {
     /// profiles from all loaded skills into one effective per-agent
     /// profile at `attach_skills` time.
     pub permissions: PermissionProfile,
+    /// Whether the skill is excluded from the LLM's auto-pickable set
+    /// (matches OpenClaw's `disable-model-invocation` field, #79).
+    /// Default `true` — Wirken's posture is that auto-invocation
+    /// requires explicit author opt-in. Auto-invocable skills declare
+    /// `disable-model-invocation: false`. Explicit-only skills are
+    /// reached via `/<skill-name>` slash commands; see [`crate::slash`].
+    pub disable_model_invocation: bool,
 }
 
 /// YAML frontmatter parsed from SKILL.md files.
@@ -31,6 +38,12 @@ struct SkillFrontmatter {
     metadata: Option<serde_json::Value>,
     #[serde(default)]
     permissions: Option<PermissionsBlock>,
+    /// Default `true` (when omitted, skill is explicit-invocation only).
+    /// Mirrors OpenClaw's `disable-model-invocation` semantic. Skills
+    /// must explicitly declare `disable-model-invocation: false` to
+    /// become auto-invocable.
+    #[serde(rename = "disable-model-invocation", default)]
+    disable_model_invocation: Option<bool>,
 }
 
 /// Loads SKILL.md files from a directory.
@@ -106,6 +119,10 @@ impl SkillLoader {
             }
         };
 
+        // Default-true (Wirken's posture: auto-invocation requires
+        // explicit opt-in). #79.
+        let disable_model_invocation = frontmatter.disable_model_invocation.unwrap_or(true);
+
         Ok(Skill {
             name: frontmatter.name.unwrap_or(dir_name),
             description: frontmatter.description.unwrap_or_default(),
@@ -114,20 +131,28 @@ impl SkillLoader {
             path: path.to_path_buf(),
             available,
             permissions,
+            disable_model_invocation,
         })
     }
 
     /// Build a system prompt fragment from loaded skills.
-    /// Only includes skills whose required binaries are available.
+    /// Includes only auto-invocable, available skills. Explicit-only
+    /// skills (`disable-model-invocation: true`) are reached via
+    /// `/<skill-name>` slash commands (#79); their bodies are injected
+    /// into the user message at invocation time, not into the system
+    /// prompt at agent init.
     pub fn build_prompt(skills: &[Skill]) -> String {
-        let available: Vec<&Skill> = skills.iter().filter(|s| s.available).collect();
+        let auto: Vec<&Skill> = skills
+            .iter()
+            .filter(|s| s.available && !s.disable_model_invocation)
+            .collect();
 
-        if available.is_empty() {
+        if auto.is_empty() {
             return String::new();
         }
 
         let mut prompt = String::from("\n\n## Available Skills\n\n");
-        for skill in &available {
+        for skill in &auto {
             prompt.push_str(&format!("### {}\n", skill.name));
             if !skill.description.is_empty() {
                 prompt.push_str(&skill.description);
@@ -155,6 +180,7 @@ fn parse_frontmatter(content: &str) -> Result<(SkillFrontmatter, String), AgentE
                 description: None,
                 metadata: None,
                 permissions: None,
+                disable_model_invocation: None,
             },
             content.to_string(),
         ));

--- a/crates/agent/src/slash.rs
+++ b/crates/agent/src/slash.rs
@@ -1,0 +1,206 @@
+//! Slash-command invocation surface for explicit-only skills (#79).
+//!
+//! Skills declared `disable-model-invocation: true` are excluded from the
+//! system prompt's auto-pickable set ([`crate::skill::SkillLoader::build_prompt`]).
+//! To reach them, the user types `/<skill-name>` as a prefix on a message.
+//! The agent detects the prefix, looks up the named skill, prepends the
+//! skill's body to the user message for that turn, and strips the prefix
+//! from what the LLM sees in subsequent context.
+//!
+//! ## Strict, not fuzzy
+//!
+//! The parser detects the `^/<name>(\s|$)` shape only — leading slash,
+//! one identifier-shaped name, then whitespace or end of string. It does
+//! not match mentions of a skill name elsewhere in the message
+//! (`"thanks for using lyrik"` is not an invocation), nor does it
+//! interpret `use lyrik to ...` as explicit invocation. Fuzzy invocation
+//! turns "explicit" into "unpredictable"; the slash prefix is the contract.
+
+use crate::skill::Skill;
+
+/// Result of running [`parse`] on a user message.
+#[derive(Debug)]
+pub enum SlashResult<'a> {
+    /// No `/<name>` prefix on the message — pass through unchanged.
+    None,
+    /// Prefix matched and named skill is loaded. The agent should
+    /// prepend `skill.body` to the rewritten message before adding it
+    /// to the conversation.
+    Invoked {
+        skill: &'a Skill,
+        /// Message body with the `/<name>` prefix and any single
+        /// trailing whitespace stripped.
+        remainder: String,
+    },
+    /// Prefix matched but the named skill is not loaded. The agent
+    /// should fail the user message rather than silently treating it
+    /// as plain text — a typo'd or out-of-scope slash is exactly the
+    /// case where silent fall-through is dangerous.
+    UnknownSkill { name: String },
+}
+
+/// Parse a user message for a leading `/<skill-name>` invocation.
+pub fn parse<'a>(message: &str, skills: &'a [Skill]) -> SlashResult<'a> {
+    let trimmed = message.trim_start();
+    let Some(after_slash) = trimmed.strip_prefix('/') else {
+        return SlashResult::None;
+    };
+    // Skill name is the prefix up to the first whitespace. Empty name
+    // (a bare `/`) is not an invocation — pass through.
+    let (name, rest) = match after_slash.find(char::is_whitespace) {
+        Some(idx) => (&after_slash[..idx], &after_slash[idx + 1..]),
+        None => (after_slash, ""),
+    };
+    if name.is_empty() {
+        return SlashResult::None;
+    }
+    if !is_skill_name_shape(name) {
+        return SlashResult::None;
+    }
+    match skills.iter().find(|s| s.name == name) {
+        Some(skill) => SlashResult::Invoked {
+            skill,
+            remainder: rest.to_string(),
+        },
+        None => SlashResult::UnknownSkill {
+            name: name.to_string(),
+        },
+    }
+}
+
+/// Skill names follow the same shape as bundled skills: alphanumeric,
+/// hyphens, underscores. Anything outside this is not a skill name and
+/// the slash prefix is treated as ordinary text (e.g., a Markdown
+/// quotation or a leading-slash URL fragment).
+fn is_skill_name_shape(s: &str) -> bool {
+    !s.is_empty()
+        && s.chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+}
+
+/// Rewrite a slash-invoked user message so the LLM sees the skill body
+/// before the user's request. The returned string is what gets added
+/// to the conversation in place of the raw user message.
+pub fn rewrite_with_skill_body(skill: &Skill, remainder: &str) -> String {
+    let mut out = String::with_capacity(skill.body.len() + remainder.len() + 64);
+    out.push_str("# Skill: ");
+    out.push_str(&skill.name);
+    out.push_str("\n\n");
+    out.push_str(&skill.body);
+    out.push_str("\n\n---\n\n");
+    out.push_str(remainder);
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::skill_perms::PermissionProfile;
+    use std::path::PathBuf;
+
+    fn skill(name: &str) -> Skill {
+        Skill {
+            name: name.to_string(),
+            description: format!("desc for {name}"),
+            required_bins: vec![],
+            body: format!("body of {name}"),
+            path: PathBuf::new(),
+            available: true,
+            permissions: PermissionProfile::default(),
+            disable_model_invocation: true,
+        }
+    }
+
+    #[test]
+    fn no_slash_prefix_returns_none() {
+        let s = vec![skill("lyrik")];
+        assert!(matches!(parse("audit src/", &s), SlashResult::None));
+    }
+
+    #[test]
+    fn slash_prefix_with_known_skill_invokes() {
+        let s = vec![skill("lyrik")];
+        match parse("/lyrik audit src/", &s) {
+            SlashResult::Invoked { skill, remainder } => {
+                assert_eq!(skill.name, "lyrik");
+                assert_eq!(remainder, "audit src/");
+            }
+            other => panic!("expected Invoked, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn slash_prefix_with_no_remainder_invokes_with_empty_remainder() {
+        let s = vec![skill("lyrik")];
+        match parse("/lyrik", &s) {
+            SlashResult::Invoked { skill, remainder } => {
+                assert_eq!(skill.name, "lyrik");
+                assert_eq!(remainder, "");
+            }
+            other => panic!("expected Invoked, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn slash_prefix_with_unknown_skill_reports_unknown() {
+        let s = vec![skill("lyrik")];
+        match parse("/nonexistent do something", &s) {
+            SlashResult::UnknownSkill { name } => assert_eq!(name, "nonexistent"),
+            other => panic!("expected UnknownSkill, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn slash_in_middle_of_message_is_not_an_invocation() {
+        let s = vec![skill("lyrik")];
+        assert!(matches!(parse("please /lyrik this", &s), SlashResult::None));
+    }
+
+    #[test]
+    fn skill_name_mention_without_slash_is_not_an_invocation() {
+        let s = vec![skill("lyrik")];
+        assert!(matches!(
+            parse("use lyrik to audit src/", &s),
+            SlashResult::None
+        ));
+    }
+
+    #[test]
+    fn bare_slash_passes_through() {
+        let s = vec![skill("lyrik")];
+        assert!(matches!(parse("/", &s), SlashResult::None));
+    }
+
+    #[test]
+    fn slash_followed_by_invalid_name_passes_through() {
+        let s = vec![skill("lyrik")];
+        // URL-shaped leading slash, code blocks, etc. are ordinary text.
+        assert!(matches!(parse("/path/to/file", &s), SlashResult::None));
+    }
+
+    #[test]
+    fn leading_whitespace_is_tolerated() {
+        let s = vec![skill("lyrik")];
+        match parse("  /lyrik audit", &s) {
+            SlashResult::Invoked { skill, remainder } => {
+                assert_eq!(skill.name, "lyrik");
+                assert_eq!(remainder, "audit");
+            }
+            other => panic!("expected Invoked, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rewrite_inlines_skill_body_before_remainder() {
+        let s = skill("lyrik");
+        let out = rewrite_with_skill_body(&s, "audit src/");
+        assert!(out.starts_with("# Skill: lyrik"));
+        assert!(out.contains("body of lyrik"));
+        assert!(out.contains("audit src/"));
+        // Body must precede remainder so the LLM reads instructions
+        // before the request.
+        let body_idx = out.find("body of lyrik").unwrap();
+        let req_idx = out.find("audit src/").unwrap();
+        assert!(body_idx < req_idx);
+    }
+}

--- a/crates/agent/src/tests.rs
+++ b/crates/agent/src/tests.rs
@@ -328,6 +328,10 @@ fn bundled_skills_merge_into_a_resolved_effective_profile() {
 
 #[test]
 fn skill_prompt_generation() {
+    // Two auto-invocable skills (disable_model_invocation: false), one
+    // available and one with a missing required binary, plus one
+    // explicit-only skill (disable_model_invocation: true). The prompt
+    // should include only the auto-invocable, available skill.
     let skills = vec![
         Skill {
             name: "weather".into(),
@@ -337,6 +341,7 @@ fn skill_prompt_generation() {
             path: PathBuf::new(),
             available: true,
             permissions: crate::skill_perms::PermissionProfile::default(),
+            disable_model_invocation: false,
         },
         Skill {
             name: "unavailable".into(),
@@ -346,6 +351,17 @@ fn skill_prompt_generation() {
             path: PathBuf::new(),
             available: false,
             permissions: crate::skill_perms::PermissionProfile::default(),
+            disable_model_invocation: false,
+        },
+        Skill {
+            name: "explicit-only".into(),
+            description: "Explicit invocation".into(),
+            required_bins: vec![],
+            body: "Should not appear in auto-prompt".into(),
+            path: PathBuf::new(),
+            available: true,
+            permissions: crate::skill_perms::PermissionProfile::default(),
+            disable_model_invocation: true,
         },
     ];
 
@@ -354,6 +370,7 @@ fn skill_prompt_generation() {
     assert!(prompt.contains("Use curl wttr.in"));
     assert!(!prompt.contains("unavailable"));
     assert!(!prompt.contains("Should not appear"));
+    assert!(!prompt.contains("explicit-only"));
 }
 
 // ---------------------------------------------------------------------------

--- a/skills/calculator/SKILL.md
+++ b/skills/calculator/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: calculator
 description: Math calculations and unit conversions
+disable-model-invocation: false
 permissions:
   tools:
     allow: [exec]

--- a/skills/csv-tools/SKILL.md
+++ b/skills/csv-tools/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: csv-tools
 description: Parse and analyze CSV data
+disable-model-invocation: false
 permissions:
   tools:
     allow: [exec]

--- a/skills/disk-usage/SKILL.md
+++ b/skills/disk-usage/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: disk-usage
 description: Analyze disk usage and find large files
+disable-model-invocation: false
 permissions:
   tools:
     allow: [exec]

--- a/skills/docker/SKILL.md
+++ b/skills/docker/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: docker
 description: Docker container management
+disable-model-invocation: true
 metadata:
   wirken:
     requires:

--- a/skills/file-search/SKILL.md
+++ b/skills/file-search/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: file-search
 description: Find files and search content across directories
+disable-model-invocation: false
 permissions:
   tools:
     allow: [exec]

--- a/skills/git/SKILL.md
+++ b/skills/git/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: git
 description: Git version control operations
+disable-model-invocation: true
 metadata:
   wirken:
     requires:

--- a/skills/github/SKILL.md
+++ b/skills/github/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: github
 description: GitHub operations via the gh CLI
+disable-model-invocation: true
 metadata:
   wirken:
     requires:

--- a/skills/json-tools/SKILL.md
+++ b/skills/json-tools/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: json-tools
 description: Parse, query, and transform JSON data
+disable-model-invocation: false
 metadata:
   wirken:
     requires:

--- a/skills/lyrik/SKILL.md
+++ b/skills/lyrik/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: lyrik
 description: Security assessment of a codebase — red team, pentest, variant hunt, regression check
+disable-model-invocation: true
 permissions:
   tools:
     allow: [exec, read_file, write_file, list_files]

--- a/skills/notes/SKILL.md
+++ b/skills/notes/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: notes
 description: Create and manage text notes in the workspace
+disable-model-invocation: true
 permissions:
   tools:
     allow: [exec, read_file, write_file, list_files]

--- a/skills/process-manager/SKILL.md
+++ b/skills/process-manager/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: process-manager
 description: Monitor and manage system processes
+disable-model-invocation: false
 permissions:
   tools:
     allow: [exec]

--- a/skills/ssh/SKILL.md
+++ b/skills/ssh/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: ssh
 description: SSH key management and remote connections
+disable-model-invocation: true
 metadata:
   wirken:
     requires:

--- a/skills/system-info/SKILL.md
+++ b/skills/system-info/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: system-info
 description: System information and monitoring
+disable-model-invocation: false
 permissions:
   tools:
     allow: [exec]

--- a/skills/tmux/SKILL.md
+++ b/skills/tmux/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: tmux
 description: Manage tmux terminal sessions
+disable-model-invocation: true
 metadata:
   wirken:
     requires:

--- a/skills/weather/SKILL.md
+++ b/skills/weather/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: weather
 description: Get current weather and forecasts
+disable-model-invocation: false
 metadata:
   wirken:
     requires:

--- a/skills/web-fetch/SKILL.md
+++ b/skills/web-fetch/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: web-fetch
 description: Fetch and extract content from URLs
+disable-model-invocation: false
 metadata:
   wirken:
     requires:


### PR DESCRIPTION
Implements #79. Default-true posture: auto-invocation requires explicit author opt-in.

Per the analysis posted on #79 after #76 landed, this is a different axis from #76's `permissions.tools.allow`:

- **#76** governs *tool visibility and dispatch* — what tools the LLM can call.
- **#79** governs *skill prose visibility in the system prompt* — whether a skill's instructions enter the LLM's context by default. Upstream of the tool-visibility question.

The two compose: a skill can be `disable-model-invocation: true` AND declare a wide `tools.allow` (lyrik's case — its tools ride along in the agent's effective profile, but its prose is not in the prompt by default, so the LLM doesn't auto-fire on a generic "audit this code"). A skill can be auto-invocable AND declare a tight `tools.allow`.

## Slash command surface

Explicit-only skills are reached via `/<skill-name>` slash invocation. The parser is strict — `^/<name>(\s|$)` only, no fuzzy regex on skill-name appearance elsewhere in the message.

```
user → "/lyrik audit src/"
  ↓
slash::parse → SlashResult::Invoked { skill: lyrik, remainder: "audit src/" }
  ↓
Agent rewrites the user message: "# Skill: lyrik\n\n<lyrik body>\n\n---\n\naudit src/"
  ↓
LLM sees skill instructions before the request; the rewritten message is what goes into the conversation log
```

Cases:
- No slash prefix → pass through unchanged.
- `/<known-skill>` → invoke, rewrite, conversation log records the rewritten message.
- `/<unknown>` → fail loud with `AgentError::UnknownSlashSkill { name, known }`. Channel surfaces to the user; no silent fall-through to plain text.
- Bare `/`, `/path/to/file`, `/<invalid-shape>` → pass through. The slash is not interpreted as an invocation when the name doesn't shape-match `[a-zA-Z0-9_-]+`.
- Slash in the middle of a message (`"please /lyrik this"`) → not an invocation; only leading-slash counts.

## Coherence checks at attach_skills

Two new attach-time validations:

- **Skill name uniqueness.** Two loaded skills with the same name make `/<name>` ambiguous. Hard-fail at attach.
- **Reachable explicit-only skills.** A `disable-model-invocation: true` skill with an empty `permissions.tools.allow` is unreachable: slash invocation would hand the LLM a skill body and zero tools to act on. Hard-fail at attach so a permissions edit doesn't silently break invocation. The check accepts `Set` (non-empty) or `Wildcard` as reachable.

## Per-skill migration choices (the precedent)

**9 default-false (auto-invocable).** Read-mostly utilities the LLM should pick up automatically:

`calculator`, `csv-tools`, `disk-usage`, `file-search`, `json-tools`, `process-manager`, `system-info`, `weather`, `web-fetch`

**7 default-true (explicit-only via `/`).** Side-effecting, network-touching, or expensive — LLM auto-firing on a phrase match is the failure mode this exists to prevent:

`docker` (containers), `git` (commits/pushes), `github` (PRs/issues), `lyrik` (resource-expensive assessment), `notes` (writes files; cost of typing `/notes` < cost of unwanted notes), `ssh` (remote commands), `tmux` (terminal commands)

Each skill declares the field explicitly even when matching the default — the choice is legible in the frontmatter.

## Tests

- 10 slash parser tests: positive (invoke, empty remainder, leading whitespace tolerated), negative (no slash, bare slash, slash mid-message, slash followed by non-name shape, skill-name mention without slash), error path (unknown skill).
- `build_prompt` filter test extended to verify explicit-only skills are excluded from the auto-pickable set even when `available: true`.
- 240 agent unit tests pass. `cargo fmt --check` clean. `cargo clippy --workspace --tests -- -D warnings` clean.

## Compatibility

Breaking change for any out-of-tree skill that relied on auto-invocation without declaring `disable-model-invocation: false`. Migration is one line in the frontmatter. The 16 bundled skills are migrated as part of this PR; the explicit choice is preserved per skill.

After this PR + #82 are both in main, the per-skill primitive set is complete: signed frontmatter declares both *what the skill needs* (`permissions:` block, four axes) and *whether the skill auto-fires* (`disable-model-invocation`). The remaining work for the Zirkel preset is the preset bundle itself, not the primitives it sits on top of.