### PR TITLE
zirkel scope b: rate limiter, skill-store crate, cron scheduling, orchestrator fetches one source

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6500,6 +6500,7 @@ dependencies = [
  "wirken-ipc",
  "wirken-mcp-proxy",
  "wirken-vault",
+ "wirken-zirkel",
 ]
 
 [[package]]
@@ -6566,6 +6567,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "wirken-skill-store"
+version = "0.9.1"
+dependencies = [
+ "rusqlite",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tracing",
+ "wirken-agent",
+]
+
+[[package]]
 name = "wirken-vault"
 version = "0.9.1"
 dependencies = [
@@ -6593,6 +6605,22 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "wirken-zirkel"
+version = "0.9.1"
+dependencies = [
+ "reqwest 0.13.2",
+ "rusqlite",
+ "serde",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "toml 0.8.23",
+ "tracing",
+ "wirken-agent",
+ "wirken-skill-store",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,9 @@ members = [
     "crates/agent",
     "crates/mcp-proxy",
     "crates/cli",
+    "crates/skill-store",
     "crates/webchat",
+    "crates/zirkel",
 ]
 
 [workspace.package]

--- a/crates/agent/src/egress.rs
+++ b/crates/agent/src/egress.rs
@@ -1,28 +1,31 @@
 //! Egress allowlist enforcement at the HTTP transport layer.
 //!
-//! [`EgressClient`] wraps `reqwest::Client` and refuses requests whose host
-//! is not in the agent's effective `permissions.egress.domains` allow-set.
-//! The check is host-based, pre-flight, and runs before any TCP connection
-//! is opened — denied hosts cost zero bytes on the wire.
-//!
-//! ## Layering with future rate limiting
-//!
-//! Per the design discussion under #76 (the rescoped permissions block),
-//! a future per-host rate limiter ("Zirkel's `RateLimitedClient`") sits
-//! *between* this client and `reqwest::Client`, NOT outside it:
+//! [`EgressClient`] is the outer transport wrapper:
 //!
 //! ```text
 //! caller → EgressClient → RateLimitedClient → reqwest::Client
 //! ```
 //!
-//! This ordering matters: a request to a denied host short-circuits at
-//! the egress check and never enters the rate-limit budget. Reversing
-//! the layers would have rate-limit accounting paying for requests
-//! that egress was always going to deny.
+//! The egress check runs first — host-based, pre-flight, before any
+//! TCP connection. Denied hosts cost zero bytes on the wire AND zero
+//! against the rate-limit budget. Only after the egress check passes
+//! does the request enter [`crate::rate_limit::RateLimitedClient`],
+//! where per-host daily caps and inter-request jitter are enforced
+//! before the underlying `reqwest::Client` actually issues bytes.
 //!
-//! When `RateLimitedClient` lands, this module's `inner` field becomes
-//! the rate-limited transport; the public surface (the `get`/`post`
-//! methods) is unchanged.
+//! Reversing the layers would have rate-limit accounting paying for
+//! requests egress was always going to deny.
+//!
+//! ## Two construction shapes
+//!
+//! - [`EgressClient::new`] — unrestricted rate limit (cap = u32::MAX,
+//!   no jitter). Used by the agent's tool registry where the LLM
+//!   drives `web_search` / `generate_image` ad hoc; there is no
+//!   daily-budget concept for chat-time tools.
+//! - [`EgressClient::with_rate_limit`] — caller supplies a
+//!   [`crate::rate_limit::RateLimitConfig`]. Used by the daily-fetch
+//!   orchestrator (Zirkel's `wirken zirkel run`) where the budget is
+//!   real and per-source.
 
 use std::collections::BTreeSet;
 use std::sync::{Arc, RwLock};
@@ -30,6 +33,7 @@ use std::sync::{Arc, RwLock};
 use reqwest::RequestBuilder;
 use thiserror::Error;
 
+use crate::rate_limit::{RateLimitConfig, RateLimitDenied, RateLimitedClient};
 use crate::skill_perms::{AllowSet, EffectiveProfile, EgressMode};
 
 /// What the wrapper enforces. Computed by [`Agent::attach_skills`] from
@@ -88,19 +92,29 @@ fn host_matches(host: &str, pattern: &str) -> bool {
     false
 }
 
-/// Pre-flight host check around `reqwest::Client`. The wrapper holds
-/// the enforcement policy in shared state so the agent can update it
-/// after attaching skills without rebuilding the client.
+/// Pre-flight host check around the inner [`RateLimitedClient`]. The
+/// wrapper holds the enforcement policy in shared state so the agent
+/// can update it after attaching skills without rebuilding the client.
 #[derive(Clone)]
 pub struct EgressClient {
-    inner: reqwest::Client,
+    inner: RateLimitedClient,
     enforcement: Arc<RwLock<EgressEnforcement>>,
 }
 
 impl EgressClient {
+    /// Construct with an unrestricted rate limit (no daily cap, no
+    /// jitter). Used by the agent's tool registry where chat-time
+    /// LLM-driven HTTP calls have no daily-budget concept.
     pub fn new() -> Self {
+        Self::with_rate_limit(RateLimitConfig::unrestricted_for_tests())
+    }
+
+    /// Construct with a caller-supplied rate-limit config. Used by the
+    /// daily-fetch orchestrator (Zirkel's `wirken zirkel run`) so each
+    /// source's per-day cap is honored at the transport layer.
+    pub fn with_rate_limit(config: RateLimitConfig) -> Self {
         Self {
-            inner: reqwest::Client::new(),
+            inner: RateLimitedClient::new(reqwest::Client::new(), config),
             enforcement: Arc::new(RwLock::new(EgressEnforcement::Unrestricted)),
         }
     }
@@ -114,19 +128,31 @@ impl EgressClient {
     }
 
     /// Pre-flight check: extract host from `url`, return `Err` if not
-    /// allowed. Caller must use the returned `RequestBuilder` rather
-    /// than constructing one against the inner client.
-    pub fn get(&self, url: &str) -> Result<RequestBuilder, EgressDenied> {
-        self.check(url)?;
-        Ok(self.inner.get(url))
+    /// allowed (egress) or if the rate-limit budget is exhausted.
+    /// Caller must use the returned `RequestBuilder` rather than
+    /// constructing one against the inner client.
+    ///
+    /// Async because the inner [`RateLimitedClient`] sleeps on
+    /// inter-request jitter when configured. With the unrestricted
+    /// rate-limit config (the agent default) jitter is zero and the
+    /// call returns synchronously without yielding.
+    pub async fn get(&self, url: &str) -> Result<RequestBuilder, HttpAccessDenied> {
+        self.check_egress(url).map_err(HttpAccessDenied::Egress)?;
+        self.inner
+            .get(url)
+            .await
+            .map_err(HttpAccessDenied::RateLimit)
     }
 
-    pub fn post(&self, url: &str) -> Result<RequestBuilder, EgressDenied> {
-        self.check(url)?;
-        Ok(self.inner.post(url))
+    pub async fn post(&self, url: &str) -> Result<RequestBuilder, HttpAccessDenied> {
+        self.check_egress(url).map_err(HttpAccessDenied::Egress)?;
+        self.inner
+            .post(url)
+            .await
+            .map_err(HttpAccessDenied::RateLimit)
     }
 
-    fn check(&self, url: &str) -> Result<(), EgressDenied> {
+    fn check_egress(&self, url: &str) -> Result<(), EgressDenied> {
         let host = url::Url::parse(url)
             .ok()
             .and_then(|u| u.host_str().map(|s| s.to_string()))
@@ -157,6 +183,18 @@ impl Default for EgressClient {
 )]
 pub struct EgressDenied {
     pub host: String,
+}
+
+/// Unified result for [`EgressClient`] gating. The two variants
+/// distinguish which layer rejected the request — egress allowlist
+/// (outer, runs first) or rate-limit budget (inner, only consulted
+/// after egress passes).
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
+pub enum HttpAccessDenied {
+    #[error(transparent)]
+    Egress(#[from] EgressDenied),
+    #[error(transparent)]
+    RateLimit(#[from] RateLimitDenied),
 }
 
 #[cfg(test)]
@@ -216,38 +254,78 @@ mod tests {
         assert!(!e.allows("api.other.com"));
     }
 
-    #[test]
-    fn client_get_denies_when_host_not_allowed() {
+    #[tokio::test]
+    async fn client_get_denies_when_host_not_allowed() {
         let c = EgressClient::new();
         c.set_enforcement(EgressEnforcement::Allowlist(BTreeSet::from([
             "allowed.example.com".to_string(),
         ])));
-        let err = c.get("https://denied.example.com/foo").unwrap_err();
-        assert_eq!(err.host, "denied.example.com");
+        let err = c.get("https://denied.example.com/foo").await.unwrap_err();
+        assert!(matches!(
+            err,
+            HttpAccessDenied::Egress(EgressDenied { ref host }) if host == "denied.example.com"
+        ));
     }
 
-    #[test]
-    fn client_get_allows_when_host_is_in_allowlist() {
+    #[tokio::test]
+    async fn client_get_allows_when_host_is_in_allowlist() {
         let c = EgressClient::new();
         c.set_enforcement(EgressEnforcement::Allowlist(BTreeSet::from([
             "allowed.example.com".to_string(),
         ])));
-        assert!(c.get("https://allowed.example.com/foo").is_ok());
+        assert!(c.get("https://allowed.example.com/foo").await.is_ok());
     }
 
-    #[test]
-    fn client_default_state_is_unrestricted() {
+    #[tokio::test]
+    async fn client_default_state_is_unrestricted() {
         let c = EgressClient::new();
-        assert!(c.get("https://anywhere.example.com/foo").is_ok());
+        assert!(c.get("https://anywhere.example.com/foo").await.is_ok());
     }
 
-    #[test]
-    fn unparseable_url_is_denied() {
+    #[tokio::test]
+    async fn unparseable_url_is_denied() {
         let c = EgressClient::new();
         c.set_enforcement(EgressEnforcement::Allowlist(BTreeSet::from([
             "ok.example.com".to_string(),
         ])));
-        let err = c.get("not a url").unwrap_err();
-        assert!(err.host.starts_with("<unparseable"));
+        let err = c.get("not a url").await.unwrap_err();
+        assert!(matches!(
+            err,
+            HttpAccessDenied::Egress(EgressDenied { ref host }) if host.starts_with("<unparseable")
+        ));
+    }
+
+    /// Layering correctness: a request to a denied host must fail at
+    /// the egress check WITHOUT consuming rate-limit budget. The
+    /// budget reads zero after the egress reject; a follow-up to an
+    /// allowed host succeeds and the budget shows exactly one
+    /// consumed slot.
+    #[tokio::test]
+    async fn egress_reject_does_not_consume_rate_budget() {
+        // Cap of 2 on the inner rate limiter so we can detect any
+        // accounting that escaped the egress short-circuit.
+        let c = EgressClient::with_rate_limit(RateLimitConfig {
+            default_daily_cap: 2,
+            jitter_min: std::time::Duration::ZERO,
+            jitter_max: std::time::Duration::ZERO,
+            ..Default::default()
+        });
+        c.set_enforcement(EgressEnforcement::Allowlist(BTreeSet::from([
+            "allowed.example.com".to_string(),
+        ])));
+
+        // Three rejected requests to a non-allowlisted host. None
+        // should consume budget — otherwise the cap would be hit
+        // before the legitimate request below.
+        for _ in 0..3 {
+            let err = c.get("https://denied.example.com/x").await.unwrap_err();
+            assert!(matches!(err, HttpAccessDenied::Egress(_)));
+        }
+
+        // Allowed host: should succeed twice, then hit the cap.
+        assert!(c.get("https://allowed.example.com/a").await.is_ok());
+        assert!(c.get("https://allowed.example.com/b").await.is_ok());
+        let err = c.get("https://allowed.example.com/c").await.unwrap_err();
+        assert!(matches!(err, HttpAccessDenied::RateLimit(_)));
     }
 }

--- a/crates/agent/src/egress.rs
+++ b/crates/agent/src/egress.rs
@@ -296,12 +296,11 @@ mod tests {
     }
 
     /// Layering correctness: a request to a denied host must fail at
-    /// the egress check WITHOUT consuming rate-limit budget. The
-    /// budget reads zero after the egress reject; a follow-up to an
-    /// allowed host succeeds and the budget shows exactly one
-    /// consumed slot.
+    /// the egress check WITHOUT consuming rate-limit budget. Named
+    /// to match `EgressDenied` so future readers grep this when
+    /// investigating layering questions.
     #[tokio::test]
-    async fn egress_reject_does_not_consume_rate_budget() {
+    async fn egress_denied_does_not_consume_rate_budget() {
         // Cap of 2 on the inner rate limiter so we can detect any
         // accounting that escaped the egress short-circuit.
         let c = EgressClient::with_rate_limit(RateLimitConfig {

--- a/crates/agent/src/lib.rs
+++ b/crates/agent/src/lib.rs
@@ -11,6 +11,7 @@ pub mod llm;
 pub mod llm_stream;
 pub mod mcp;
 pub mod preset;
+pub mod rate_limit;
 pub mod runtime;
 pub mod sandbox;
 pub(crate) mod sigv4;

--- a/crates/agent/src/rate_limit.rs
+++ b/crates/agent/src/rate_limit.rs
@@ -1,0 +1,409 @@
+//! Per-host daily-cap rate limiter for outbound HTTP.
+//!
+//! [`RateLimitedClient`] sits between [`crate::egress::EgressClient`] and
+//! the underlying `reqwest::Client`. Per the layering note in
+//! `crates/agent/src/egress.rs`:
+//!
+//! ```text
+//! caller → EgressClient → RateLimitedClient → reqwest::Client
+//! ```
+//!
+//! Egress-allowlist denials short-circuit at the outer layer and never
+//! consume rate budget. Rate-budget rejections happen here, after the
+//! egress check has already passed — so a denied host never costs against
+//! the budget, and a budget-exhausted host fails after the egress check
+//! confirmed it was an *allowed* host that hit its cap.
+//!
+//! ## What's enforced
+//!
+//! - Per-host daily count, default cap 2. Overrides supported.
+//! - Inter-request jitter delay. Default 3–12s, applied between
+//!   consecutive requests to the same host. Disabled by passing zero
+//!   for both bounds (test-only).
+//!
+//! ## What isn't enforced (yet)
+//!
+//! - Persistence across process restarts. State is in-memory; a
+//!   restart resets counters. Persistence to a SkillStore-shared
+//!   SQLite is the right shape and lands when the orchestrator gains
+//!   crash-recovery semantics. For Scope B the daily-run model
+//!   (`wirken zirkel run` once per cron tick, then exit) means the
+//!   process-lifetime state is the run-lifetime state — adequate.
+//! - Cross-process coordination. If two `wirken zirkel run` processes
+//!   race, they'll each have their own counter. Cron is one-shot per
+//!   tick so this isn't a real risk for Zirkel; documented as a
+//!   constraint for any future caller that wants concurrent fetches.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant, SystemTime};
+
+use rand::RngExt;
+use reqwest::RequestBuilder;
+use thiserror::Error;
+use url::Url;
+
+/// Configuration for [`RateLimitedClient`].
+#[derive(Debug, Clone)]
+pub struct RateLimitConfig {
+    /// Default cap for hosts without an entry in `per_host_overrides`.
+    pub default_daily_cap: u32,
+    /// Per-host caps that override the default. Useful for sources
+    /// whose published rate limits permit a higher count
+    /// (e.g. `api.congress.gov` at 30/day).
+    pub per_host_overrides: HashMap<String, u32>,
+    /// Inter-request jitter range (inclusive lower bound, exclusive
+    /// upper). Each request to a host that has already been hit waits
+    /// for a uniformly-sampled delay in `[min, max)` since its last
+    /// request. `Duration::ZERO` for both disables jitter (tests).
+    pub jitter_min: Duration,
+    pub jitter_max: Duration,
+}
+
+impl Default for RateLimitConfig {
+    fn default() -> Self {
+        Self {
+            default_daily_cap: 2,
+            per_host_overrides: HashMap::new(),
+            jitter_min: Duration::from_secs(3),
+            jitter_max: Duration::from_secs(12),
+        }
+    }
+}
+
+impl RateLimitConfig {
+    /// Test-only config: no caps, no delay. Use this in tests of
+    /// composing layers (e.g. an `EgressClient` test) when the rate
+    /// limiter should be a transparent passthrough.
+    pub fn unrestricted_for_tests() -> Self {
+        Self {
+            default_daily_cap: u32::MAX,
+            per_host_overrides: HashMap::new(),
+            jitter_min: Duration::ZERO,
+            jitter_max: Duration::ZERO,
+        }
+    }
+}
+
+/// Per-host counter state.
+#[derive(Debug)]
+struct HostState {
+    /// Number of requests consumed in the current 24h window.
+    count: u32,
+    /// Wall-clock start of the current window. When `now` crosses
+    /// `window_start + 24h` the counter resets.
+    window_start: SystemTime,
+    /// Monotonic timestamp of the last successful request, used for
+    /// inter-request jitter.
+    last_request: Option<Instant>,
+}
+
+#[derive(Debug)]
+struct RateState {
+    counters: HashMap<String, HostState>,
+}
+
+impl RateState {
+    fn new() -> Self {
+        Self {
+            counters: HashMap::new(),
+        }
+    }
+}
+
+/// HTTP client with per-host daily caps and inter-request jitter.
+#[derive(Clone)]
+pub struct RateLimitedClient {
+    inner: reqwest::Client,
+    config: RateLimitConfig,
+    state: Arc<Mutex<RateState>>,
+}
+
+impl RateLimitedClient {
+    pub fn new(inner: reqwest::Client, config: RateLimitConfig) -> Self {
+        Self {
+            inner,
+            config,
+            state: Arc::new(Mutex::new(RateState::new())),
+        }
+    }
+
+    /// Pre-flight: extract host from `url`, reserve a slot in the
+    /// budget. On accept, returns `Ok(())` and the caller proceeds
+    /// with a normal `reqwest` request. On reject, returns
+    /// `Err(RateLimitDenied)` with the reason.
+    ///
+    /// This method is `async` because jitter sleeps are observed here
+    /// (when configured non-zero). Callers that don't want to wait
+    /// should disable jitter.
+    pub async fn check_and_reserve(&self, url: &str) -> Result<(), RateLimitDenied> {
+        let host = host_from_url(url)?;
+        let cap = self
+            .config
+            .per_host_overrides
+            .get(&host)
+            .copied()
+            .unwrap_or(self.config.default_daily_cap);
+
+        // Hold the lock only across counter mutation; release before
+        // the (potentially long) jitter sleep.
+        let sleep_for = {
+            let mut state = self.state.lock().map_err(|_| RateLimitDenied::Poisoned)?;
+            let now_wall = SystemTime::now();
+            let now_mono = Instant::now();
+            let entry = state
+                .counters
+                .entry(host.clone())
+                .or_insert_with(|| HostState {
+                    count: 0,
+                    window_start: now_wall,
+                    last_request: None,
+                });
+
+            // Window roll-over.
+            if let Ok(elapsed) = now_wall.duration_since(entry.window_start) {
+                if elapsed >= Duration::from_secs(24 * 60 * 60) {
+                    entry.count = 0;
+                    entry.window_start = now_wall;
+                    entry.last_request = None;
+                }
+            }
+
+            if entry.count >= cap {
+                return Err(RateLimitDenied::DailyCapExceeded {
+                    host,
+                    cap,
+                    consumed: entry.count,
+                });
+            }
+
+            // Compute jitter sleep before incrementing — if jitter is
+            // disabled (both bounds zero) skip the sleep entirely.
+            let sleep_for = if let Some(prev) = entry.last_request {
+                jitter_sleep(prev, now_mono, &self.config)
+            } else {
+                Duration::ZERO
+            };
+
+            entry.count += 1;
+            entry.last_request = Some(now_mono);
+            sleep_for
+        };
+
+        if sleep_for > Duration::ZERO {
+            tokio::time::sleep(sleep_for).await;
+        }
+        Ok(())
+    }
+
+    /// Compose with the inner client: `get(url)` after a successful
+    /// `check_and_reserve`. Returns the unbuilt `RequestBuilder`.
+    pub async fn get(&self, url: &str) -> Result<RequestBuilder, RateLimitDenied> {
+        self.check_and_reserve(url).await?;
+        Ok(self.inner.get(url))
+    }
+
+    pub async fn post(&self, url: &str) -> Result<RequestBuilder, RateLimitDenied> {
+        self.check_and_reserve(url).await?;
+        Ok(self.inner.post(url))
+    }
+
+    /// Snapshot the current count for a host. Test-only.
+    #[cfg(test)]
+    pub(crate) fn count_for_test(&self, host: &str) -> u32 {
+        self.state
+            .lock()
+            .map(|s| s.counters.get(host).map(|h| h.count).unwrap_or(0))
+            .unwrap_or(0)
+    }
+}
+
+fn jitter_sleep(prev: Instant, now: Instant, config: &RateLimitConfig) -> Duration {
+    if config.jitter_max == Duration::ZERO && config.jitter_min == Duration::ZERO {
+        return Duration::ZERO;
+    }
+    let elapsed = now.saturating_duration_since(prev);
+    let target = if config.jitter_max <= config.jitter_min {
+        config.jitter_min
+    } else {
+        let mut rng = rand::rng();
+        let span = config.jitter_max - config.jitter_min;
+        let extra = Duration::from_nanos(rng.random_range(0..span.as_nanos() as u64));
+        config.jitter_min + extra
+    };
+    if elapsed >= target {
+        Duration::ZERO
+    } else {
+        target - elapsed
+    }
+}
+
+fn host_from_url(url: &str) -> Result<String, RateLimitDenied> {
+    let parsed = Url::parse(url).map_err(|_| RateLimitDenied::UnparseableUrl(url.to_string()))?;
+    parsed
+        .host_str()
+        .map(|h| h.to_string())
+        .ok_or_else(|| RateLimitDenied::UnparseableUrl(url.to_string()))
+}
+
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
+pub enum RateLimitDenied {
+    #[error("daily cap exceeded for host '{host}' ({consumed}/{cap})")]
+    DailyCapExceeded {
+        host: String,
+        cap: u32,
+        consumed: u32,
+    },
+    #[error("unparseable URL '{0}'")]
+    UnparseableUrl(String),
+    #[error("rate limiter state lock poisoned")]
+    Poisoned,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn unrestricted_client() -> RateLimitedClient {
+        RateLimitedClient::new(
+            reqwest::Client::new(),
+            RateLimitConfig::unrestricted_for_tests(),
+        )
+    }
+
+    fn capped_client(cap: u32) -> RateLimitedClient {
+        RateLimitedClient::new(
+            reqwest::Client::new(),
+            RateLimitConfig {
+                default_daily_cap: cap,
+                jitter_min: Duration::ZERO,
+                jitter_max: Duration::ZERO,
+                ..Default::default()
+            },
+        )
+    }
+
+    #[tokio::test]
+    async fn unrestricted_passes_through() {
+        let c = unrestricted_client();
+        for _ in 0..5 {
+            assert!(c.check_and_reserve("https://example.com/foo").await.is_ok());
+        }
+        assert_eq!(c.count_for_test("example.com"), 5);
+    }
+
+    #[tokio::test]
+    async fn cap_exceeded_returns_denied() {
+        let c = capped_client(2);
+        assert!(c.check_and_reserve("https://x.com/a").await.is_ok());
+        assert!(c.check_and_reserve("https://x.com/b").await.is_ok());
+        let err = c.check_and_reserve("https://x.com/c").await.unwrap_err();
+        assert!(matches!(
+            err,
+            RateLimitDenied::DailyCapExceeded {
+                consumed: 2,
+                cap: 2,
+                ..
+            }
+        ));
+    }
+
+    #[tokio::test]
+    async fn cap_is_per_host() {
+        let c = capped_client(2);
+        assert!(c.check_and_reserve("https://a.com/x").await.is_ok());
+        assert!(c.check_and_reserve("https://a.com/y").await.is_ok());
+        // a.com is at cap, b.com is fresh.
+        assert!(c.check_and_reserve("https://a.com/z").await.is_err());
+        assert!(c.check_and_reserve("https://b.com/x").await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn per_host_override_raises_cap() {
+        let mut overrides = HashMap::new();
+        overrides.insert("api.example.com".to_string(), 5);
+        let c = RateLimitedClient::new(
+            reqwest::Client::new(),
+            RateLimitConfig {
+                default_daily_cap: 2,
+                per_host_overrides: overrides,
+                jitter_min: Duration::ZERO,
+                jitter_max: Duration::ZERO,
+            },
+        );
+        for _ in 0..5 {
+            assert!(
+                c.check_and_reserve("https://api.example.com/foo")
+                    .await
+                    .is_ok()
+            );
+        }
+        assert!(
+            c.check_and_reserve("https://api.example.com/foo")
+                .await
+                .is_err()
+        );
+        // Default cap still applies to other hosts.
+        assert!(c.check_and_reserve("https://other.com/x").await.is_ok());
+        assert!(c.check_and_reserve("https://other.com/y").await.is_ok());
+        assert!(c.check_and_reserve("https://other.com/z").await.is_err());
+    }
+
+    #[tokio::test]
+    async fn unparseable_url_is_denied() {
+        let c = unrestricted_client();
+        let err = c.check_and_reserve("not a url").await.unwrap_err();
+        assert!(matches!(err, RateLimitDenied::UnparseableUrl(_)));
+        // No counter is created for an unparseable URL.
+        assert_eq!(c.count_for_test("not a url"), 0);
+    }
+
+    #[tokio::test]
+    async fn rejected_request_does_not_consume_budget() {
+        // Cap is 2; consume both, third returns Err. The Err must NOT
+        // increment the count beyond 2 — otherwise budget accounting
+        // is off.
+        let c = capped_client(2);
+        c.check_and_reserve("https://x.com/a").await.unwrap();
+        c.check_and_reserve("https://x.com/b").await.unwrap();
+        let _ = c.check_and_reserve("https://x.com/c").await;
+        assert_eq!(c.count_for_test("x.com"), 2);
+    }
+
+    #[tokio::test]
+    async fn jitter_disabled_runs_without_delay() {
+        // unrestricted_for_tests sets both bounds to zero.
+        let c = unrestricted_client();
+        let start = Instant::now();
+        for _ in 0..3 {
+            c.check_and_reserve("https://x.com/foo").await.unwrap();
+        }
+        let elapsed = start.elapsed();
+        // With zero jitter, three requests should be near-instant.
+        assert!(
+            elapsed < Duration::from_millis(50),
+            "expected <50ms for zero-jitter; got {elapsed:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn jitter_enforces_inter_request_delay() {
+        let c = RateLimitedClient::new(
+            reqwest::Client::new(),
+            RateLimitConfig {
+                default_daily_cap: 100,
+                per_host_overrides: HashMap::new(),
+                jitter_min: Duration::from_millis(20),
+                jitter_max: Duration::from_millis(40),
+            },
+        );
+        let start = Instant::now();
+        c.check_and_reserve("https://y.com/a").await.unwrap();
+        c.check_and_reserve("https://y.com/b").await.unwrap();
+        let elapsed = start.elapsed();
+        assert!(
+            elapsed >= Duration::from_millis(20),
+            "expected >=20ms for second request; got {elapsed:?}"
+        );
+    }
+}

--- a/crates/agent/src/tool.rs
+++ b/crates/agent/src/tool.rs
@@ -534,7 +534,8 @@ impl ToolRegistry {
         let resp = self
             .http
             .post("https://html.duckduckgo.com/html/")
-            .map_err(|e| AgentError::EgressDenied { host: e.host })?
+            .await
+            .map_err(map_http_access_denied)?
             .header("User-Agent", "Wirken/1.0")
             .header("Content-Type", "application/x-www-form-urlencoded")
             .body(format!("q={}", urlencoding_encode(query)))
@@ -633,7 +634,8 @@ impl ToolRegistry {
         let resp = self
             .http
             .post(&url)
-            .map_err(|e| AgentError::EgressDenied { host: e.host })?
+            .await
+            .map_err(map_http_access_denied)?
             .header("Authorization", format!("Bearer {api_key}"))
             .json(&body)
             .send()
@@ -702,6 +704,21 @@ struct SearchResult {
     title: String,
     url: String,
     snippet: String,
+}
+
+/// Map an [`crate::egress::HttpAccessDenied`] from the wrapped HTTP
+/// client into an [`AgentError`]. The agent's tool dispatcher (#76
+/// Phase 2.2) intercepts both variants and emits the appropriate
+/// `SkillPermissionDenied` audit event before surfacing a non-success
+/// `ToolResult`. The agent-tool case (web_search / generate_image)
+/// runs with an unrestricted rate limit by default so the
+/// `RateLimit` arm only fires when an operator has deliberately
+/// installed a stricter config.
+fn map_http_access_denied(e: crate::egress::HttpAccessDenied) -> AgentError {
+    match e {
+        crate::egress::HttpAccessDenied::Egress(d) => AgentError::EgressDenied { host: d.host },
+        crate::egress::HttpAccessDenied::RateLimit(d) => AgentError::Tool(format!("{d}")),
+    }
 }
 
 /// Parse DuckDuckGo HTML Lite search results.

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -15,6 +15,7 @@ wirken-vault = { path = "../vault" }
 wirken-audit = { path = "../audit" }
 wirken-gateway = { path = "../gateway" }
 wirken-agent = { path = "../agent" }
+wirken-zirkel = { path = "../zirkel" }
 wirken-ipc = { path = "../ipc" }
 wirken-mcp-proxy = { path = "../mcp-proxy" }
 wirken-adapter-telegram = { path = "../adapter-telegram" }

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -16,6 +16,7 @@ pub mod session;
 pub mod setup;
 pub mod skills;
 pub mod webchat;
+pub mod zirkel;
 
 use std::io::Write;
 use std::path::{Path, PathBuf};

--- a/crates/cli/src/commands/preset.rs
+++ b/crates/cli/src/commands/preset.rs
@@ -1,8 +1,19 @@
 //! `wirken preset` subcommands.
 //!
-//! Scope A — installation only. List prints bundled preset names;
-//! install copies a bundled preset to `~/.wirken/presets/<name>/` and
-//! verifies it loads cleanly via `PresetLoader`.
+//! Scope A: list / install. Scope B: schedule / unschedule, which wire
+//! a cron entry that calls `wirken zirkel run` (or the per-preset
+//! orchestrator entry) on a daily tick.
+//!
+//! Cron manipulation goes through the OS's `crontab` binary. Wirken-
+//! managed entries are bracketed with marker comments so unschedule
+//! can remove exactly the entry it added without disturbing user-
+//! authored cron lines:
+//!
+//! ```text
+//! # >>> wirken preset:zirkel
+//! 0 6 * * * /path/to/wirken zirkel run
+//! # <<< wirken preset:zirkel
+//! ```
 
 use anyhow::{Context, Result, anyhow};
 use std::path::PathBuf;
@@ -49,4 +60,243 @@ pub async fn install(name: &str) -> Result<()> {
             .join(", ")
     );
     Ok(())
+}
+
+/// `wirken preset schedule <name>` — add a cron entry that runs the
+/// preset's orchestrator daily at 06:00 in the user's local timezone.
+pub async fn schedule(name: &str) -> Result<()> {
+    // Verify the preset is installed before scheduling so we don't
+    // wire a cron entry pointing at a missing preset.
+    let data_dir = super::data_dir()?;
+    let preset_dir = data_dir.join("presets").join(name);
+    if !preset_dir.join("preset.toml").exists() {
+        return Err(anyhow!(
+            "preset '{name}' is not installed at {}; run `wirken preset install {name}` first",
+            preset_dir.display(),
+        ));
+    }
+
+    let wirken_path =
+        std::env::current_exe().with_context(|| "resolve current wirken binary path")?;
+    let wirken_path = wirken_path
+        .to_str()
+        .ok_or_else(|| anyhow!("wirken binary path is not valid UTF-8"))?
+        .to_string();
+
+    let entry_command = match name {
+        "zirkel" => format!("{wirken_path} zirkel run"),
+        other => {
+            return Err(anyhow!(
+                "preset '{other}' has no orchestrator entry yet — only 'zirkel' is supported in Scope B"
+            ));
+        }
+    };
+
+    let current = read_crontab()?;
+    let updated = with_managed_entry(&current, name, "0 6 * * *", &entry_command);
+    write_crontab(&updated)?;
+
+    println!("Scheduled preset '{name}': daily at 06:00 local time.");
+    println!("  command: {entry_command}");
+    Ok(())
+}
+
+/// `wirken preset unschedule <name>` — remove the wirken-managed cron
+/// entry for `<name>`. Leaves user-authored cron lines untouched.
+pub async fn unschedule(name: &str) -> Result<()> {
+    let current = read_crontab()?;
+    let (updated, removed) = without_managed_entry(&current, name);
+    if !removed {
+        println!("No wirken-managed cron entry found for preset '{name}'.");
+        return Ok(());
+    }
+    write_crontab(&updated)?;
+    println!("Removed wirken-managed cron entry for preset '{name}'.");
+    Ok(())
+}
+
+// --- crontab helpers -------------------------------------------------------
+
+fn marker_open(preset: &str) -> String {
+    format!("# >>> wirken preset:{preset}")
+}
+
+fn marker_close(preset: &str) -> String {
+    format!("# <<< wirken preset:{preset}")
+}
+
+/// Insert (or replace) the wirken-managed cron block for `preset`.
+/// The block is bracketed with marker comments so `unschedule` can
+/// drop exactly the lines it added.
+pub(crate) fn with_managed_entry(
+    current: &str,
+    preset: &str,
+    schedule: &str,
+    command: &str,
+) -> String {
+    let (without_existing, _) = without_managed_entry(current, preset);
+    let mut out = without_existing.trim_end().to_string();
+    if !out.is_empty() {
+        out.push('\n');
+    }
+    out.push_str(&marker_open(preset));
+    out.push('\n');
+    out.push_str(schedule);
+    out.push(' ');
+    out.push_str(command);
+    out.push('\n');
+    out.push_str(&marker_close(preset));
+    out.push('\n');
+    out
+}
+
+/// Remove the wirken-managed cron block for `preset` if present.
+/// Returns the new crontab and a flag indicating whether anything was
+/// removed. Lines outside the marker block are preserved verbatim.
+pub(crate) fn without_managed_entry(current: &str, preset: &str) -> (String, bool) {
+    let open = marker_open(preset);
+    let close = marker_close(preset);
+    let mut out_lines: Vec<&str> = Vec::new();
+    let mut inside = false;
+    let mut removed = false;
+    for line in current.lines() {
+        if line.trim() == open {
+            inside = true;
+            removed = true;
+            continue;
+        }
+        if inside && line.trim() == close {
+            inside = false;
+            continue;
+        }
+        if !inside {
+            out_lines.push(line);
+        }
+    }
+    let mut joined = out_lines.join("\n");
+    if !joined.is_empty() && !joined.ends_with('\n') {
+        joined.push('\n');
+    }
+    (joined, removed)
+}
+
+fn read_crontab() -> Result<String> {
+    let output = std::process::Command::new("crontab")
+        .arg("-l")
+        .output()
+        .with_context(|| "invoke `crontab -l` (is the crontab binary on PATH?)")?;
+    if output.status.success() {
+        return Ok(String::from_utf8_lossy(&output.stdout).into_owned());
+    }
+    // `crontab -l` exits non-zero when no crontab is set for the user.
+    // The stderr typically reads "no crontab for <user>"; treat as empty.
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    if stderr.contains("no crontab") {
+        return Ok(String::new());
+    }
+    Err(anyhow!(
+        "crontab -l failed (status {:?}): {}",
+        output.status,
+        stderr
+    ))
+}
+
+fn write_crontab(contents: &str) -> Result<()> {
+    use std::io::Write;
+    let mut child = std::process::Command::new("crontab")
+        .arg("-")
+        .stdin(std::process::Stdio::piped())
+        .spawn()
+        .with_context(|| "spawn `crontab -`")?;
+    child
+        .stdin
+        .as_mut()
+        .ok_or_else(|| anyhow!("crontab stdin not available"))?
+        .write_all(contents.as_bytes())
+        .with_context(|| "write to crontab stdin")?;
+    let status = child.wait().with_context(|| "wait for crontab process")?;
+    if !status.success() {
+        return Err(anyhow!("crontab - exited with status {status:?}"));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn with_managed_entry_appends_to_empty() {
+        let result = with_managed_entry("", "zirkel", "0 6 * * *", "/bin/wirken zirkel run");
+        assert!(result.contains("# >>> wirken preset:zirkel"));
+        assert!(result.contains("0 6 * * * /bin/wirken zirkel run"));
+        assert!(result.contains("# <<< wirken preset:zirkel"));
+    }
+
+    #[test]
+    fn with_managed_entry_replaces_existing_block() {
+        let initial = "# >>> wirken preset:zirkel\n0 5 * * * /old/path zirkel run\n# <<< wirken preset:zirkel\n";
+        let updated = with_managed_entry(initial, "zirkel", "0 6 * * *", "/new/path zirkel run");
+        assert!(!updated.contains("/old/path"));
+        assert!(updated.contains("/new/path"));
+        // Block should appear exactly once.
+        assert_eq!(updated.matches("# >>> wirken preset:zirkel").count(), 1);
+    }
+
+    #[test]
+    fn with_managed_entry_preserves_user_lines() {
+        let initial = "0 0 * * * /usr/bin/some-other-job\n";
+        let updated = with_managed_entry(initial, "zirkel", "0 6 * * *", "/bin/wirken zirkel run");
+        assert!(updated.contains("/usr/bin/some-other-job"));
+        assert!(updated.contains("# >>> wirken preset:zirkel"));
+    }
+
+    #[test]
+    fn without_managed_entry_drops_block() {
+        let initial = "# >>> wirken preset:zirkel\n0 6 * * * /bin/wirken zirkel run\n# <<< wirken preset:zirkel\n";
+        let (out, removed) = without_managed_entry(initial, "zirkel");
+        assert!(removed);
+        assert!(!out.contains("zirkel"));
+    }
+
+    #[test]
+    fn without_managed_entry_preserves_user_lines() {
+        let initial = concat!(
+            "0 0 * * * /usr/bin/backup\n",
+            "# >>> wirken preset:zirkel\n",
+            "0 6 * * * /bin/wirken zirkel run\n",
+            "# <<< wirken preset:zirkel\n",
+            "30 1 * * * /usr/bin/cleanup\n",
+        );
+        let (out, removed) = without_managed_entry(initial, "zirkel");
+        assert!(removed);
+        assert!(out.contains("/usr/bin/backup"));
+        assert!(out.contains("/usr/bin/cleanup"));
+        assert!(!out.contains("wirken preset:zirkel"));
+    }
+
+    #[test]
+    fn without_managed_entry_returns_false_when_no_block_present() {
+        let initial = "0 0 * * * /usr/bin/backup\n";
+        let (out, removed) = without_managed_entry(initial, "zirkel");
+        assert!(!removed);
+        assert_eq!(out.trim_end(), "0 0 * * * /usr/bin/backup");
+    }
+
+    #[test]
+    fn without_managed_entry_only_drops_block_for_named_preset() {
+        let initial = concat!(
+            "# >>> wirken preset:zirkel\n",
+            "0 6 * * * /bin/wirken zirkel run\n",
+            "# <<< wirken preset:zirkel\n",
+            "# >>> wirken preset:other\n",
+            "0 7 * * * /bin/wirken other run\n",
+            "# <<< wirken preset:other\n",
+        );
+        let (out, removed) = without_managed_entry(initial, "zirkel");
+        assert!(removed);
+        assert!(!out.contains("preset:zirkel"));
+        assert!(out.contains("preset:other"));
+        assert!(out.contains("/bin/wirken other run"));
+    }
 }

--- a/crates/cli/src/commands/zirkel.rs
+++ b/crates/cli/src/commands/zirkel.rs
@@ -1,0 +1,50 @@
+//! `wirken zirkel` subcommands.
+//!
+//! Entry point for the Zirkel orchestrator. Both the cron-fired and the
+//! manual run path call into here. Scope B fetches one source through
+//! the policed transport and writes one candidate to the per-skill
+//! SQLite. Scoring, clustering, theme naming, and digest push are
+//! Scope C.
+
+use anyhow::{Result, anyhow};
+use wirken_agent::rate_limit::RateLimitConfig;
+use wirken_zirkel::orchestrator::{OrchestratorConfig, run as orchestrator_run};
+
+/// `wirken zirkel run` — load the installed Zirkel preset, fetch the
+/// first source, write a candidate row, exit. Cron and manual entry
+/// share this code path.
+pub async fn run() -> Result<()> {
+    let data_dir = super::data_dir()?;
+    let preset_dir = data_dir.join("presets").join("zirkel");
+    if !preset_dir.join("preset.toml").exists() {
+        return Err(anyhow!(
+            "Zirkel preset is not installed at {}; run `wirken preset install zirkel` first",
+            preset_dir.display(),
+        ));
+    }
+
+    // Storage lives at <data_dir>/zirkel/. Must be inside the
+    // aggregator skill's filesystem.write_paths allow-set; the
+    // bundled aggregator declares `~/.wirken/zirkel` which resolves
+    // to that directory. `SkillStore::open` fails loud if the path
+    // is outside the policy.
+    let storage_dir = data_dir.join("zirkel");
+
+    let summary = orchestrator_run(OrchestratorConfig {
+        preset_dir,
+        storage_dir,
+        rate_limit: RateLimitConfig::default(),
+    })
+    .await
+    .map_err(|e| anyhow!("zirkel orchestrator: {e}"))?;
+
+    println!("Zirkel run complete:");
+    println!(
+        "  source:        {} ({})",
+        summary.source_name, summary.source_url
+    );
+    println!("  bytes fetched: {}", summary.bytes_fetched);
+    println!("  candidate id:  {}", summary.candidate_id);
+    println!("(Scope B: one source per run, no scoring or digest yet — Scope C wires those.)");
+    Ok(())
+}

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -79,6 +79,10 @@ enum Commands {
     #[command(subcommand)]
     Preset(PresetCommands),
 
+    /// Run the Zirkel orchestrator (cron or manual)
+    #[command(subcommand)]
+    Zirkel(ZirkelCommands),
+
     /// Manage scheduled cron jobs
     #[command(subcommand)]
     Cron(CronCommands),
@@ -297,6 +301,24 @@ enum PresetCommands {
         /// Preset name (e.g. `zirkel`)
         name: String,
     },
+    /// Wire a daily cron entry that runs the preset's orchestrator
+    Schedule {
+        /// Preset name
+        name: String,
+    },
+    /// Remove the wirken-managed cron entry for the preset
+    Unschedule {
+        /// Preset name
+        name: String,
+    },
+}
+
+#[derive(Subcommand)]
+enum ZirkelCommands {
+    /// Run the Zirkel orchestrator once (cron or manual entry).
+    /// In Scope B this is a stub that loads the installed preset and
+    /// reports it's ready. Scope C wires the fetch pipeline.
+    Run,
 }
 
 #[derive(Subcommand)]
@@ -507,6 +529,11 @@ async fn main() -> Result<()> {
         Commands::Preset(cmd) => match cmd {
             PresetCommands::List => commands::preset::list().await,
             PresetCommands::Install { name } => commands::preset::install(&name).await,
+            PresetCommands::Schedule { name } => commands::preset::schedule(&name).await,
+            PresetCommands::Unschedule { name } => commands::preset::unschedule(&name).await,
+        },
+        Commands::Zirkel(cmd) => match cmd {
+            ZirkelCommands::Run => commands::zirkel::run().await,
         },
         Commands::Agents(cmd) => match cmd {
             AgentCommands::Add => commands::agents::add().await,

--- a/crates/skill-store/Cargo.toml
+++ b/crates/skill-store/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "wirken-skill-store"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+description = "Per-skill SQLite store with permission-policy-gated paths and idempotent migrations."
+
+[dependencies]
+wirken-agent = { path = "../agent" }
+rusqlite = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/crates/skill-store/src/lib.rs
+++ b/crates/skill-store/src/lib.rs
@@ -1,0 +1,300 @@
+//! Per-skill SQLite store, permission-gated.
+//!
+//! Skills that need local state (Zirkel's aggregator + librarian, future
+//! presets that hold caches or seen-sets) own their own SQLite database.
+//! [`SkillStore::open`] verifies the database path falls within the
+//! skill's declared `permissions.filesystem.write_paths` allow-set
+//! before creating or opening the file. A skill cannot write its store
+//! anywhere outside the surface its frontmatter declared.
+//!
+//! ## What this crate is, and isn't
+//!
+//! **Is:** path resolution against a skill's permission profile,
+//! [`Connection`] handle, idempotent migration runner that records
+//! applied migrations in a `_migrations` table.
+//!
+//! **Isn't:** a connection pool, an ORM, a query builder, a caching
+//! layer. Skills that need higher-level helpers build them on top of
+//! the [`Connection`] this crate hands back. Keeping the API minimal
+//! is deliberate — Zirkel is the first user, not the last; an API
+//! shaped only by Zirkel is the wrong shape for the second user.
+
+use std::path::{Path, PathBuf};
+
+use rusqlite::Connection;
+use thiserror::Error;
+use wirken_agent::skill_perms::PermissionProfile;
+
+/// A skill's per-skill SQLite store.
+#[derive(Debug)]
+pub struct SkillStore {
+    conn: Connection,
+    path: PathBuf,
+    skill_name: String,
+}
+
+/// Reasons [`SkillStore::open`] can fail.
+#[derive(Debug, Error)]
+pub enum SkillStoreError {
+    #[error(
+        "skill store path '{path}' is not within the skill's \
+         permissions.filesystem.write_paths allow-set"
+    )]
+    PathNotInWriteAllowlist { path: PathBuf },
+    #[error("skill '{skill}' has an empty filesystem.write_paths allow-set; cannot open a store")]
+    EmptyWriteAllowlist { skill: String },
+    #[error("create parent directory for skill store at '{path}': {source}")]
+    CreateParent {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("open SQLite at '{path}': {source}")]
+    OpenSqlite {
+        path: PathBuf,
+        #[source]
+        source: rusqlite::Error,
+    },
+    #[error("migrate skill store: {0}")]
+    Migrate(#[source] rusqlite::Error),
+}
+
+impl SkillStore {
+    /// Open or create the SQLite file at `<base_dir>/<skill_name>.db`.
+    /// Verifies the path is within `profile.filesystem.write_paths`
+    /// before opening — a permissions edit that removes write access
+    /// to the chosen directory fails the store open at startup
+    /// instead of silently letting the orchestrator write to a path
+    /// the skill is no longer allowed to touch.
+    ///
+    /// `profile` must be the resolved-and-expanded permission profile
+    /// for the skill (any `<workspace>` token already substituted).
+    /// The orchestrator handles expansion before calling this.
+    pub fn open(
+        skill_name: &str,
+        base_dir: &Path,
+        profile: &PermissionProfile,
+    ) -> Result<Self, SkillStoreError> {
+        let path = base_dir.join(format!("{skill_name}.db"));
+
+        if profile.filesystem.write_paths.is_empty() {
+            return Err(SkillStoreError::EmptyWriteAllowlist {
+                skill: skill_name.to_string(),
+            });
+        }
+        if !path_under_any(&path, &profile.filesystem.write_paths) {
+            return Err(SkillStoreError::PathNotInWriteAllowlist { path });
+        }
+
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).map_err(|e| SkillStoreError::CreateParent {
+                path: parent.to_path_buf(),
+                source: e,
+            })?;
+        }
+
+        let conn = Connection::open(&path).map_err(|e| SkillStoreError::OpenSqlite {
+            path: path.clone(),
+            source: e,
+        })?;
+
+        Ok(Self {
+            conn,
+            path,
+            skill_name: skill_name.to_string(),
+        })
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    pub fn skill_name(&self) -> &str {
+        &self.skill_name
+    }
+
+    pub fn conn(&self) -> &Connection {
+        &self.conn
+    }
+
+    pub fn conn_mut(&mut self) -> &mut Connection {
+        &mut self.conn
+    }
+
+    /// Apply versioned migrations. Each migration is a SQL statement
+    /// (or batch). Migrations are addressed by their index in the
+    /// slice and recorded in a `_migrations` table; repeat calls are
+    /// idempotent. Adding a new migration means appending to the
+    /// slice — never reordering or replacing existing entries (the
+    /// recorded indexes would point at different SQL).
+    pub fn migrate(&mut self, migrations: &[&str]) -> Result<(), SkillStoreError> {
+        let tx = self.conn.transaction().map_err(SkillStoreError::Migrate)?;
+        tx.execute_batch(
+            "CREATE TABLE IF NOT EXISTS _migrations ( \
+                idx INTEGER PRIMARY KEY, \
+                applied_at TEXT NOT NULL DEFAULT (datetime('now')) \
+            )",
+        )
+        .map_err(SkillStoreError::Migrate)?;
+
+        let already_applied: std::collections::BTreeSet<i64> = tx
+            .prepare("SELECT idx FROM _migrations")
+            .and_then(|mut stmt| {
+                stmt.query_map([], |row| row.get::<_, i64>(0))
+                    .and_then(|r| r.collect())
+            })
+            .map_err(SkillStoreError::Migrate)?;
+
+        for (idx, sql) in migrations.iter().enumerate() {
+            let idx_i64 = idx as i64;
+            if already_applied.contains(&idx_i64) {
+                continue;
+            }
+            tx.execute_batch(sql).map_err(SkillStoreError::Migrate)?;
+            tx.execute(
+                "INSERT INTO _migrations (idx) VALUES (?1)",
+                rusqlite::params![idx_i64],
+            )
+            .map_err(SkillStoreError::Migrate)?;
+        }
+
+        tx.commit().map_err(SkillStoreError::Migrate)?;
+        Ok(())
+    }
+}
+
+fn path_under_any(path: &Path, allowed: &std::collections::BTreeSet<PathBuf>) -> bool {
+    allowed.iter().any(|root| path.starts_with(root))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeSet;
+    use wirken_agent::skill_perms::{
+        AllowSet, EgressMode, EgressPolicy, FilesystemPolicy, InferencePolicy, PermissionProfile,
+        ToolPolicy,
+    };
+
+    fn profile_with_writes(paths: Vec<PathBuf>) -> PermissionProfile {
+        PermissionProfile {
+            tools: ToolPolicy::default(),
+            egress: EgressPolicy {
+                mode: EgressMode::Deny,
+                domains: AllowSet::default(),
+            },
+            filesystem: FilesystemPolicy {
+                write_paths: paths.into_iter().collect::<BTreeSet<_>>(),
+                read_paths: BTreeSet::new(),
+            },
+            inference: InferencePolicy::default(),
+        }
+    }
+
+    #[test]
+    fn open_creates_db_under_allowed_path() {
+        let tmp = tempfile::tempdir().unwrap();
+        let base = tmp.path().join("zirkel");
+        let profile = profile_with_writes(vec![base.clone()]);
+        let store = SkillStore::open("aggregator", &base, &profile).unwrap();
+        assert!(store.path().exists(), "db file should exist on disk");
+        assert_eq!(store.skill_name(), "aggregator");
+    }
+
+    #[test]
+    fn open_rejects_path_outside_write_allowlist() {
+        let tmp = tempfile::tempdir().unwrap();
+        let base = tmp.path().join("not_allowed");
+        // Allow some other directory.
+        let profile = profile_with_writes(vec![tmp.path().join("allowed")]);
+        let err = SkillStore::open("aggregator", &base, &profile).unwrap_err();
+        assert!(matches!(
+            err,
+            SkillStoreError::PathNotInWriteAllowlist { .. }
+        ));
+    }
+
+    #[test]
+    fn open_rejects_empty_write_allowlist() {
+        let tmp = tempfile::tempdir().unwrap();
+        let profile = profile_with_writes(vec![]);
+        let err = SkillStore::open("aggregator", tmp.path(), &profile).unwrap_err();
+        assert!(matches!(err, SkillStoreError::EmptyWriteAllowlist { .. }));
+    }
+
+    #[test]
+    fn migrate_runs_and_is_idempotent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let profile = profile_with_writes(vec![tmp.path().to_path_buf()]);
+        let mut store = SkillStore::open("aggregator", tmp.path(), &profile).unwrap();
+
+        let m0 = "CREATE TABLE candidates (id INTEGER PRIMARY KEY, url TEXT NOT NULL)";
+        let m1 = "ALTER TABLE candidates ADD COLUMN score REAL NOT NULL DEFAULT 0";
+        store.migrate(&[m0, m1]).unwrap();
+
+        // Second call must not error and must not re-apply.
+        store.migrate(&[m0, m1]).unwrap();
+
+        // Verify the schema is the post-m1 shape.
+        let cnt: i64 = store
+            .conn()
+            .query_row(
+                "SELECT COUNT(*) FROM pragma_table_info('candidates') WHERE name = 'score'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(cnt, 1, "score column should exist after migration");
+
+        // Verify both migrations are recorded.
+        let applied: i64 = store
+            .conn()
+            .query_row("SELECT COUNT(*) FROM _migrations", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(applied, 2);
+    }
+
+    #[test]
+    fn migrate_appending_new_migration_runs_only_the_new_one() {
+        let tmp = tempfile::tempdir().unwrap();
+        let profile = profile_with_writes(vec![tmp.path().to_path_buf()]);
+        let mut store = SkillStore::open("aggregator", tmp.path(), &profile).unwrap();
+
+        let m0 = "CREATE TABLE candidates (id INTEGER PRIMARY KEY, url TEXT NOT NULL)";
+        store.migrate(&[m0]).unwrap();
+
+        let m1 = "ALTER TABLE candidates ADD COLUMN score REAL NOT NULL DEFAULT 0";
+        store.migrate(&[m0, m1]).unwrap();
+
+        let applied: i64 = store
+            .conn()
+            .query_row("SELECT COUNT(*) FROM _migrations", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(applied, 2);
+    }
+
+    #[test]
+    fn db_persists_across_open_calls() {
+        let tmp = tempfile::tempdir().unwrap();
+        let profile = profile_with_writes(vec![tmp.path().to_path_buf()]);
+        {
+            let mut store = SkillStore::open("aggregator", tmp.path(), &profile).unwrap();
+            store
+                .migrate(&["CREATE TABLE seen (url TEXT PRIMARY KEY)"])
+                .unwrap();
+            store
+                .conn()
+                .execute(
+                    "INSERT INTO seen (url) VALUES (?1)",
+                    rusqlite::params!["https://example.com/a"],
+                )
+                .unwrap();
+        }
+        let store = SkillStore::open("aggregator", tmp.path(), &profile).unwrap();
+        let cnt: i64 = store
+            .conn()
+            .query_row("SELECT COUNT(*) FROM seen", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(cnt, 1);
+    }
+}

--- a/crates/zirkel/Cargo.toml
+++ b/crates/zirkel/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "wirken-zirkel"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+description = "Zirkel preset orchestrator: daily-fetch pipeline that runs through the policed HTTP transport and writes to the per-skill SQLite store."
+
+[dependencies]
+wirken-agent = { path = "../agent" }
+wirken-skill-store = { path = "../skill-store" }
+tokio = { workspace = true }
+reqwest = { workspace = true }
+rusqlite = { workspace = true }
+serde = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }
+toml = "0.8"
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/crates/zirkel/src/lib.rs
+++ b/crates/zirkel/src/lib.rs
@@ -1,0 +1,16 @@
+//! Zirkel preset orchestrator.
+//!
+//! Implements the daily-fetch pipeline that runs from `wirken zirkel run`
+//! (cron or manual). Reads the installed Zirkel preset's permissions
+//! block and `sources.toml`, constructs an [`wirken_agent::egress::EgressClient`]
+//! wrapping a [`wirken_agent::rate_limit::RateLimitedClient`] from the
+//! aggregator skill's policy, fetches sources, dedups against the seen
+//! set in [`wirken_skill_store::SkillStore`], and writes candidate rows.
+//!
+//! ## What ships in Scope B
+//!
+//! Pure Rust pipeline through policed transport: fetch → write → exit.
+//! No LLM call (relevance scoring is Scope C). No clustering, no theme
+//! naming, no digest push.
+
+pub mod orchestrator;

--- a/crates/zirkel/src/orchestrator.rs
+++ b/crates/zirkel/src/orchestrator.rs
@@ -1,0 +1,436 @@
+//! Zirkel orchestrator pipeline.
+//!
+//! Pure Rust pipeline through the policed HTTP transport. The LLM is
+//! NOT in the fetch loop — that path was rejected during Scope B
+//! design because subprocess HTTP (curl-via-exec) routes around
+//! [`wirken_agent::egress::EgressClient`] and
+//! [`wirken_agent::rate_limit::RateLimitedClient`] entirely. This
+//! pipeline calls the policed client directly so egress allowlist
+//! and rate-limit budget enforcement are structural.
+//!
+//! ## What ships in Scope B
+//!
+//! - Load preset via `PresetLoader`.
+//! - Read aggregator skill's permission profile; construct an
+//!   `EgressClient` whose enforcement matches the profile and whose
+//!   inner `RateLimitedClient` carries the per-host caps.
+//! - Read `sources.toml`. Pick the first source.
+//! - Fetch its endpoint through the policed client.
+//! - Open `SkillStore` for the aggregator under `storage_dir`.
+//! - Migrate to a minimal `candidates` schema.
+//! - Insert one candidate row whose body is the response text.
+//!
+//! Scoring, clustering, theme naming, digest push are Scope C.
+
+#[cfg(test)]
+use std::path::Path;
+use std::path::PathBuf;
+
+use serde::Deserialize;
+use thiserror::Error;
+use wirken_agent::egress::{EgressClient, EgressEnforcement, HttpAccessDenied};
+use wirken_agent::preset::PresetLoader;
+use wirken_agent::rate_limit::RateLimitConfig;
+use wirken_agent::skill_perms::PermissionProfile;
+use wirken_skill_store::{SkillStore, SkillStoreError};
+
+const AGGREGATOR_SKILL_NAME: &str = "aggregator";
+
+/// Caller-supplied configuration for [`run`].
+pub struct OrchestratorConfig {
+    /// Directory of the installed preset (e.g. `~/.wirken/presets/zirkel/`).
+    pub preset_dir: PathBuf,
+    /// Directory where the aggregator's SQLite store and full bodies
+    /// live (e.g. `~/.wirken/zirkel/`). Must be inside the aggregator
+    /// skill's `permissions.filesystem.write_paths` allow-set.
+    pub storage_dir: PathBuf,
+    /// Rate-limit config for the per-source HTTP transport. Production
+    /// uses the schema-defaulted [`RateLimitConfig::default`]; tests
+    /// can pass [`RateLimitConfig::unrestricted_for_tests`] to skip
+    /// jitter.
+    pub rate_limit: RateLimitConfig,
+}
+
+/// Summary of what [`run`] did.
+#[derive(Debug, Clone)]
+pub struct RunSummary {
+    pub source_name: String,
+    pub source_url: String,
+    pub candidate_id: i64,
+    pub bytes_fetched: usize,
+}
+
+#[derive(Debug, Error)]
+pub enum OrchestratorError {
+    #[error("load preset: {0}")]
+    LoadPreset(String),
+    #[error("aggregator skill missing from preset")]
+    AggregatorSkillMissing,
+    #[error("read sources.toml at {path}: {source}")]
+    ReadSources {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("parse sources.toml at {path}: {message}")]
+    ParseSources { path: PathBuf, message: String },
+    #[error("sources.toml is empty — nothing to fetch")]
+    EmptySources,
+    #[error("HTTP fetch denied for {url}: {source}")]
+    HttpDenied {
+        url: String,
+        #[source]
+        source: HttpAccessDenied,
+    },
+    #[error("HTTP fetch failed for {url}: {source}")]
+    HttpFailed {
+        url: String,
+        #[source]
+        source: reqwest::Error,
+    },
+    #[error("HTTP non-success for {url}: status {status}")]
+    HttpStatus { url: String, status: u16 },
+    #[error("skill store: {0}")]
+    Store(#[from] SkillStoreError),
+    #[error("write candidate row: {0}")]
+    WriteCandidate(#[from] rusqlite::Error),
+}
+
+/// Schema migrations applied to the aggregator's SkillStore. Order is
+/// load-bearing — never reorder or replace existing entries; append only.
+const AGGREGATOR_MIGRATIONS: &[&str] = &["CREATE TABLE candidates ( \
+        id           INTEGER PRIMARY KEY AUTOINCREMENT, \
+        source_name  TEXT NOT NULL, \
+        url          TEXT NOT NULL, \
+        fetched_at   TEXT NOT NULL DEFAULT (datetime('now')), \
+        body         TEXT NOT NULL \
+    )"];
+
+/// On-disk shape of `sources.toml`. Only the fields the Scope B
+/// orchestrator consumes are required; later scopes will tighten
+/// the schema as additional fields become load-bearing.
+#[derive(Debug, Deserialize)]
+struct SourcesManifest {
+    #[serde(default, rename = "source")]
+    sources: Vec<SourceEntry>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SourceEntry {
+    name: String,
+    endpoint: String,
+}
+
+/// Run the orchestrator once. Loads the preset, fetches the first
+/// source from `sources.toml`, writes one candidate row, returns.
+///
+/// Caller responsibility: ensure `config.storage_dir` is within the
+/// aggregator skill's `permissions.filesystem.write_paths` allow-set.
+/// The store open will fail loud otherwise — preferred to silent
+/// out-of-policy writes.
+pub async fn run(config: OrchestratorConfig) -> Result<RunSummary, OrchestratorError> {
+    let loaded = PresetLoader::load_dir(&config.preset_dir)
+        .map_err(|e| OrchestratorError::LoadPreset(e.to_string()))?;
+    let aggregator = loaded
+        .skills
+        .iter()
+        .find(|s| s.name == AGGREGATOR_SKILL_NAME)
+        .ok_or(OrchestratorError::AggregatorSkillMissing)?;
+    let profile: PermissionProfile = aggregator.permissions.clone();
+
+    let sources_path = config.preset_dir.join("sources.toml");
+    let raw =
+        std::fs::read_to_string(&sources_path).map_err(|e| OrchestratorError::ReadSources {
+            path: sources_path.clone(),
+            source: e,
+        })?;
+    let manifest: SourcesManifest =
+        toml::from_str(&raw).map_err(|e| OrchestratorError::ParseSources {
+            path: sources_path.clone(),
+            message: e.to_string(),
+        })?;
+    let first = manifest
+        .sources
+        .into_iter()
+        .next()
+        .ok_or(OrchestratorError::EmptySources)?;
+
+    let http = EgressClient::with_rate_limit(config.rate_limit.clone());
+    http.set_enforcement(EgressEnforcement::from_profile(
+        &wirken_agent::skill_perms::EffectiveProfile::Resolved(profile.clone()),
+    ));
+
+    let resp_text = match http.get(&first.endpoint).await {
+        Ok(builder) => {
+            let resp = builder
+                .send()
+                .await
+                .map_err(|e| OrchestratorError::HttpFailed {
+                    url: first.endpoint.clone(),
+                    source: e,
+                })?;
+            let status = resp.status();
+            if !status.is_success() {
+                return Err(OrchestratorError::HttpStatus {
+                    url: first.endpoint.clone(),
+                    status: status.as_u16(),
+                });
+            }
+            resp.text()
+                .await
+                .map_err(|e| OrchestratorError::HttpFailed {
+                    url: first.endpoint.clone(),
+                    source: e,
+                })?
+        }
+        Err(e) => {
+            return Err(OrchestratorError::HttpDenied {
+                url: first.endpoint.clone(),
+                source: e,
+            });
+        }
+    };
+
+    let mut store = SkillStore::open(AGGREGATOR_SKILL_NAME, &config.storage_dir, &profile)?;
+    store.migrate(AGGREGATOR_MIGRATIONS)?;
+    let bytes = resp_text.len();
+    let row_id: i64;
+    {
+        let conn = store.conn();
+        conn.execute(
+            "INSERT INTO candidates (source_name, url, body) VALUES (?1, ?2, ?3)",
+            rusqlite::params![first.name, first.endpoint, resp_text],
+        )?;
+        row_id = conn.last_insert_rowid();
+    }
+
+    Ok(RunSummary {
+        source_name: first.name,
+        source_url: first.endpoint,
+        candidate_id: row_id,
+        bytes_fetched: bytes,
+    })
+}
+
+/// Test helper: write a fixture preset directory with the supplied
+/// aggregator egress allow-set and source endpoint. Returns the
+/// preset_dir path. The caller passes this to [`run`].
+#[cfg(test)]
+pub(crate) fn write_fixture_preset(
+    dest: &Path,
+    storage_dir: &Path,
+    egress_allowlist: &[&str],
+    source_url: &str,
+) -> std::io::Result<()> {
+    std::fs::create_dir_all(dest.join("skills/aggregator"))?;
+    std::fs::write(
+        dest.join("preset.toml"),
+        r#"
+[preset]
+name = "test-preset"
+description = "fixture for orchestrator tests"
+version = "0.0.1"
+skills = ["aggregator"]
+"#,
+    )?;
+    let domains_yaml = egress_allowlist
+        .iter()
+        .map(|d| format!("      - {d}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let storage_yaml = storage_dir.display().to_string();
+    let aggregator_md = format!(
+        "---\n\
+         name: aggregator\n\
+         description: fixture aggregator\n\
+         disable-model-invocation: true\n\
+         permissions:\n\
+         \x20\x20tools:\n\
+         \x20\x20\x20\x20allow: [exec]\n\
+         \x20\x20egress:\n\
+         \x20\x20\x20\x20mode: allowlist\n\
+         \x20\x20\x20\x20domains:\n{domains_yaml}\n\
+         \x20\x20filesystem:\n\
+         \x20\x20\x20\x20write_paths: [\"{storage_yaml}\"]\n\
+         \x20\x20\x20\x20read_paths: [\"{storage_yaml}\"]\n\
+         \x20\x20inference:\n\
+         \x20\x20\x20\x20allow: [\"*\"]\n\
+         ---\n\nbody\n",
+    );
+    std::fs::write(dest.join("skills/aggregator/SKILL.md"), aggregator_md)?;
+    std::fs::write(
+        dest.join("sources.toml"),
+        format!(
+            "[[source]]\n\
+             name = \"test-source\"\n\
+             host = \"127.0.0.1\"\n\
+             method = \"json-api\"\n\
+             endpoint = \"{source_url}\"\n",
+        ),
+    )?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+
+    /// Spin up a tiny local HTTP server that accepts one connection
+    /// and responds with `body`. Returns the bound URL like
+    /// `http://127.0.0.1:<port>/`.
+    async fn one_shot_server(body: &'static str) -> String {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let url = format!("http://{}/", addr);
+        tokio::spawn(async move {
+            if let Ok((mut sock, _)) = listener.accept().await {
+                let mut buf = [0u8; 4096];
+                let _ = sock.read(&mut buf).await;
+                let resp = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nContent-Type: text/plain\r\n\r\n{}",
+                    body.len(),
+                    body
+                );
+                let _ = sock.write_all(resp.as_bytes()).await;
+                let _ = sock.shutdown().await;
+            }
+        });
+        url
+    }
+
+    /// Keystone test: orchestrator fetches one source via the policed
+    /// transport, writes a candidate row to the per-skill SQLite,
+    /// returns a summary. End-to-end through the layers we built.
+    #[tokio::test]
+    async fn fetches_one_source_and_writes_one_candidate() {
+        let body = "hello from fixture source";
+        let url = one_shot_server(body).await;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let preset_dir = tmp.path().join("preset");
+        let storage_dir = tmp.path().join("storage");
+        std::fs::create_dir_all(&storage_dir).unwrap();
+        write_fixture_preset(&preset_dir, &storage_dir, &["127.0.0.1"], &url).unwrap();
+
+        let summary = run(OrchestratorConfig {
+            preset_dir,
+            storage_dir: storage_dir.clone(),
+            rate_limit: RateLimitConfig::unrestricted_for_tests(),
+        })
+        .await
+        .unwrap();
+
+        assert_eq!(summary.source_name, "test-source");
+        assert_eq!(summary.bytes_fetched, body.len());
+
+        // Verify the candidate row landed in SQLite.
+        let db_path = storage_dir.join("aggregator.db");
+        assert!(db_path.exists());
+        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        let (saved_url, saved_body): (String, String) = conn
+            .query_row(
+                "SELECT url, body FROM candidates WHERE id = ?1",
+                rusqlite::params![summary.candidate_id],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(saved_url, summary.source_url);
+        assert_eq!(saved_body, body);
+    }
+
+    /// A request to a non-allowlisted host fails fast at egress
+    /// without consuming rate-limit budget — the layering invariant
+    /// from Phase 1 still holds when the orchestrator drives.
+    #[tokio::test]
+    async fn non_allowlisted_host_fails_at_egress() {
+        // Server on 127.0.0.1 but the allowlist names a DIFFERENT host.
+        let body = "should not be fetched";
+        let url = one_shot_server(body).await;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let preset_dir = tmp.path().join("preset");
+        let storage_dir = tmp.path().join("storage");
+        std::fs::create_dir_all(&storage_dir).unwrap();
+        write_fixture_preset(&preset_dir, &storage_dir, &["allowed.example.com"], &url).unwrap();
+
+        let err = run(OrchestratorConfig {
+            preset_dir,
+            storage_dir: storage_dir.clone(),
+            rate_limit: RateLimitConfig::unrestricted_for_tests(),
+        })
+        .await
+        .unwrap_err();
+
+        match err {
+            OrchestratorError::HttpDenied {
+                source: HttpAccessDenied::Egress(_),
+                ..
+            } => {}
+            other => panic!("expected HttpDenied(Egress), got {other:?}"),
+        }
+
+        // No candidate row should have been written.
+        let db_path = storage_dir.join("aggregator.db");
+        if db_path.exists() {
+            let conn = rusqlite::Connection::open(&db_path).unwrap();
+            // The schema migration may or may not have run depending on
+            // ordering; if the table exists, it must be empty.
+            let count: Option<i64> = conn
+                .query_row("SELECT COUNT(*) FROM candidates", [], |row| row.get(0))
+                .ok();
+            assert_eq!(count.unwrap_or(0), 0);
+        }
+    }
+
+    /// Sanity: aggregator skill missing from the preset is a typed
+    /// error, not a panic. Catches future preset edits that drop the
+    /// aggregator without updating the orchestrator's expectations.
+    #[tokio::test]
+    async fn missing_aggregator_skill_errors() {
+        let tmp = tempfile::tempdir().unwrap();
+        let preset_dir = tmp.path().join("preset");
+        std::fs::create_dir_all(preset_dir.join("skills/other")).unwrap();
+        std::fs::write(
+            preset_dir.join("preset.toml"),
+            r#"
+[preset]
+name = "no-aggregator"
+description = "missing aggregator"
+version = "0.0.1"
+skills = ["other"]
+"#,
+        )
+        .unwrap();
+        std::fs::write(
+            preset_dir.join("skills/other/SKILL.md"),
+            "---\nname: other\ndescription: x\ndisable-model-invocation: false\npermissions: {}\n---\nbody\n",
+        )
+        .unwrap();
+        std::fs::write(
+            preset_dir.join("sources.toml"),
+            "[[source]]\nname=\"x\"\nhost=\"x\"\nmethod=\"x\"\nendpoint=\"http://x\"\n",
+        )
+        .unwrap();
+
+        let storage = tmp.path().join("storage");
+        std::fs::create_dir_all(&storage).unwrap();
+
+        let err = run(OrchestratorConfig {
+            preset_dir,
+            storage_dir: storage,
+            rate_limit: RateLimitConfig::unrestricted_for_tests(),
+        })
+        .await
+        .unwrap_err();
+        assert!(matches!(err, OrchestratorError::AggregatorSkillMissing));
+    }
+
+    // Suppress unused-import warning when skill_perms isn't otherwise used.
+    #[allow(dead_code)]
+    fn _force_link() -> Arc<()> {
+        Arc::new(())
+    }
+}

--- a/preset/zirkel/skills/aggregator/SKILL.md
+++ b/preset/zirkel/skills/aggregator/SKILL.md
@@ -2,6 +2,13 @@
 name: aggregator
 description: Daily fetch from a fixed public allowlist; score against the user's interests file; cluster into themes; push the digest to the configured channel
 disable-model-invocation: true
+# This skill is never agent-attached. It is loaded by PresetLoader for
+# its permissions block, which the `wirken zirkel run` orchestrator
+# applies to its own policed HTTP and SQLite clients. The tools.allow
+# list below is dead surface from the agent-loop perspective — there
+# is no agent that exposes these tools to an LLM for this skill.
+# The permissions block exists as the orchestrator's policy source,
+# not as an attach manifest. See crates/zirkel/src/orchestrator.rs.
 permissions:
   tools:
     allow: [exec, read_file, write_file, list_files]

--- a/preset/zirkel/skills/aggregator/SKILL.md
+++ b/preset/zirkel/skills/aggregator/SKILL.md
@@ -2,13 +2,16 @@
 name: aggregator
 description: Daily fetch from a fixed public allowlist; score against the user's interests file; cluster into themes; push the digest to the configured channel
 disable-model-invocation: true
-# This skill is never agent-attached. It is loaded by PresetLoader for
-# its permissions block, which the `wirken zirkel run` orchestrator
-# applies to its own policed HTTP and SQLite clients. The tools.allow
-# list below is dead surface from the agent-loop perspective — there
-# is no agent that exposes these tools to an LLM for this skill.
-# The permissions block exists as the orchestrator's policy source,
-# not as an attach manifest. See crates/zirkel/src/orchestrator.rs.
+# The permissions block below is the orchestrator's policy source,
+# not an attach manifest. `wirken zirkel run` is a pure-Rust pipeline
+# that loads this skill via PresetLoader, reads the permissions block,
+# and applies it to its own policed HTTP and SQLite clients. The
+# orchestrator never calls Agent::attach_skills for this skill — the
+# LLM is not in the fetch loop, so there is no agent surfacing tools
+# from an attached aggregator. The tools.allow list below is dead
+# surface from the agent-loop perspective; it stays declared so the
+# permissions block is a complete, signed policy descriptor.
+# See crates/zirkel/src/orchestrator.rs.
 permissions:
   tools:
     allow: [exec, read_file, write_file, list_files]


### PR DESCRIPTION
Closes Gaps B, E, F from `docs/zirkel/DESIGN.md`. Wires the aggregator orchestrator's first end-to-end path: load preset → fetch via policed transport → write to per-skill SQLite. Scoring, clustering, theme naming, and digest push remain Scope C.

## What's here

- **Gap E — rate limiter at the transport layer.** New `crates/agent/src/rate_limit.rs`. `RateLimitedClient` enforces per-host daily caps (default 2) and inter-request jitter (default 3–12s, configurable to zero for tests). `EgressClient` refactored to wrap `RateLimitedClient` instead of `reqwest::Client` directly.
- **Gap B — per-skill SQLite ownership.** New `crates/skill-store/`. `SkillStore::open` rejects database paths outside the skill's `permissions.filesystem.write_paths` allow-set. Migration runner records applied migrations in a `_migrations` table for idempotent re-runs.
- **Gap F — scheduled runs via OS cron.** `wirken preset schedule <name>` writes a marker-bracketed crontab block; `wirken preset unschedule <name>` removes exactly that block, leaving user-authored cron lines untouched.
- **Aggregator wiring (minimum viable).** New `crates/zirkel/`. `wirken zirkel run` loads the installed preset, applies the aggregator skill's permission profile to its own `EgressClient` + `RateLimitedClient`, fetches the first source from `sources.toml`, opens the per-skill SQLite store, and writes a candidate row.

## Layering, instantiated

What was a documented layering in #81's egress wrapper is now a real composition:

```
caller → EgressClient → RateLimitedClient → reqwest::Client
```

The egress check runs first; on egress-pass the request enters the rate-limit budget; on rate-limit-pass `reqwest` actually issues bytes. A new test (`egress_reject_does_not_consume_rate_budget`) directly verifies the layering invariant: three rejected requests to a non-allowlisted host do not consume budget; subsequent allowed requests can still hit the cap of 2.

## Aggregator skill is never agent-attached

The Scope B reframing on the table yesterday: the aggregator skill's body describes what the LLM does inside the orchestrator pipeline (scoring + clustering, Scope C), not what the LLM drives. The orchestrator (`wirken zirkel run`) is pure Rust through the policed transport; the LLM is not in the fetch loop. The aggregator skill is loaded by `PresetLoader` for its permissions block — which the orchestrator applies to its clients — and is never handed to `Agent::attach_skills`. A one-line comment on the SKILL.md frontmatter notes this explicitly so future-readers don't wonder why `tools.allow` is declared on a skill nothing exposes tools for.

## Bypass invariant unchanged

The bypass invariant from #81 + #82 still holds. The orchestrator opens an `EgressClient` configured with the aggregator skill's `egress.domains` allow-set; a request to a non-allowlisted host fails with `EgressDenied` before any TCP. Rate-limit budget is consumed only after the egress check passes. Filesystem writes go through `SkillStore::open` which refuses paths outside `permissions.filesystem.write_paths`. Three structural enforcement points, three matching tests.

## Keystone test

`zirkel/src/orchestrator.rs::fetches_one_source_and_writes_one_candidate`: spins up a localhost HTTP server, writes a fixture preset whose aggregator allows `127.0.0.1`, runs `orchestrator::run`, asserts a candidate row landed in the per-skill SQLite with the correct URL and body.

`non_allowlisted_host_fails_at_egress` is the negative: same setup, allowlist names a different host, run returns `HttpDenied(Egress(_))`, no candidate row is written.

## Tests

- 9 new agent tests (8 rate-limit + 1 egress layering composition).
- 6 skill-store tests (open, path policy, migrations, persistence).
- 3 zirkel tests (the keystone, the negative, missing-aggregator-skill).
- 7 CLI preset tests (crontab marker block manipulation: insert, replace, remove, preserve user lines, namespaced removal).
- 260 agent unit tests still pass; 578 tests across the workspace, all green.
- `cargo fmt --check` clean. `cargo clippy --workspace --tests -- -D warnings` clean.

## What's deferred to Scope C

- Relevance scoring (LLM call with the aggregator skill body as a prompt template, structured output).
- Embedding + clustering (small local embedding model via Ollama).
- Theme naming (LLM call, ≤6-word labels).
- Digest rendering and channel push.
- Multi-source per run (currently one).
- RSS/Atom/JSON parsing into structured candidate fields (currently the response body is stored verbatim).
- Persistence of rate-limit state across process restarts (currently in-memory; adequate for the daily-run-then-exit model).