### PR TITLE
preset: bundle concept (Gap G) + Zirkel scaffold (Scope A)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -654,7 +654,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1364,7 +1364,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2645,7 +2645,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3177,7 +3177,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit",
+ "toml_edit 0.25.8+spec-1.1.0",
 ]
 
 [[package]]
@@ -3758,7 +3758,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3840,7 +3840,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4105,6 +4105,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -4647,7 +4656,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4882,17 +4891,38 @@ dependencies = [
 
 [[package]]
 name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
+ "toml_edit 0.22.27",
+]
+
+[[package]]
+name = "toml"
 version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
  "indexmap 2.13.0",
  "serde_core",
- "serde_spanned",
+ "serde_spanned 1.1.0",
  "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "toml_writer",
  "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -4915,6 +4945,20 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap 2.13.0",
+ "serde",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
+ "toml_write",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_edit"
 version = "0.25.8+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16bff38f1d86c47f9ff0647e6838d7bb362522bdf44006c7068c2b1e606f1f3c"
@@ -4933,6 +4977,12 @@ checksum = "2334f11ee363607eb04df9b8fc8a13ca1715a72ba8662a26ac285c98aabb4011"
 dependencies = [
  "winnow 1.0.0",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"
@@ -5579,7 +5629,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "sha2",
- "toml",
+ "toml 0.9.12+spec-1.1.0",
  "wasmtime-environ",
  "windows-sys 0.61.2",
  "zstd",
@@ -5921,7 +5971,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6386,6 +6436,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "toml 0.8.23",
  "tracing",
  "url",
  "uuid",

--- a/crates/agent/Cargo.toml
+++ b/crates/agent/Cargo.toml
@@ -19,6 +19,7 @@ reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = "0.9"
+toml = "0.8"
 tracing = { workspace = true }
 thiserror = { workspace = true }
 anyhow = { workspace = true }

--- a/crates/agent/src/bundled_presets.rs
+++ b/crates/agent/src/bundled_presets.rs
@@ -1,0 +1,145 @@
+//! Bundled presets shipped with Wirken.
+//!
+//! Same shape as [`crate::bundled_skills`] but for multi-file preset
+//! bundles. The CLI's `wirken preset install <name>` writes these to
+//! `~/.wirken/presets/<name>/`; from there the user (or a follow-up
+//! scope's runtime) loads them via [`crate::preset::PresetLoader`].
+//!
+//! Adding a new bundled preset means: (1) commit the preset directory
+//! under `preset/<name>/`, (2) add a `BundledPreset` entry below with
+//! one `(relative_path, include_str!)` pair per file in the bundle.
+
+use std::io;
+use std::path::Path;
+
+struct BundledPreset {
+    name: &'static str,
+    files: &'static [(&'static str, &'static str)],
+}
+
+const PRESETS: &[BundledPreset] = &[BundledPreset {
+    name: "zirkel",
+    files: &[
+        (
+            "preset.toml",
+            include_str!("../../../preset/zirkel/preset.toml"),
+        ),
+        (
+            "sources.toml",
+            include_str!("../../../preset/zirkel/sources.toml"),
+        ),
+        (
+            "skills/aggregator/SKILL.md",
+            include_str!("../../../preset/zirkel/skills/aggregator/SKILL.md"),
+        ),
+        (
+            "skills/librarian/SKILL.md",
+            include_str!("../../../preset/zirkel/skills/librarian/SKILL.md"),
+        ),
+    ],
+}];
+
+/// Write a bundled preset's files to `dest_dir`. The directory is
+/// created if missing; existing files are overwritten so an update of
+/// the wirken binary refreshes the on-disk preset on next install.
+/// Returns the count of files written.
+pub fn install_bundled_preset(name: &str, dest_dir: &Path) -> io::Result<usize> {
+    let preset = PRESETS.iter().find(|p| p.name == name).ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::NotFound,
+            format!("no bundled preset named '{name}'"),
+        )
+    })?;
+    let mut count = 0;
+    for (rel_path, content) in preset.files {
+        let path = dest_dir.join(rel_path);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        std::fs::write(&path, content)?;
+        count += 1;
+    }
+    Ok(count)
+}
+
+/// Names of every bundled preset.
+pub fn bundled_preset_names() -> Vec<&'static str> {
+    PRESETS.iter().map(|p| p.name).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn zirkel_is_bundled() {
+        let names = bundled_preset_names();
+        assert!(names.contains(&"zirkel"), "zirkel preset should be bundled");
+    }
+
+    #[test]
+    fn install_zirkel_writes_expected_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dest = tmp.path().join("zirkel");
+        let count = install_bundled_preset("zirkel", &dest).unwrap();
+        assert_eq!(count, 4, "zirkel bundle should write 4 files");
+        assert!(dest.join("preset.toml").exists());
+        assert!(dest.join("sources.toml").exists());
+        assert!(dest.join("skills/aggregator/SKILL.md").exists());
+        assert!(dest.join("skills/librarian/SKILL.md").exists());
+    }
+
+    #[test]
+    fn install_unknown_preset_is_not_found() {
+        let tmp = tempfile::tempdir().unwrap();
+        let err = install_bundled_preset("does-not-exist", tmp.path()).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::NotFound);
+    }
+
+    /// The keystone integration test: install the bundled Zirkel preset
+    /// to a temp dir, load it via `PresetLoader::load_dir`, and verify
+    /// the bundle is internally coherent (both skills load with parsed
+    /// permissions blocks; effective profile resolves cleanly via the
+    /// per-skill permissions union from #76).
+    #[test]
+    fn zirkel_preset_loads_and_merges_into_a_resolved_effective_profile() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dest = tmp.path().join("zirkel");
+        install_bundled_preset("zirkel", &dest).unwrap();
+
+        let loaded = crate::preset::PresetLoader::load_dir(&dest).unwrap();
+        assert_eq!(loaded.metadata.name, "zirkel");
+        assert_eq!(loaded.skills.len(), 2);
+
+        let names: Vec<&str> = loaded.skills.iter().map(|s| s.name.as_str()).collect();
+        assert!(names.contains(&"aggregator"));
+        assert!(names.contains(&"librarian"));
+
+        // Both Zirkel skills are explicit-only.
+        for s in &loaded.skills {
+            assert!(
+                s.disable_model_invocation,
+                "{} should be disable-model-invocation: true",
+                s.name
+            );
+        }
+
+        // The merged effective profile must be Resolved (not Legacy)
+        // and must not produce a default-conflict — both skills declare
+        // `inference.default = "ollama"` so the union is unanimous.
+        let profiles: Vec<_> = loaded
+            .skills
+            .iter()
+            .map(|s| s.permissions.clone())
+            .collect();
+        let eff = crate::skill_perms::effective_for_skills(&profiles).unwrap();
+        match eff {
+            crate::skill_perms::EffectiveProfile::Resolved(p) => {
+                assert_eq!(p.inference.default.as_deref(), Some("ollama"));
+            }
+            crate::skill_perms::EffectiveProfile::Legacy => {
+                panic!("zirkel preset merged to Legacy — at least one skill missed migration")
+            }
+        }
+    }
+}

--- a/crates/agent/src/lib.rs
+++ b/crates/agent/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod attestation;
+pub mod bundled_presets;
 pub mod bundled_skills;
 pub mod context;
 pub mod conversation;
@@ -9,6 +10,7 @@ pub mod identity;
 pub mod llm;
 pub mod llm_stream;
 pub mod mcp;
+pub mod preset;
 pub mod runtime;
 pub mod sandbox;
 pub(crate) mod sigv4;

--- a/crates/agent/src/preset.rs
+++ b/crates/agent/src/preset.rs
@@ -1,0 +1,305 @@
+//! Preset bundles — curated multi-skill packages with a coherent posture.
+//!
+//! A preset is a directory containing a `preset.toml` declaration plus a
+//! `skills/<name>/SKILL.md` per included skill. Optional siblings:
+//! `sources.toml`, `prompts/`, and (in later scopes) per-preset config
+//! that the runtime consumes.
+//!
+//! ```text
+//! preset/<name>/
+//!   preset.toml                    # name, description, version, skills[]
+//!   skills/
+//!     <skill_a>/SKILL.md
+//!     <skill_b>/SKILL.md
+//!   sources.toml                   # optional, preset-specific
+//!   prompts/                       # optional, preset-specific
+//! ```
+//!
+//! [`PresetLoader::load_dir`] reads the declaration, verifies the
+//! referenced skill subdirectories exist, loads each through
+//! [`crate::skill::SkillLoader`], and returns a [`LoadedPreset`]. The
+//! caller (typically [`crate::Agent::attach_skills`]) merges the
+//! profiles via #76's union semantics; coherence checks fire there.
+//!
+//! Loading the preset does *not* configure the runtime — fetcher,
+//! scheduler, and channel-push wiring are the next scope. This module
+//! is the keystone gap-G fix from `docs/zirkel/DESIGN.md` (Scope A):
+//! the directory layout, the `preset.toml` schema, and the smoke test
+//! that the bundle is internally coherent. Later scopes wire the
+//! runtime pieces.
+
+use std::path::{Path, PathBuf};
+
+use serde::Deserialize;
+use thiserror::Error;
+
+use crate::error::AgentError;
+use crate::skill::{Skill, SkillLoader};
+
+/// On-disk shape of `preset.toml`. Only the `[preset]` table is
+/// required at this scope; later scopes may add `[channel]`,
+/// `[scheduler]`, `[storage]` etc. as the runtime pieces land.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PresetManifest {
+    pub preset: PresetMetadata,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PresetMetadata {
+    pub name: String,
+    #[serde(default)]
+    pub description: String,
+    #[serde(default)]
+    pub version: String,
+    /// Names of skill subdirectories under `skills/`. Each must exist
+    /// with a `SKILL.md`. Order is irrelevant — the agent computes the
+    /// effective profile as a union and skill-name uniqueness is
+    /// enforced at attach time.
+    pub skills: Vec<String>,
+}
+
+/// What [`PresetLoader::load_dir`] returns: the manifest plus the
+/// loaded skills. The caller decides what to do with them — typically
+/// `agent.attach_skills(loaded.skills, vec![])`.
+#[derive(Debug)]
+pub struct LoadedPreset {
+    pub metadata: PresetMetadata,
+    pub skills: Vec<Skill>,
+}
+
+#[derive(Debug, Error)]
+pub enum PresetError {
+    #[error("preset.toml not found at {0}")]
+    ManifestMissing(PathBuf),
+    #[error("preset.toml at {0} could not be read: {1}")]
+    ManifestUnreadable(PathBuf, std::io::Error),
+    #[error("preset.toml at {0} failed to parse: {1}")]
+    ManifestParse(PathBuf, String),
+    #[error("preset declares skill '{skill}' but no SKILL.md exists at {expected}")]
+    SkillMissing { skill: String, expected: PathBuf },
+    #[error("preset declares no skills — at least one required")]
+    EmptySkillList,
+    #[error("preset name in manifest is empty")]
+    EmptyName,
+    #[error("preset declares duplicate skill name '{0}'")]
+    DuplicateSkill(String),
+}
+
+pub struct PresetLoader;
+
+impl PresetLoader {
+    /// Read a preset directory: parse the manifest, verify the
+    /// declared skill subdirectories exist and load each. Returns
+    /// `LoadedPreset` whose `skills` are ready to hand to
+    /// `Agent::attach_skills`.
+    ///
+    /// This loader does not enforce any cross-skill coherence
+    /// (permissions merge, name uniqueness, reachability of explicit-
+    /// only skills) — those checks fire in `attach_skills` per #76 and
+    /// #79, and are the same regardless of whether the skills came
+    /// from a preset or were attached individually.
+    pub fn load_dir(preset_dir: &Path) -> Result<LoadedPreset, PresetError> {
+        let manifest_path = preset_dir.join("preset.toml");
+        if !manifest_path.exists() {
+            return Err(PresetError::ManifestMissing(manifest_path));
+        }
+        let raw = std::fs::read_to_string(&manifest_path)
+            .map_err(|e| PresetError::ManifestUnreadable(manifest_path.clone(), e))?;
+        let manifest: PresetManifest = toml::from_str(&raw)
+            .map_err(|e| PresetError::ManifestParse(manifest_path.clone(), e.to_string()))?;
+
+        if manifest.preset.name.trim().is_empty() {
+            return Err(PresetError::EmptyName);
+        }
+        if manifest.preset.skills.is_empty() {
+            return Err(PresetError::EmptySkillList);
+        }
+        // Catch in-manifest duplicates early — `attach_skills` will
+        // also reject them, but a preset-author bug deserves a clearer
+        // pointer at the manifest line.
+        let mut seen = std::collections::BTreeSet::new();
+        for s in &manifest.preset.skills {
+            if !seen.insert(s.clone()) {
+                return Err(PresetError::DuplicateSkill(s.clone()));
+            }
+        }
+
+        let skills_root = preset_dir.join("skills");
+        let mut skills = Vec::with_capacity(manifest.preset.skills.len());
+        for declared in &manifest.preset.skills {
+            let skill_dir = skills_root.join(declared);
+            let skill_md = skill_dir.join("SKILL.md");
+            if !skill_md.exists() {
+                return Err(PresetError::SkillMissing {
+                    skill: declared.clone(),
+                    expected: skill_md,
+                });
+            }
+            let skill = SkillLoader::load_file(&skill_md).map_err(|e| {
+                // Surface the load error with preset context but keep
+                // the original variant family.
+                match e {
+                    AgentError::SkillLoad(msg) => PresetError::ManifestParse(
+                        skill_md.clone(),
+                        format!("skill '{declared}' failed to load: {msg}"),
+                    ),
+                    other => PresetError::ManifestParse(
+                        skill_md.clone(),
+                        format!("skill '{declared}' failed to load: {other}"),
+                    ),
+                }
+            })?;
+            skills.push(skill);
+        }
+
+        Ok(LoadedPreset {
+            metadata: manifest.preset,
+            skills,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write_skill_md(dir: &Path, name: &str, body: &str) {
+        std::fs::create_dir_all(dir).unwrap();
+        let frontmatter = format!(
+            "---\n\
+             name: {name}\n\
+             description: test skill {name}\n\
+             disable-model-invocation: false\n\
+             permissions: {{}}\n\
+             ---\n\n{body}\n",
+        );
+        std::fs::write(dir.join("SKILL.md"), frontmatter).unwrap();
+    }
+
+    #[test]
+    fn loads_a_minimal_preset() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        std::fs::write(
+            root.join("preset.toml"),
+            r#"
+[preset]
+name = "test"
+description = "test preset"
+version = "0.0.1"
+skills = ["alpha", "beta"]
+"#,
+        )
+        .unwrap();
+        write_skill_md(&root.join("skills/alpha"), "alpha", "alpha body");
+        write_skill_md(&root.join("skills/beta"), "beta", "beta body");
+
+        let loaded = PresetLoader::load_dir(root).unwrap();
+        assert_eq!(loaded.metadata.name, "test");
+        assert_eq!(loaded.metadata.skills, vec!["alpha", "beta"]);
+        assert_eq!(loaded.skills.len(), 2);
+        assert_eq!(loaded.skills[0].name, "alpha");
+        assert_eq!(loaded.skills[1].name, "beta");
+    }
+
+    #[test]
+    fn missing_manifest_is_an_error() {
+        let tmp = tempfile::tempdir().unwrap();
+        let err = PresetLoader::load_dir(tmp.path()).unwrap_err();
+        assert!(matches!(err, PresetError::ManifestMissing(_)));
+    }
+
+    #[test]
+    fn missing_skill_subdir_is_an_error() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        std::fs::write(
+            root.join("preset.toml"),
+            r#"
+[preset]
+name = "test"
+skills = ["only_declared"]
+"#,
+        )
+        .unwrap();
+        // No skills/only_declared/SKILL.md — should error.
+        let err = PresetLoader::load_dir(root).unwrap_err();
+        assert!(matches!(err, PresetError::SkillMissing { .. }));
+    }
+
+    #[test]
+    fn empty_skill_list_is_an_error() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        std::fs::write(
+            root.join("preset.toml"),
+            r#"
+[preset]
+name = "test"
+skills = []
+"#,
+        )
+        .unwrap();
+        let err = PresetLoader::load_dir(root).unwrap_err();
+        assert!(matches!(err, PresetError::EmptySkillList));
+    }
+
+    #[test]
+    fn duplicate_skill_in_manifest_is_an_error() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        std::fs::write(
+            root.join("preset.toml"),
+            r#"
+[preset]
+name = "test"
+skills = ["alpha", "alpha"]
+"#,
+        )
+        .unwrap();
+        write_skill_md(&root.join("skills/alpha"), "alpha", "alpha");
+        let err = PresetLoader::load_dir(root).unwrap_err();
+        assert!(matches!(err, PresetError::DuplicateSkill(_)));
+    }
+
+    #[test]
+    fn empty_name_is_an_error() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        std::fs::write(
+            root.join("preset.toml"),
+            r#"
+[preset]
+name = ""
+skills = ["alpha"]
+"#,
+        )
+        .unwrap();
+        write_skill_md(&root.join("skills/alpha"), "alpha", "alpha");
+        let err = PresetLoader::load_dir(root).unwrap_err();
+        assert!(matches!(err, PresetError::EmptyName));
+    }
+
+    #[test]
+    fn unknown_top_level_field_is_rejected() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        std::fs::write(
+            root.join("preset.toml"),
+            r#"
+[preset]
+name = "test"
+skills = ["alpha"]
+
+[unknown]
+foo = "bar"
+"#,
+        )
+        .unwrap();
+        write_skill_md(&root.join("skills/alpha"), "alpha", "alpha");
+        let err = PresetLoader::load_dir(root).unwrap_err();
+        assert!(matches!(err, PresetError::ManifestParse(_, _)));
+    }
+}

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -9,6 +9,7 @@ pub mod doctor;
 pub mod mcp;
 pub mod mcp_proxy;
 pub mod permission;
+pub mod preset;
 pub mod run;
 pub mod service;
 pub mod session;

--- a/crates/cli/src/commands/preset.rs
+++ b/crates/cli/src/commands/preset.rs
@@ -1,0 +1,52 @@
+//! `wirken preset` subcommands.
+//!
+//! Scope A — installation only. List prints bundled preset names;
+//! install copies a bundled preset to `~/.wirken/presets/<name>/` and
+//! verifies it loads cleanly via `PresetLoader`.
+
+use anyhow::{Context, Result, anyhow};
+use std::path::PathBuf;
+
+/// `wirken preset list` — print the names of bundled presets.
+pub async fn list() -> Result<()> {
+    let names = wirken_agent::bundled_presets::bundled_preset_names();
+    if names.is_empty() {
+        println!("(no bundled presets)");
+        return Ok(());
+    }
+    println!("Bundled presets:");
+    for name in names {
+        println!("  {name}");
+    }
+    Ok(())
+}
+
+/// `wirken preset install <name>` — write the bundled preset to
+/// `<data_dir>/presets/<name>/` and verify it loads.
+pub async fn install(name: &str) -> Result<()> {
+    let data_dir = super::data_dir()?;
+    let presets_root = data_dir.join("presets");
+    std::fs::create_dir_all(&presets_root)
+        .with_context(|| format!("create presets root at {}", presets_root.display()))?;
+    let dest: PathBuf = presets_root.join(name);
+
+    let count = wirken_agent::bundled_presets::install_bundled_preset(name, &dest)
+        .map_err(|e| anyhow!("install preset '{name}': {e}"))?;
+
+    let loaded = wirken_agent::preset::PresetLoader::load_dir(&dest)
+        .map_err(|e| anyhow!("preset '{name}' wrote {count} files but failed to load: {e}"))?;
+
+    println!("Installed preset '{name}' to {}", dest.display());
+    println!("  files written: {count}");
+    println!("  description:   {}", loaded.metadata.description);
+    println!(
+        "  skills:        {}",
+        loaded
+            .skills
+            .iter()
+            .map(|s| s.name.as_str())
+            .collect::<Vec<_>>()
+            .join(", ")
+    );
+    Ok(())
+}

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -75,6 +75,10 @@ enum Commands {
     #[command(subcommand)]
     Skills(SkillCommands),
 
+    /// Install and inspect bundled presets
+    #[command(subcommand)]
+    Preset(PresetCommands),
+
     /// Manage scheduled cron jobs
     #[command(subcommand)]
     Cron(CronCommands),
@@ -285,6 +289,17 @@ enum SkillCommands {
 }
 
 #[derive(Subcommand)]
+enum PresetCommands {
+    /// List bundled presets that can be installed
+    List,
+    /// Install a bundled preset to ~/.wirken/presets/<name>/
+    Install {
+        /// Preset name (e.g. `zirkel`)
+        name: String,
+    },
+}
+
+#[derive(Subcommand)]
 enum CronCommands {
     /// List scheduled cron jobs
     List {
@@ -488,6 +503,10 @@ async fn main() -> Result<()> {
             SkillCommands::List => commands::skills::list().await,
             SkillCommands::Sign { dir } => commands::skills::sign(&dir).await,
             SkillCommands::Verify { dir } => commands::skills::verify(&dir).await,
+        },
+        Commands::Preset(cmd) => match cmd {
+            PresetCommands::List => commands::preset::list().await,
+            PresetCommands::Install { name } => commands::preset::install(&name).await,
         },
         Commands::Agents(cmd) => match cmd {
             AgentCommands::Add => commands::agents::add().await,

--- a/preset/zirkel/preset.toml
+++ b/preset/zirkel/preset.toml
@@ -1,0 +1,24 @@
+# Zirkel preset declaration.
+#
+# A Wirken preset is a curated bundle of skills with a coherent posture —
+# permission profiles, invocation surfaces, and an inference policy that
+# survive merge at attach time. The agent loads the preset's skills as a
+# unit; the per-skill `permissions:` blocks (signed in each SKILL.md
+# frontmatter) merge to the agent's effective profile via the union
+# semantics established in #76.
+#
+# Channel adapter, sources.toml shape, fetcher/cron wiring, and the
+# librarian's retrieval surface are not yet implemented. This file
+# declares what the preset *is*; the loader (Scope A) verifies the
+# bundle is internally coherent. Later scopes wire the runtime pieces.
+
+[preset]
+name = "zirkel"
+description = "Locked-down research aggregator for non-technical users — daily fetch + librarian over the kept set"
+version = "0.1.0"
+
+# Skills bundled with this preset. Each must exist as a subdirectory
+# under `skills/` with a `SKILL.md`. Order is irrelevant — the agent
+# computes the effective profile as a union and skill-name uniqueness
+# is enforced at attach time.
+skills = ["aggregator", "librarian"]

--- a/preset/zirkel/skills/aggregator/SKILL.md
+++ b/preset/zirkel/skills/aggregator/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: aggregator
+description: Daily fetch from a fixed public allowlist; score against the user's interests file; cluster into themes; push the digest to the configured channel
+disable-model-invocation: true
+permissions:
+  tools:
+    allow: [exec, read_file, write_file, list_files]
+  egress:
+    mode: allowlist
+    domains:
+      # The egress allowlist is the same set as sources.toml. Until the
+      # loader derives one from the other, both are maintained by hand
+      # in this preset. Adding a source means editing both files in the
+      # same commit. Mismatch is an attach-time error in a later scope.
+      - export.arxiv.org
+      - papers.ssrn.com
+      - www.ftc.gov
+      - www.fcc.gov
+      - www.consumerfinance.gov
+      - www.hhs.gov
+      - edpb.europa.eu
+      - ico.org.uk
+      - www.cnil.fr
+      - api.congress.gov
+      - api.govinfo.gov
+      - www.federalregister.gov
+      - api.federalregister.gov
+  filesystem:
+    read_paths: ["<workspace>", "~/.wirken/zirkel"]
+    write_paths: ["~/.wirken/zirkel"]
+  inference:
+    allow: ["ollama", "privatemode"]
+    default: "ollama"
+---
+
+# Aggregator
+
+Fires once per day on a cron the operator configures. Performs a strict-pipeline run over the source allowlist:
+
+1. Fetch each source in `sources.toml` via the declared method (RSS / API / rate-limited scrape). The HTTP wrapper enforces the egress allowlist and (in a later scope) the per-host rate limit.
+2. Normalize fetched items into candidate records: `title`, `source`, `date`, `url`, `body_excerpt`, `citation_json`.
+3. Skip if the candidate's content hash is already in the seen set.
+4. Score the candidate's relevance against the user's interests file (`~/.wirken/zirkel/interests.toml`). Output: a float in `[0, 1]` plus a one-line `why_surfaced` rationale that names the matched interest.
+5. If the score crosses the keep threshold and no skip pattern matches, write the candidate to the local SQLite store. Otherwise, log the skip with reason.
+6. After all sources fetched, cluster the run's kept candidates into emergent themes using a small local embedding model.
+7. Render the digest as plain prose with footnote-ready citations on every item. Push to the configured channel adapter.
+
+Aggregator does not synthesize claims about the world. The digest reads as *"N items kept, M skipped. Today's themes: [theme A: items 1, 4; theme B: items 2, 3, 7]. Each item links to its source with a one-line why-surfaced explanation."* No "today the regulators are saying X" prose.
+
+This skill is `disable-model-invocation: true`. Reach it via `/aggregator` (manual run) or via the operator's cron that calls the underlying CLI command directly.
+
+## State
+
+- `~/.wirken/zirkel/zirkel.db` — SQLite database holding candidates, seen, themes, skipped_log, runs, and the cached interests snapshot per run.
+- `~/.wirken/zirkel/interests.toml` — user-editable; reloaded at the start of every run; a hash of the file is recorded in the audit log so changes are visible run-to-run.
+- `~/.wirken/zirkel/bodies/` — full bodies referenced by `candidates.body_full_path` for items where the excerpt is too small for retrieval.
+
+The aggregator and librarian share this state; both skills are scoped to the same `~/.wirken/zirkel/` directory by their permissions blocks.
+
+## Inputs the operator provides
+
+- `sources.toml` (preset-level, alongside `preset.toml`) — the addressable public set of sources.
+- `interests.toml` (per-user, in `~/.wirken/zirkel/`) — concepts, keywords, exclusions, optional source weight tweaks.
+- Channel adapter pin and target (configured at preset install).
+
+## What runtime pieces are not yet implemented
+
+The runtime fetcher, scheduled-run wiring, SQLite schema, and clustering integration are deferred to follow-up scopes. This skill declares the contract; the agent attaches it as part of the Zirkel preset; a later scope makes the daily run actually fire.

--- a/preset/zirkel/skills/librarian/SKILL.md
+++ b/preset/zirkel/skills/librarian/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: librarian
+description: Retrieval-only chat over the kept set in SQLite — no live fetch, no synthesized factual claims about the world
+disable-model-invocation: true
+permissions:
+  tools:
+    allow: [exec, read_file]
+  egress:
+    mode: deny
+  filesystem:
+    read_paths: ["~/.wirken/zirkel"]
+    write_paths: []
+  inference:
+    allow: ["ollama", "privatemode"]
+    default: "ollama"
+---
+
+# Librarian
+
+Answers chat queries against the kept set of candidates in `~/.wirken/zirkel/zirkel.db`. Retrieval-only. No live fetch — that's the aggregator's job. No synthesized factual claims about the world.
+
+Reach this skill via `/librarian <query>`.
+
+## What it returns
+
+For each query the librarian:
+
+1. Looks up matching candidates in SQLite by interest-match, keyword, or theme.
+2. Returns the matched candidates: `title`, `source`, `date`, `url`, `why_surfaced`.
+3. If asked to characterize *what the matched documents say*, answers strictly with attribution: *"per the FTC press release of 2026-04-12: …"*. Never as the librarian's own claim.
+4. When no kept candidate matches, refuses the question with a clear message: *"the kept set has nothing on this. Suggest you broaden the interests file or wait for tomorrow's run."* No guess, no fall-through to the LLM's training-set knowledge.
+
+## What it will not do
+
+- Reach the network. The `permissions.egress.mode = deny` block ensures this is enforced in code, not just prose.
+- Answer based on the LLM's training set rather than the retrieval result.
+- Aggregate a "summary of what the regulators said this month" that goes beyond paraphrase of specific kept items with attribution.
+- Write to the kept set. The `permissions.filesystem.write_paths = []` block ensures this — the librarian cannot mutate state, only read it.
+
+## Sharing state with the aggregator
+
+The librarian reads the same `~/.wirken/zirkel/` directory the aggregator writes. The aggregator declares write access; the librarian declares read access; the agent's effective filesystem profile (union) covers both.
+
+## What runtime pieces are not yet implemented
+
+The SQLite retrieval surface, query parser, and feedback-mark commands are deferred to follow-up scopes. This skill declares the contract; the agent attaches it as part of the Zirkel preset; a later scope wires it to actual database queries.

--- a/preset/zirkel/sources.toml
+++ b/preset/zirkel/sources.toml
@@ -1,0 +1,112 @@
+# Zirkel source allowlist.
+#
+# The single source of truth for what the aggregator may fetch. Each
+# entry pins a fetch method (RSS / API / scrape) and the host the
+# request goes to. The egress allowlist in `skills/aggregator/SKILL.md`
+# is the same set of hosts; until the loader derives one from the
+# other automatically, both are kept in sync by hand. Adding a source
+# means editing both files in the same commit.
+#
+# Schema is provisional — Scope A only ships the structure. Field
+# semantics get tightened when the fetcher lands.
+
+[[source]]
+class = "papers"
+name = "arxiv-cs-cy"
+host = "export.arxiv.org"
+method = "atom-api"
+endpoint = "https://export.arxiv.org/api/query?search_query=cat:cs.CY&sortBy=submittedDate&sortOrder=descending"
+notes = "arXiv computers-and-society. Public, no key. Honors >= 3s between requests."
+
+[[source]]
+class = "papers"
+name = "arxiv-cs-cr"
+host = "export.arxiv.org"
+method = "atom-api"
+endpoint = "https://export.arxiv.org/api/query?search_query=cat:cs.CR&sortBy=submittedDate&sortOrder=descending"
+notes = "arXiv cryptography-and-security. Same shape as cs-cy."
+
+[[source]]
+class = "papers"
+name = "ssrn-privacy"
+host = "papers.ssrn.com"
+method = "rss"
+endpoint = "https://papers.ssrn.com/sol3/JELJOUR_Results.cfm?form_name=journalBrowse&journal_id=privacy&fmt=rss"
+notes = "SSRN topic RSS. No public API; rate-limited by SSRN."
+
+[[source]]
+class = "regulator"
+name = "ftc-press"
+host = "www.ftc.gov"
+method = "rss"
+endpoint = "https://www.ftc.gov/news-events/news/press-releases/feed"
+
+[[source]]
+class = "regulator"
+name = "fcc-daily"
+host = "www.fcc.gov"
+method = "rss"
+endpoint = "https://www.fcc.gov/news-events/headlines/feed"
+
+[[source]]
+class = "regulator"
+name = "cfpb-blog"
+host = "www.consumerfinance.gov"
+method = "rss"
+endpoint = "https://www.consumerfinance.gov/about-us/blog/feed/"
+
+[[source]]
+class = "regulator"
+name = "hhs-ocr"
+host = "www.hhs.gov"
+method = "rss"
+endpoint = "https://www.hhs.gov/about/news/index.html"
+notes = "HIPAA enforcement actions. RSS endpoint may need verification at fetcher implementation time."
+
+[[source]]
+class = "regulator"
+name = "edpb"
+host = "edpb.europa.eu"
+method = "rss"
+endpoint = "https://edpb.europa.eu/news/news_en.rss"
+
+[[source]]
+class = "regulator"
+name = "ico-uk"
+host = "ico.org.uk"
+method = "rss"
+endpoint = "https://ico.org.uk/about-the-ico/media-centre/news-and-blogs/feed/"
+
+[[source]]
+class = "regulator"
+name = "cnil-fr"
+host = "www.cnil.fr"
+method = "rss"
+endpoint = "https://www.cnil.fr/fr/rss.xml"
+notes = "French content. Relevance scorer must accept multilingual input."
+
+[[source]]
+class = "legislative"
+name = "congress-gov"
+host = "api.congress.gov"
+method = "json-api"
+endpoint = "https://api.congress.gov/v3/"
+auth = "api_key_required"
+notes = "Free key. Stored in vault, never reaches the LLM."
+
+[[source]]
+class = "legislative"
+name = "govinfo-gov"
+host = "api.govinfo.gov"
+method = "json-api"
+endpoint = "https://api.govinfo.gov/"
+auth = "api_key_required"
+notes = "Free key. Federal Register filings, hearing transcripts."
+
+[[source]]
+class = "legislative"
+name = "federal-register"
+host = "www.federalregister.gov"
+method = "json-api"
+endpoint = "https://www.federalregister.gov/api/v1/"
+notes = "Public, no key."


### PR DESCRIPTION
Closes Gap G from `docs/zirkel/DESIGN.md` and lands the directory layout / `preset.toml` schema / install command that future Zirkel scopes (B: fetcher + storage + scheduler; C: full v1) sit on top of.

## What this is, and isn't

**Is:** the directory layout for preset bundles, the `preset.toml` schema, a loader that verifies the bundle is internally coherent, a CLI install command, the Zirkel preset's directory structure (`preset.toml`, two `SKILL.md` files with their `permissions:` blocks and `disable-model-invocation: true` declarations, a `sources.toml` allowlist).

**Isn't:** the runtime fetcher, scheduled-run wiring, SQLite schema, channel push, clustering. Those land in Scope B and C.

The smoke test (`zirkel_preset_loads_and_merges_into_a_resolved_effective_profile`) is the keystone: it installs the bundled preset to a temp directory, loads it via `PresetLoader::load_dir`, verifies both skills attach with explicit-only invocation, and checks that the per-skill `permissions:` blocks merge into a resolved effective profile with unanimous `inference.default = "ollama"`. That guarantees the bundle as committed is internally coherent.

## Directory layout

```
preset/zirkel/
  preset.toml                       # name, description, version, skills[]
  sources.toml                      # the addressable public source set
  skills/
    aggregator/SKILL.md             # daily fetch + score + cluster + push
    librarian/SKILL.md              # retrieval-only chat over the kept set
  prompts/                          # (placeholder; later scopes)
```

`preset.toml` schema is the minimum that's coherent for Scope A:

```toml
[preset]
name = "zirkel"
description = "..."
version = "0.1.0"
skills = ["aggregator", "librarian"]
```

`#[serde(deny_unknown_fields)]` on the manifest — adding a `[channel]` or `[scheduler]` table later is a deliberate schema change, not a silent drift.

## Coherence checks at preset-load time

- Manifest exists and parses.
- `preset.name` is non-empty.
- `preset.skills` is non-empty.
- No duplicate skill name in the manifest list.
- Every declared skill has a corresponding `skills/<name>/SKILL.md` on disk.

Cross-skill checks (permissions merge, attach-time skill-name uniqueness, reachability of explicit-only skills) live in `Agent::attach_skills` from #76 and #79; they fire identically whether skills came from a preset or were attached individually.

## Per-skill choices, made deliberately

Both Zirkel skills are `disable-model-invocation: true` — neither should auto-fire on a phrase match.

**aggregator:**
- `tools.allow: [exec, read_file, write_file, list_files]`
- `egress.mode: allowlist`, domains list maintained in sync with `sources.toml` (followup scope will derive one from the other automatically)
- `filesystem.read_paths: ["<workspace>", "~/.wirken/zirkel"]`
- `filesystem.write_paths: ["~/.wirken/zirkel"]`
- `inference.allow: ["ollama", "privatemode"]`, `inference.default: "ollama"`

**librarian:**
- `tools.allow: [exec, read_file]` — no writes
- `egress.mode: deny` — retrieval-only, never reaches the network
- `filesystem.read_paths: ["~/.wirken/zirkel"]`, `write_paths: []`
- `inference.allow: ["ollama", "privatemode"]`, `inference.default: "ollama"` (matches aggregator → unanimous merge)

## CLI

```
wirken preset list
wirken preset install zirkel
```

`install` writes the bundled files to `<data_dir>/presets/zirkel/` and runs `PresetLoader::load_dir` on the result so a corrupted bundle fails loud at install rather than silently at first use.

## Tests

11 new tests in `wirken-agent`:

- 6 in `preset.rs`: minimal preset loads, missing manifest, missing skill subdirectory, empty skill list, duplicate in manifest, empty name, unknown top-level field rejected.
- 4 in `bundled_presets.rs`: zirkel is bundled, install writes 4 files to the right paths, unknown preset name returns NotFound, the keystone integration smoke test (install → load → verify resolved profile).
- All ride through `cargo test --workspace` which is now at 251 agent unit tests + 47 across other crates, all green. `cargo fmt --check` clean. `cargo clippy --workspace --tests -- -D warnings` clean.

## Bypass invariant unchanged

This PR adds new bundled content but does not change the per-skill enforcement model from #76 / #82 / #83. The bypass invariant — only zero-skill agents reach `EffectiveProfile::Legacy` — still holds. Loading the Zirkel preset attaches two skills, both with explicit `permissions:` blocks; the agent's effective profile is `Resolved`.

## Next scope

Scope B (next session): per-skill SQLite (Gap B), rate limiter as transport (Gap E layered into the existing `EgressClient`), scheduled runs via OS cron (Gap F), wire the aggregator skill's runtime so a manual `/aggregator` invocation actually fetches.