### PR TITLE
zirkel scope c-foundation: interests, multi-source RSS, keyword screen, dedup, audit events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1427,6 +1427,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "feed-rs"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4c0591d23efd0d595099af69a31863ac1823046b1b021e3b06ba3aae7e00991"
+dependencies = [
+ "chrono",
+ "mediatype",
+ "quick-xml",
+ "regex",
+ "serde",
+ "serde_json",
+ "siphasher",
+ "url",
+ "uuid",
+]
+
+[[package]]
 name = "ff"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2529,6 +2546,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
 
 [[package]]
+name = "mediatype"
+version = "0.19.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33746aadcb41349ec291e7f2f0a3aa6834d1d7c58066fb4b01f68efc4c4b7631"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3270,6 +3296,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-xml"
+version = "0.37.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+dependencies = [
+ "encoding_rs",
+ "memchr",
+]
+
+[[package]]
 name = "quinn"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3521,6 +3557,18 @@ dependencies = [
  "log",
  "rustc-hash",
  "smallvec",
+]
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -6611,15 +6659,22 @@ dependencies = [
 name = "wirken-zirkel"
 version = "0.9.1"
 dependencies = [
+ "chrono",
+ "feed-rs",
  "reqwest 0.13.2",
  "rusqlite",
  "serde",
+ "serde_json",
+ "sha2",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "toml 0.8.23",
  "tracing",
+ "url",
+ "uuid",
  "wirken-agent",
+ "wirken-audit",
  "wirken-skill-store",
 ]
 

--- a/crates/audit/src/session_log.rs
+++ b/crates/audit/src/session_log.rs
@@ -259,6 +259,72 @@ pub enum SessionEvent {
         agent_id: String,
         trigger: Option<String>,
     },
+    /// Zirkel orchestrator: an HTTP fetch went out through the policed
+    /// transport. `source` is the source's name in `sources.toml`;
+    /// `host` is the URL host. `bytes` is the response payload size on
+    /// success, `0` on transport-layer denial. `outcome` distinguishes
+    /// success / `egress_denied` / `rate_limited` / `http_error_<code>`
+    /// / `network_error`.
+    HttpFetch {
+        source: String,
+        host: String,
+        url: String,
+        outcome: String,
+        bytes: u64,
+        run_id: Option<String>,
+    },
+    /// Zirkel: a fetched item passed exclusion + keyword screening and
+    /// landed in the candidates table with its keyword-match score.
+    /// `score` is the count of distinct keyword matches in this slice;
+    /// the LLM-relevance score lives in a separate event under C-LLM.
+    /// `matched_keywords` is the JSON-encoded list, kept verbatim so
+    /// the chain-verifier can replay the screening decision.
+    CandidateScored {
+        run_id: String,
+        candidate_id: i64,
+        keyword_match_score: u32,
+        matched_keywords: String,
+    },
+    /// Zirkel: the user marked a candidate as kept from the digest.
+    /// Emitted by C-Signal when the keep button (or numbered reply) is
+    /// processed.
+    CandidateKept {
+        run_id: String,
+        candidate_id: i64,
+        via: String,
+    },
+    /// Zirkel: the user marked a candidate as skipped, or the
+    /// orchestrator dropped it pre-scoring (exclusion match, score 0,
+    /// dedup hit). `reason` distinguishes user-skipped /
+    /// exclusion_match / score_zero / duplicate_url.
+    CandidateSkipped {
+        run_id: String,
+        url_hash: HashHex,
+        source: String,
+        reason: String,
+    },
+    /// Zirkel: a per-run cluster was named by the LLM (C-LLM scope).
+    ThemeNamed {
+        run_id: String,
+        theme_id: i64,
+        name: String,
+        member_count: u32,
+    },
+    /// Zirkel: the daily digest was rendered and pushed to the
+    /// configured channel (C-Signal scope).
+    DigestPushed {
+        run_id: String,
+        channel_adapter: String,
+        item_count: u32,
+    },
+    /// Zirkel: the interests file changed between runs. `before_hash`
+    /// is the hash recorded on the previous run's snapshot;
+    /// `after_hash` is the current hash. Emitted at the start of every
+    /// run that detects a delta.
+    InterestsEdited {
+        before_hash: HashHex,
+        after_hash: HashHex,
+    },
     /// Sandbox lazily provisioned (item 3 emits this once at first
     /// use).
     SandboxProvisioned { name: String, mode: String },

--- a/crates/cli/src/commands/zirkel.rs
+++ b/crates/cli/src/commands/zirkel.rs
@@ -1,18 +1,22 @@
 //! `wirken zirkel` subcommands.
 //!
-//! Entry point for the Zirkel orchestrator. Both the cron-fired and the
-//! manual run path call into here. Scope B fetches one source through
-//! the policed transport and writes one candidate to the per-skill
-//! SQLite. Scoring, clustering, theme naming, and digest push are
-//! Scope C.
+//! Entry point for the Zirkel orchestrator. Both the cron-fired and
+//! the manual run path call into here. The C-foundation slice loops
+//! every source in `sources.toml`, dispatches RSS/Atom through the
+//! policed transport, dedups against the seen table, screens with
+//! the user's interests file, and writes kept items to the per-skill
+//! SQLite. LLM relevance scoring, clustering, theme naming, and
+//! digest push are subsequent Scope C slices.
+
+use std::sync::Arc;
 
 use anyhow::{Result, anyhow};
 use wirken_agent::rate_limit::RateLimitConfig;
+use wirken_audit::{SessionLog, SqliteSessionLog};
 use wirken_zirkel::orchestrator::{OrchestratorConfig, run as orchestrator_run};
 
-/// `wirken zirkel run` — load the installed Zirkel preset, fetch the
-/// first source, write a candidate row, exit. Cron and manual entry
-/// share this code path.
+/// `wirken zirkel run` — load the installed Zirkel preset, run the
+/// daily fetch + screen pipeline, exit.
 pub async fn run() -> Result<()> {
     let data_dir = super::data_dir()?;
     let preset_dir = data_dir.join("presets").join("zirkel");
@@ -24,27 +28,61 @@ pub async fn run() -> Result<()> {
     }
 
     // Storage lives at <data_dir>/zirkel/. Must be inside the
-    // aggregator skill's filesystem.write_paths allow-set; the
-    // bundled aggregator declares `~/.wirken/zirkel` which resolves
-    // to that directory. `SkillStore::open` fails loud if the path
-    // is outside the policy.
+    // aggregator skill's filesystem.write_paths allow-set.
     let storage_dir = data_dir.join("zirkel");
+    std::fs::create_dir_all(&storage_dir)?;
+    let interests_path = storage_dir.join("interests.toml");
+    if !interests_path.exists() {
+        return Err(anyhow!(
+            "interests file not found at {}. Create it with `keywords = [...]` and \
+             optional `exclusions = [...]` before running.",
+            interests_path.display()
+        ));
+    }
+
+    // Wirken's session-log SQLite is the audit chain. Open it as a
+    // thread-safe trait object so the orchestrator's HttpFetch /
+    // CandidateScored / CandidateSkipped events join the same chain
+    // the agent runtime writes to.
+    let audit_path = data_dir.join("audit.db");
+    let session_log: Arc<dyn SessionLog> = Arc::new(
+        SqliteSessionLog::open(&audit_path)
+            .map_err(|e| anyhow!("open audit log at {}: {e}", audit_path.display()))?,
+    );
 
     let summary = orchestrator_run(OrchestratorConfig {
         preset_dir,
         storage_dir,
+        interests_path,
         rate_limit: RateLimitConfig::default(),
+        session_log: Some(session_log),
     })
     .await
     .map_err(|e| anyhow!("zirkel orchestrator: {e}"))?;
 
-    println!("Zirkel run complete:");
-    println!(
-        "  source:        {} ({})",
-        summary.source_name, summary.source_url
-    );
-    println!("  bytes fetched: {}", summary.bytes_fetched);
-    println!("  candidate id:  {}", summary.candidate_id);
-    println!("(Scope B: one source per run, no scoring or digest yet — Scope C wires those.)");
+    println!("Zirkel run complete (run_id: {}):", summary.run_id);
+    println!("  sources attempted:   {}", summary.sources_attempted);
+    println!("  sources succeeded:   {}", summary.sources_succeeded);
+    if !summary.sources_unsupported.is_empty() {
+        println!(
+            "  sources unsupported: {}",
+            summary.sources_unsupported.join(", ")
+        );
+    }
+    if !summary.sources_failed.is_empty() {
+        println!("  sources failed:      {}", summary.sources_failed.len());
+        for failure in &summary.sources_failed {
+            println!("    - {}: {}", failure.source, failure.reason);
+        }
+    }
+    println!("  items seen:          {}", summary.items_seen);
+    println!("  items new:           {}", summary.items_new);
+    println!("  items excluded:      {}", summary.items_excluded);
+    println!("  items score 0:       {}", summary.items_score_zero);
+    println!("  items kept:          {}", summary.items_kept);
+    if summary.interests_changed {
+        println!("  interests changed:   yes (audit event emitted)");
+    }
+    println!("(C-foundation: keyword screen only. LLM relevance scoring is the next slice.)");
     Ok(())
 }

--- a/crates/zirkel/Cargo.toml
+++ b/crates/zirkel/Cargo.toml
@@ -8,14 +8,21 @@ description = "Zirkel preset orchestrator: daily-fetch pipeline that runs throug
 
 [dependencies]
 wirken-agent = { path = "../agent" }
+wirken-audit = { path = "../audit" }
 wirken-skill-store = { path = "../skill-store" }
 tokio = { workspace = true }
 reqwest = { workspace = true }
 rusqlite = { workspace = true }
 serde = { workspace = true }
+serde_json = { workspace = true }
+sha2 = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 toml = "0.8"
+feed-rs = "2"
+chrono = { workspace = true }
+uuid = { version = "1", features = ["v4"] }
+url = "2"
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/zirkel/src/fetcher.rs
+++ b/crates/zirkel/src/fetcher.rs
@@ -1,0 +1,266 @@
+//! RSS / Atom fetcher.
+//!
+//! `feed-rs` parses both RSS 2.0 and Atom into a unified `Feed` type.
+//! This module wraps it: HTTP-fetch via the policed
+//! [`wirken_agent::egress::EgressClient`], parse, normalize each
+//! entry into a [`FetchedItem`].
+//!
+//! ## Why no `Fetcher` trait yet
+//!
+//! There's exactly one fetcher implementation in this slice. Adding
+//! a trait now would shape the API around a second implementation
+//! that hasn't shipped — exactly the "seam for an uncommitted
+//! boundary" pattern we said no to. The trait lands when the C-API
+//! and C-scrape slices add congress.gov, govinfo.gov, and committee
+//! sites: a real second implementation tells us what the abstraction
+//! should look like.
+//!
+//! ## Failure modes
+//!
+//! - HTTP-level denial (egress / rate limit) → [`FetchError::Denied`].
+//! - Network error → [`FetchError::Network`].
+//! - Non-success HTTP status → [`FetchError::HttpStatus`].
+//! - Parse error → [`FetchError::Parse`]. Best-effort recovery is
+//!   not attempted — a malformed feed gets logged and skipped at
+//!   the orchestrator level.
+
+use chrono::{DateTime, Utc};
+use thiserror::Error;
+use wirken_agent::egress::{EgressClient, HttpAccessDenied};
+
+/// One normalized item produced by a fetcher.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FetchedItem {
+    pub source_name: String,
+    pub url: String,
+    pub title: String,
+    pub abstract_text: String,
+    /// RFC 3339 string, or empty if the feed entry had no date.
+    pub published_at: String,
+}
+
+#[derive(Debug, Error)]
+pub enum FetchError {
+    #[error("HTTP denied for {url}: {source}")]
+    Denied {
+        url: String,
+        #[source]
+        source: HttpAccessDenied,
+    },
+    #[error("HTTP non-success for {url}: status {status}")]
+    HttpStatus { url: String, status: u16 },
+    #[error("network error for {url}: {source}")]
+    Network {
+        url: String,
+        #[source]
+        source: reqwest::Error,
+    },
+    #[error("parse error for {url}: {message}")]
+    Parse { url: String, message: String },
+}
+
+/// Fetch a feed and return its items normalized to [`FetchedItem`].
+pub async fn fetch_rss(
+    http: &EgressClient,
+    source_name: &str,
+    url: &str,
+) -> Result<Vec<FetchedItem>, FetchError> {
+    let body = fetch_body(http, url).await?;
+    parse_feed(source_name, url, &body)
+}
+
+/// HTTP-fetch raw bytes of a feed. Separated from parsing so tests
+/// can exercise the parser directly without a server.
+pub async fn fetch_body(http: &EgressClient, url: &str) -> Result<String, FetchError> {
+    let builder = http.get(url).await.map_err(|e| FetchError::Denied {
+        url: url.to_string(),
+        source: e,
+    })?;
+    let resp = builder.send().await.map_err(|e| FetchError::Network {
+        url: url.to_string(),
+        source: e,
+    })?;
+    let status = resp.status();
+    if !status.is_success() {
+        return Err(FetchError::HttpStatus {
+            url: url.to_string(),
+            status: status.as_u16(),
+        });
+    }
+    resp.text().await.map_err(|e| FetchError::Network {
+        url: url.to_string(),
+        source: e,
+    })
+}
+
+/// Parse an RSS 2.0 or Atom feed body.
+pub fn parse_feed(
+    source_name: &str,
+    feed_url: &str,
+    body: &str,
+) -> Result<Vec<FetchedItem>, FetchError> {
+    let parsed = feed_rs::parser::parse(body.as_bytes()).map_err(|e| FetchError::Parse {
+        url: feed_url.to_string(),
+        message: e.to_string(),
+    })?;
+    let mut out = Vec::with_capacity(parsed.entries.len());
+    for entry in parsed.entries {
+        let url = entry
+            .links
+            .iter()
+            .find(|l| !l.href.is_empty())
+            .map(|l| l.href.clone())
+            .unwrap_or_default();
+        if url.is_empty() {
+            // Entries without a URL aren't useful — they can't be
+            // deduped or shown in a digest. Skip rather than fail.
+            continue;
+        }
+        let title = entry
+            .title
+            .as_ref()
+            .map(|t| t.content.trim().to_string())
+            .unwrap_or_default();
+        let abstract_text = entry
+            .summary
+            .as_ref()
+            .map(|s| s.content.clone())
+            .or_else(|| entry.content.as_ref().and_then(|c| c.body.clone()))
+            .unwrap_or_default();
+        let published_at = entry
+            .published
+            .or(entry.updated)
+            .map(format_rfc3339)
+            .unwrap_or_default();
+        out.push(FetchedItem {
+            source_name: source_name.to_string(),
+            url,
+            title,
+            abstract_text,
+            published_at,
+        });
+    }
+    Ok(out)
+}
+
+fn format_rfc3339(dt: DateTime<Utc>) -> String {
+    dt.to_rfc3339()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ATOM_FIXTURE: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>arXiv cs.CY recent</title>
+  <link href="http://arxiv.org/list/cs.CY/recent"/>
+  <updated>2026-04-29T00:00:00Z</updated>
+  <id>http://arxiv.org/list/cs.CY/recent</id>
+
+  <entry>
+    <id>http://arxiv.org/abs/2604.00001</id>
+    <title>BIPA-style enforcement in employment biometrics</title>
+    <link href="http://arxiv.org/abs/2604.00001"/>
+    <published>2026-04-28T12:00:00Z</published>
+    <updated>2026-04-28T12:00:00Z</updated>
+    <summary>This paper surveys BIPA enforcement actions and their effect on employer-collected biometric templates.</summary>
+    <author><name>A. Researcher</name></author>
+  </entry>
+
+  <entry>
+    <id>http://arxiv.org/abs/2604.00002</id>
+    <title>Cookie banner UX patterns 2026</title>
+    <link href="http://arxiv.org/abs/2604.00002"/>
+    <published>2026-04-27T12:00:00Z</published>
+    <updated>2026-04-27T12:00:00Z</updated>
+    <summary>An empirical study of cookie banner designs.</summary>
+    <author><name>B. Researcher</name></author>
+  </entry>
+</feed>
+"#;
+
+    const RSS2_FIXTURE: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>FTC Press Releases</title>
+    <link>https://www.ftc.gov/news-events/news/press-releases</link>
+    <description>Latest press releases.</description>
+    <item>
+      <title>FTC sues data broker over Section 5 unfairness</title>
+      <link>https://www.ftc.gov/news-events/news/press-releases/2026/04/ftc-sues-data-broker</link>
+      <pubDate>Tue, 28 Apr 2026 14:00:00 GMT</pubDate>
+      <description>The Federal Trade Commission today filed suit against ExampleCorp under Section 5 of the FTC Act for unfair data broker practices.</description>
+    </item>
+    <item>
+      <title>FTC requests comments on social media privacy</title>
+      <link>https://www.ftc.gov/news-events/news/press-releases/2026/04/ftc-comments-social-privacy</link>
+      <pubDate>Mon, 27 Apr 2026 09:30:00 GMT</pubDate>
+      <description>The FTC announced a request for public comment on social media privacy practices.</description>
+    </item>
+  </channel>
+</rss>
+"#;
+
+    #[test]
+    fn parses_atom_feed() {
+        let items = parse_feed(
+            "arxiv-cs-cy",
+            "https://export.arxiv.org/list/cs.CY",
+            ATOM_FIXTURE,
+        )
+        .unwrap();
+        assert_eq!(items.len(), 2);
+        assert_eq!(
+            items[0].title,
+            "BIPA-style enforcement in employment biometrics"
+        );
+        assert_eq!(items[0].url, "http://arxiv.org/abs/2604.00001");
+        assert!(items[0].abstract_text.contains("BIPA"));
+        assert_eq!(items[0].source_name, "arxiv-cs-cy");
+        assert!(!items[0].published_at.is_empty());
+    }
+
+    #[test]
+    fn parses_rss2_feed() {
+        let items = parse_feed("ftc-press", "https://www.ftc.gov/feed", RSS2_FIXTURE).unwrap();
+        assert_eq!(items.len(), 2);
+        assert_eq!(
+            items[0].title,
+            "FTC sues data broker over Section 5 unfairness"
+        );
+        assert!(items[0].abstract_text.contains("Section 5"));
+        assert_eq!(items[0].source_name, "ftc-press");
+        assert!(!items[0].published_at.is_empty());
+    }
+
+    #[test]
+    fn malformed_feed_returns_parse_error() {
+        let err = parse_feed("x", "https://x", "not a feed at all").unwrap_err();
+        assert!(matches!(err, FetchError::Parse { .. }));
+    }
+
+    #[test]
+    fn entries_without_link_are_skipped() {
+        let bad = r#"<?xml version="1.0"?>
+<rss version="2.0">
+  <channel>
+    <title>x</title>
+    <link>https://x</link>
+    <description>x</description>
+    <item>
+      <title>has-link</title>
+      <link>https://example.com/a</link>
+      <description>x</description>
+    </item>
+    <item>
+      <title>no-link</title>
+      <description>x</description>
+    </item>
+  </channel>
+</rss>"#;
+        let items = parse_feed("x", "https://x", bad).unwrap();
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].title, "has-link");
+    }
+}

--- a/crates/zirkel/src/interests.rs
+++ b/crates/zirkel/src/interests.rs
@@ -1,0 +1,244 @@
+//! User-owned interests file.
+//!
+//! Path: `~/.wirken/zirkel/interests.toml`. The lawyer hand-edits
+//! this; the orchestrator reads it on every run, snapshots a copy
+//! into `interests_snapshots` for reproducibility, and uses it to
+//! screen + score fetched items.
+//!
+//! ## Schema (deliberately small)
+//!
+//! ```toml
+//! keywords   = ["BIPA", "Section 5 unfairness", "data broker"]
+//! exclusions = ["cookie banner", "GDPR fines under €1M"]
+//! ```
+//!
+//! Two axes — keywords and exclusions — both case-insensitive
+//! substring matches against the candidate's title + abstract.
+//! No `concepts` axis, no embeddings, no learned weights. The user's
+//! actual interface is the file. If the keyword version produces
+//! noise complaints, an embedded-concept axis lands later (Scope D).
+
+use std::path::Path;
+
+use serde::Deserialize;
+use sha2::{Digest, Sha256};
+use thiserror::Error;
+
+/// Parsed interests file in memory.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Interests {
+    pub keywords: Vec<String>,
+    pub exclusions: Vec<String>,
+    /// SHA-256 hex of the file contents at parse time. Recorded in
+    /// `interests_snapshots.file_hash`; an `InterestsEdited` audit
+    /// event fires when the hash differs from the previous run.
+    pub file_hash: String,
+    /// The verbatim bytes parsed. Snapshotted into the run row.
+    pub raw_contents: String,
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
+struct InterestsRaw {
+    #[serde(default)]
+    keywords: Vec<String>,
+    #[serde(default)]
+    exclusions: Vec<String>,
+}
+
+#[derive(Debug, Error)]
+pub enum InterestsError {
+    #[error("read interests file at {path}: {source}")]
+    Read {
+        path: std::path::PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("parse interests file at {path}: {message}")]
+    Parse {
+        path: std::path::PathBuf,
+        message: String,
+    },
+}
+
+/// Parse an interests file from disk.
+pub fn load(path: &Path) -> Result<Interests, InterestsError> {
+    let raw = std::fs::read_to_string(path).map_err(|e| InterestsError::Read {
+        path: path.to_path_buf(),
+        source: e,
+    })?;
+    parse(&raw).map_err(|message| InterestsError::Parse {
+        path: path.to_path_buf(),
+        message,
+    })
+}
+
+/// Parse interests from a string. Used by the loader and by tests.
+pub fn parse(raw: &str) -> Result<Interests, String> {
+    let parsed: InterestsRaw =
+        toml::from_str(raw).map_err(|e| format!("invalid interests TOML: {e}"))?;
+    let mut hasher = Sha256::new();
+    hasher.update(raw.as_bytes());
+    let file_hash = hex::encode(hasher.finalize());
+    Ok(Interests {
+        keywords: parsed.keywords,
+        exclusions: parsed.exclusions,
+        file_hash,
+        raw_contents: raw.to_string(),
+    })
+}
+
+/// Snapshot the interests file into `interests_snapshots` for the
+/// given run. Idempotent against `(run_id, file_hash)` — calling
+/// twice for the same run is a no-op.
+pub fn snapshot(
+    conn: &rusqlite::Connection,
+    run_id: &str,
+    interests: &Interests,
+) -> Result<(), rusqlite::Error> {
+    let already: i64 = conn.query_row(
+        "SELECT COUNT(*) FROM interests_snapshots WHERE run_id = ?1 AND file_hash = ?2",
+        rusqlite::params![run_id, interests.file_hash],
+        |row| row.get(0),
+    )?;
+    if already > 0 {
+        return Ok(());
+    }
+    conn.execute(
+        "INSERT INTO interests_snapshots (run_id, file_hash, contents) VALUES (?1, ?2, ?3)",
+        rusqlite::params![run_id, interests.file_hash, interests.raw_contents],
+    )?;
+    Ok(())
+}
+
+/// The most recent (largest `id`) snapshot's `file_hash`, or `None`
+/// if no snapshots exist. Used by the orchestrator to decide whether
+/// to emit an `InterestsEdited` audit event at the start of a run.
+pub fn last_snapshot_hash(conn: &rusqlite::Connection) -> Result<Option<String>, rusqlite::Error> {
+    let row: Option<String> = conn
+        .query_row(
+            "SELECT file_hash FROM interests_snapshots ORDER BY id DESC LIMIT 1",
+            [],
+            |row| row.get(0),
+        )
+        .ok();
+    Ok(row)
+}
+
+mod hex {
+    pub fn encode(bytes: impl AsRef<[u8]>) -> String {
+        let bytes = bytes.as_ref();
+        let mut s = String::with_capacity(bytes.len() * 2);
+        for b in bytes {
+            s.push_str(&format!("{:02x}", b));
+        }
+        s
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_full_block() {
+        let raw = r#"
+keywords   = ["BIPA", "Section 5"]
+exclusions = ["cookie banner"]
+"#;
+        let i = parse(raw).unwrap();
+        assert_eq!(i.keywords, vec!["BIPA", "Section 5"]);
+        assert_eq!(i.exclusions, vec!["cookie banner"]);
+        assert_eq!(i.file_hash.len(), 64);
+        assert_eq!(i.raw_contents, raw);
+    }
+
+    #[test]
+    fn parses_only_keywords() {
+        let i = parse(r#"keywords = ["X"]"#).unwrap();
+        assert_eq!(i.keywords, vec!["X"]);
+        assert!(i.exclusions.is_empty());
+    }
+
+    #[test]
+    fn parses_only_exclusions() {
+        let i = parse(r#"exclusions = ["X"]"#).unwrap();
+        assert!(i.keywords.is_empty());
+        assert_eq!(i.exclusions, vec!["X"]);
+    }
+
+    #[test]
+    fn parses_both_empty() {
+        let i = parse("").unwrap();
+        assert!(i.keywords.is_empty());
+        assert!(i.exclusions.is_empty());
+    }
+
+    #[test]
+    fn rejects_unknown_field() {
+        let err = parse(r#"concepts = ["foo"]"#).unwrap_err();
+        assert!(err.contains("invalid interests TOML"));
+    }
+
+    #[test]
+    fn rejects_malformed_toml() {
+        let err = parse("keywords = [unclosed").unwrap_err();
+        assert!(err.contains("invalid interests TOML"));
+    }
+
+    #[test]
+    fn file_hash_is_deterministic_and_content_sensitive() {
+        let a = parse("keywords = [\"X\"]").unwrap();
+        let b = parse("keywords = [\"X\"]").unwrap();
+        let c = parse("keywords = [\"Y\"]").unwrap();
+        assert_eq!(a.file_hash, b.file_hash);
+        assert_ne!(a.file_hash, c.file_hash);
+    }
+
+    #[test]
+    fn snapshot_is_idempotent_for_same_hash() {
+        let conn = rusqlite::Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE interests_snapshots ( \
+                id INTEGER PRIMARY KEY AUTOINCREMENT, \
+                run_id TEXT NOT NULL, \
+                file_hash TEXT NOT NULL, \
+                contents TEXT NOT NULL, \
+                created_at TEXT NOT NULL DEFAULT (datetime('now')) \
+            )",
+        )
+        .unwrap();
+        let i = parse(r#"keywords = ["X"]"#).unwrap();
+        snapshot(&conn, "run-1", &i).unwrap();
+        snapshot(&conn, "run-1", &i).unwrap();
+        let count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM interests_snapshots WHERE run_id = 'run-1'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(count, 1);
+    }
+
+    #[test]
+    fn last_snapshot_hash_returns_most_recent() {
+        let conn = rusqlite::Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE interests_snapshots ( \
+                id INTEGER PRIMARY KEY AUTOINCREMENT, \
+                run_id TEXT NOT NULL, \
+                file_hash TEXT NOT NULL, \
+                contents TEXT NOT NULL, \
+                created_at TEXT NOT NULL DEFAULT (datetime('now')) \
+            )",
+        )
+        .unwrap();
+        assert!(last_snapshot_hash(&conn).unwrap().is_none());
+        let a = parse(r#"keywords = ["A"]"#).unwrap();
+        snapshot(&conn, "run-1", &a).unwrap();
+        let b = parse(r#"keywords = ["B"]"#).unwrap();
+        snapshot(&conn, "run-2", &b).unwrap();
+        assert_eq!(last_snapshot_hash(&conn).unwrap(), Some(b.file_hash));
+    }
+}

--- a/crates/zirkel/src/lib.rs
+++ b/crates/zirkel/src/lib.rs
@@ -13,4 +13,8 @@
 //! No LLM call (relevance scoring is Scope C). No clustering, no theme
 //! naming, no digest push.
 
+pub mod fetcher;
+pub mod interests;
 pub mod orchestrator;
+pub mod schema;
+pub mod score;

--- a/crates/zirkel/src/orchestrator.rs
+++ b/crates/zirkel/src/orchestrator.rs
@@ -8,31 +8,49 @@
 //! pipeline calls the policed client directly so egress allowlist
 //! and rate-limit budget enforcement are structural.
 //!
-//! ## What ships in Scope B
+//! ## What ships in the C-foundation slice
 //!
-//! - Load preset via `PresetLoader`.
-//! - Read aggregator skill's permission profile; construct an
-//!   `EgressClient` whose enforcement matches the profile and whose
-//!   inner `RateLimitedClient` carries the per-host caps.
-//! - Read `sources.toml`. Pick the first source.
-//! - Fetch its endpoint through the policed client.
-//! - Open `SkillStore` for the aggregator under `storage_dir`.
-//! - Migrate to a minimal `candidates` schema.
-//! - Insert one candidate row whose body is the response text.
+//! - Load preset; read aggregator skill's permission profile.
+//! - Load interests file from [`OrchestratorConfig::interests_path`]
+//!   and snapshot it into `interests_snapshots` for the run.
+//! - For every source in `sources.toml`: dispatch by `method` (RSS
+//!   and Atom go through [`crate::fetcher`]; API and scrape methods
+//!   are unsupported in this slice and logged as skipped).
+//! - Dedup parsed items against the `seen` table by URL.
+//! - Screen each new item with [`crate::score::screen`] — exclusions
+//!   take precedence over keyword matches; items with score 0 land in
+//!   `skipped_log`, not `candidates`.
+//! - Write kept items to `candidates` with `run_id`, `matched_keywords`,
+//!   and `keyword_match_score`.
+//! - Emit `HttpFetch`, `CandidateScored`, `CandidateSkipped`, and
+//!   `InterestsEdited` audit events into the supplied
+//!   [`wirken_audit::SessionLog`].
 //!
-//! Scoring, clustering, theme naming, digest push are Scope C.
+//! Scoring's `keyword_match_score` field is the count of distinct
+//! keyword matches against title + abstract, not a 0–100 relevance
+//! rating. The C-LLM slice adds a separate `llm_relevance_score
+//! REAL` column for the LLM-driven relevance pass; the keyword score
+//! stays as a transparent first filter the user can verify.
 
-#[cfg(test)]
-use std::path::Path;
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use serde::Deserialize;
+use sha2::{Digest, Sha256};
 use thiserror::Error;
 use wirken_agent::egress::{EgressClient, EgressEnforcement, HttpAccessDenied};
 use wirken_agent::preset::PresetLoader;
 use wirken_agent::rate_limit::RateLimitConfig;
 use wirken_agent::skill_perms::PermissionProfile;
+use wirken_audit::{
+    HashHex, OwnSession, SessionEvent, SessionHandle, SessionId, SessionLog, TrustLevel,
+};
 use wirken_skill_store::{SkillStore, SkillStoreError};
+
+use crate::fetcher::{FetchError, FetchedItem, fetch_rss};
+use crate::interests::{InterestsError, last_snapshot_hash, load as load_interests, snapshot};
+use crate::schema::AGGREGATOR_MIGRATIONS;
+use crate::score::{Item, Screened, screen};
 
 const AGGREGATOR_SKILL_NAME: &str = "aggregator";
 
@@ -40,24 +58,50 @@ const AGGREGATOR_SKILL_NAME: &str = "aggregator";
 pub struct OrchestratorConfig {
     /// Directory of the installed preset (e.g. `~/.wirken/presets/zirkel/`).
     pub preset_dir: PathBuf,
-    /// Directory where the aggregator's SQLite store and full bodies
-    /// live (e.g. `~/.wirken/zirkel/`). Must be inside the aggregator
-    /// skill's `permissions.filesystem.write_paths` allow-set.
+    /// Directory where the aggregator's SQLite store lives. Must be
+    /// inside the aggregator skill's
+    /// `permissions.filesystem.write_paths` allow-set.
     pub storage_dir: PathBuf,
-    /// Rate-limit config for the per-source HTTP transport. Production
-    /// uses the schema-defaulted [`RateLimitConfig::default`]; tests
-    /// can pass [`RateLimitConfig::unrestricted_for_tests`] to skip
-    /// jitter.
+    /// Path to the interests file. Conventionally `<storage_dir>/interests.toml`
+    /// but kept explicit so tests can drop a fixture anywhere.
+    pub interests_path: PathBuf,
+    /// Rate-limit config for per-source HTTP. Production uses
+    /// [`RateLimitConfig::default`]; tests can pass
+    /// [`RateLimitConfig::unrestricted_for_tests`] to skip jitter.
     pub rate_limit: RateLimitConfig,
+    /// Audit log to emit fetch / score / skip events into. `None`
+    /// disables audit emission — useful for tests that don't care
+    /// about audit chain semantics. Production threads in the same
+    /// `Arc<dyn SessionLog>` the rest of Wirken uses so the chain is
+    /// continuous across orchestrator runs and agent sessions.
+    pub session_log: Option<Arc<dyn SessionLog>>,
 }
 
-/// Summary of what [`run`] did.
-#[derive(Debug, Clone)]
+/// Outcome of one orchestrator run, by category.
+#[derive(Debug, Clone, Default)]
 pub struct RunSummary {
-    pub source_name: String,
-    pub source_url: String,
-    pub candidate_id: i64,
-    pub bytes_fetched: usize,
+    pub run_id: String,
+    pub sources_attempted: usize,
+    pub sources_succeeded: usize,
+    /// Sources whose method this slice does not yet support
+    /// (api / scrape). Logged as skipped in the audit, not failed.
+    pub sources_unsupported: Vec<String>,
+    /// Sources whose fetch or parse failed. The run continues — one
+    /// flaky source does not block the others.
+    pub sources_failed: Vec<SourceFailure>,
+    pub items_seen: usize,
+    pub items_new: usize,
+    pub items_excluded: usize,
+    pub items_score_zero: usize,
+    pub items_kept: usize,
+    pub kept_candidate_ids: Vec<i64>,
+    pub interests_changed: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct SourceFailure {
+    pub source: String,
+    pub reason: String,
 }
 
 #[derive(Debug, Error)]
@@ -74,61 +118,40 @@ pub enum OrchestratorError {
     },
     #[error("parse sources.toml at {path}: {message}")]
     ParseSources { path: PathBuf, message: String },
-    #[error("sources.toml is empty — nothing to fetch")]
-    EmptySources,
-    #[error("HTTP fetch denied for {url}: {source}")]
-    HttpDenied {
-        url: String,
-        #[source]
-        source: HttpAccessDenied,
-    },
-    #[error("HTTP fetch failed for {url}: {source}")]
-    HttpFailed {
-        url: String,
-        #[source]
-        source: reqwest::Error,
-    },
-    #[error("HTTP non-success for {url}: status {status}")]
-    HttpStatus { url: String, status: u16 },
+    #[error("load interests: {0}")]
+    LoadInterests(#[from] InterestsError),
     #[error("skill store: {0}")]
     Store(#[from] SkillStoreError),
-    #[error("write candidate row: {0}")]
-    WriteCandidate(#[from] rusqlite::Error),
+    #[error("sqlite: {0}")]
+    Sqlite(#[from] rusqlite::Error),
 }
 
-/// Schema migrations applied to the aggregator's SkillStore. Order is
-/// load-bearing — never reorder or replace existing entries; append only.
-const AGGREGATOR_MIGRATIONS: &[&str] = &["CREATE TABLE candidates ( \
-        id           INTEGER PRIMARY KEY AUTOINCREMENT, \
-        source_name  TEXT NOT NULL, \
-        url          TEXT NOT NULL, \
-        fetched_at   TEXT NOT NULL DEFAULT (datetime('now')), \
-        body         TEXT NOT NULL \
-    )"];
-
-/// On-disk shape of `sources.toml`. Only the fields the Scope B
-/// orchestrator consumes are required; later scopes will tighten
-/// the schema as additional fields become load-bearing.
+/// On-disk shape of `sources.toml`.
 #[derive(Debug, Deserialize)]
 struct SourcesManifest {
     #[serde(default, rename = "source")]
     sources: Vec<SourceEntry>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone)]
 struct SourceEntry {
     name: String,
     endpoint: String,
+    method: String,
 }
 
-/// Run the orchestrator once. Loads the preset, fetches the first
-/// source from `sources.toml`, writes one candidate row, returns.
-///
-/// Caller responsibility: ensure `config.storage_dir` is within the
-/// aggregator skill's `permissions.filesystem.write_paths` allow-set.
-/// The store open will fail loud otherwise — preferred to silent
-/// out-of-policy writes.
+/// Adapter so [`FetchedItem`] can be passed to [`screen`].
+impl Item for FetchedItem {
+    fn haystack(&self) -> String {
+        format!("{} {}", self.title, self.abstract_text)
+    }
+}
+
+/// Run the orchestrator once.
 pub async fn run(config: OrchestratorConfig) -> Result<RunSummary, OrchestratorError> {
+    let run_id = uuid::Uuid::new_v4().to_string();
+
+    // Preset + aggregator profile.
     let loaded = PresetLoader::load_dir(&config.preset_dir)
         .map_err(|e| OrchestratorError::LoadPreset(e.to_string()))?;
     let aggregator = loaded
@@ -138,6 +161,11 @@ pub async fn run(config: OrchestratorConfig) -> Result<RunSummary, OrchestratorE
         .ok_or(OrchestratorError::AggregatorSkillMissing)?;
     let profile: PermissionProfile = aggregator.permissions.clone();
 
+    // Interests file is required — running without one would produce
+    // an unscored fetch with no honest threshold for digest inclusion.
+    let interests = load_interests(&config.interests_path)?;
+
+    // Sources manifest.
     let sources_path = config.preset_dir.join("sources.toml");
     let raw =
         std::fs::read_to_string(&sources_path).map_err(|e| OrchestratorError::ReadSources {
@@ -149,138 +177,338 @@ pub async fn run(config: OrchestratorConfig) -> Result<RunSummary, OrchestratorE
             path: sources_path.clone(),
             message: e.to_string(),
         })?;
-    let first = manifest
-        .sources
-        .into_iter()
-        .next()
-        .ok_or(OrchestratorError::EmptySources)?;
 
+    // Policed HTTP transport with the aggregator's egress allow-set.
     let http = EgressClient::with_rate_limit(config.rate_limit.clone());
     http.set_enforcement(EgressEnforcement::from_profile(
         &wirken_agent::skill_perms::EffectiveProfile::Resolved(profile.clone()),
     ));
 
-    let resp_text = match http.get(&first.endpoint).await {
-        Ok(builder) => {
-            let resp = builder
-                .send()
-                .await
-                .map_err(|e| OrchestratorError::HttpFailed {
-                    url: first.endpoint.clone(),
-                    source: e,
-                })?;
-            let status = resp.status();
-            if !status.is_success() {
-                return Err(OrchestratorError::HttpStatus {
-                    url: first.endpoint.clone(),
-                    status: status.as_u16(),
-                });
-            }
-            resp.text()
-                .await
-                .map_err(|e| OrchestratorError::HttpFailed {
-                    url: first.endpoint.clone(),
-                    source: e,
-                })?
-        }
-        Err(e) => {
-            return Err(OrchestratorError::HttpDenied {
-                url: first.endpoint.clone(),
-                source: e,
-            });
-        }
-    };
-
+    // Per-skill SQLite store.
     let mut store = SkillStore::open(AGGREGATOR_SKILL_NAME, &config.storage_dir, &profile)?;
     store.migrate(AGGREGATOR_MIGRATIONS)?;
-    let bytes = resp_text.len();
-    let row_id: i64;
-    {
-        let conn = store.conn();
-        conn.execute(
-            "INSERT INTO candidates (source_name, url, body) VALUES (?1, ?2, ?3)",
-            rusqlite::params![first.name, first.endpoint, resp_text],
-        )?;
-        row_id = conn.last_insert_rowid();
+
+    // Audit handle for this run.
+    let audit_handle = config
+        .session_log
+        .as_ref()
+        .map(|log| log.handle_for(SessionId::new(run_id.clone())));
+
+    // Snapshot interests and detect change against the prior run.
+    let prior_hash = last_snapshot_hash(store.conn())?;
+    snapshot(store.conn(), &run_id, &interests)?;
+    let interests_changed = match prior_hash.as_deref() {
+        Some(h) if h != interests.file_hash => {
+            emit(
+                config.session_log.as_ref(),
+                audit_handle.as_ref(),
+                SessionEvent::InterestsEdited {
+                    before_hash: HashHex(h.to_string()),
+                    after_hash: HashHex(interests.file_hash.clone()),
+                },
+            );
+            true
+        }
+        _ => false,
+    };
+
+    let mut summary = RunSummary {
+        run_id: run_id.clone(),
+        interests_changed,
+        ..Default::default()
+    };
+
+    for source in &manifest.sources {
+        summary.sources_attempted += 1;
+
+        // Dispatch by method. Foundation slice supports RSS and Atom
+        // (both via feed-rs); api / scrape are recorded as skipped.
+        let items = match source.method.as_str() {
+            "rss" | "atom-api" => match fetch_rss(&http, &source.name, &source.endpoint).await {
+                Ok(items) => {
+                    emit_http_fetch(
+                        config.session_log.as_ref(),
+                        audit_handle.as_ref(),
+                        source,
+                        "ok",
+                        bytes_total(&items),
+                        &run_id,
+                    );
+                    items
+                }
+                Err(e) => {
+                    let outcome = fetch_outcome_label(&e);
+                    emit_http_fetch(
+                        config.session_log.as_ref(),
+                        audit_handle.as_ref(),
+                        source,
+                        &outcome,
+                        0,
+                        &run_id,
+                    );
+                    summary.sources_failed.push(SourceFailure {
+                        source: source.name.clone(),
+                        reason: e.to_string(),
+                    });
+                    continue;
+                }
+            },
+            other => {
+                summary.sources_unsupported.push(source.name.clone());
+                tracing::info!(
+                    "source '{}' uses method '{}' which is unsupported in the C-foundation slice",
+                    source.name,
+                    other
+                );
+                continue;
+            }
+        };
+
+        summary.sources_succeeded += 1;
+        summary.items_seen += items.len();
+
+        for item in items {
+            // Dedup against the seen table.
+            let url_hash = sha256_hex(&item.url);
+            let already_seen: i64 = store.conn().query_row(
+                "SELECT COUNT(*) FROM seen WHERE url_hash = ?1",
+                rusqlite::params![url_hash],
+                |row| row.get(0),
+            )?;
+            if already_seen > 0 {
+                emit_skip(
+                    config.session_log.as_ref(),
+                    audit_handle.as_ref(),
+                    &run_id,
+                    &item,
+                    &url_hash,
+                    "duplicate_url",
+                );
+                store.conn().execute(
+                    "INSERT INTO skipped_log (run_id, url_hash, url, source_name, reason) \
+                     VALUES (?1, ?2, ?3, ?4, ?5)",
+                    rusqlite::params![
+                        &run_id,
+                        &url_hash,
+                        &item.url,
+                        &item.source_name,
+                        "duplicate_url"
+                    ],
+                )?;
+                continue;
+            }
+            // Mark seen before screening so a later orchestrator run
+            // doesn't re-discover the same URL even if screening
+            // changed (e.g., updated interests file would make a
+            // previously-excluded item now match a keyword).
+            store.conn().execute(
+                "INSERT INTO seen (url, url_hash) VALUES (?1, ?2)",
+                rusqlite::params![&item.url, &url_hash],
+            )?;
+            summary.items_new += 1;
+
+            match screen(&item, &interests.keywords, &interests.exclusions) {
+                Screened::Excluded { matched_exclusion } => {
+                    summary.items_excluded += 1;
+                    store.conn().execute(
+                        "INSERT INTO skipped_log (run_id, url_hash, url, source_name, reason, detail) \
+                         VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+                        rusqlite::params![
+                            &run_id,
+                            &url_hash,
+                            &item.url,
+                            &item.source_name,
+                            "exclusion_match",
+                            matched_exclusion
+                        ],
+                    )?;
+                    emit_skip(
+                        config.session_log.as_ref(),
+                        audit_handle.as_ref(),
+                        &run_id,
+                        &item,
+                        &url_hash,
+                        "exclusion_match",
+                    );
+                }
+                Screened::Zero => {
+                    summary.items_score_zero += 1;
+                    store.conn().execute(
+                        "INSERT INTO skipped_log (run_id, url_hash, url, source_name, reason) \
+                         VALUES (?1, ?2, ?3, ?4, ?5)",
+                        rusqlite::params![
+                            &run_id,
+                            &url_hash,
+                            &item.url,
+                            &item.source_name,
+                            "score_zero"
+                        ],
+                    )?;
+                    emit_skip(
+                        config.session_log.as_ref(),
+                        audit_handle.as_ref(),
+                        &run_id,
+                        &item,
+                        &url_hash,
+                        "score_zero",
+                    );
+                }
+                Screened::Kept {
+                    matched_keywords,
+                    keyword_match_score,
+                } => {
+                    let matched_json = serde_json::to_string(&matched_keywords)
+                        .unwrap_or_else(|_| "[]".to_string());
+                    let published_at: Option<String> = if item.published_at.is_empty() {
+                        None
+                    } else {
+                        Some(item.published_at.clone())
+                    };
+                    store.conn().execute(
+                        "INSERT INTO candidates ( \
+                            source_name, url, body, run_id, title, published_at, \
+                            matched_keywords, keyword_match_score \
+                         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+                        rusqlite::params![
+                            &item.source_name,
+                            &item.url,
+                            &item.abstract_text,
+                            &run_id,
+                            &item.title,
+                            &published_at,
+                            &matched_json,
+                            keyword_match_score as i64,
+                        ],
+                    )?;
+                    let candidate_id = store.conn().last_insert_rowid();
+                    summary.items_kept += 1;
+                    summary.kept_candidate_ids.push(candidate_id);
+                    if let (Some(log), Some(handle)) =
+                        (config.session_log.as_ref(), audit_handle.as_ref())
+                    {
+                        let _ = log.append(
+                            handle,
+                            TrustLevel::System,
+                            SessionEvent::CandidateScored {
+                                run_id: run_id.clone(),
+                                candidate_id,
+                                keyword_match_score,
+                                matched_keywords: matched_json,
+                            },
+                        );
+                    }
+                }
+            }
+        }
     }
 
-    Ok(RunSummary {
-        source_name: first.name,
-        source_url: first.endpoint,
-        candidate_id: row_id,
-        bytes_fetched: bytes,
-    })
+    Ok(summary)
 }
 
-/// Test helper: write a fixture preset directory with the supplied
-/// aggregator egress allow-set and source endpoint. Returns the
-/// preset_dir path. The caller passes this to [`run`].
-#[cfg(test)]
-pub(crate) fn write_fixture_preset(
-    dest: &Path,
-    storage_dir: &Path,
-    egress_allowlist: &[&str],
-    source_url: &str,
-) -> std::io::Result<()> {
-    std::fs::create_dir_all(dest.join("skills/aggregator"))?;
-    std::fs::write(
-        dest.join("preset.toml"),
-        r#"
-[preset]
-name = "test-preset"
-description = "fixture for orchestrator tests"
-version = "0.0.1"
-skills = ["aggregator"]
-"#,
-    )?;
-    let domains_yaml = egress_allowlist
+fn sha256_hex(s: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(s.as_bytes());
+    let bytes = hasher.finalize();
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        out.push_str(&format!("{:02x}", b));
+    }
+    out
+}
+
+fn bytes_total(items: &[FetchedItem]) -> u64 {
+    items
         .iter()
-        .map(|d| format!("      - {d}"))
-        .collect::<Vec<_>>()
-        .join("\n");
-    let storage_yaml = storage_dir.display().to_string();
-    let aggregator_md = format!(
-        "---\n\
-         name: aggregator\n\
-         description: fixture aggregator\n\
-         disable-model-invocation: true\n\
-         permissions:\n\
-         \x20\x20tools:\n\
-         \x20\x20\x20\x20allow: [exec]\n\
-         \x20\x20egress:\n\
-         \x20\x20\x20\x20mode: allowlist\n\
-         \x20\x20\x20\x20domains:\n{domains_yaml}\n\
-         \x20\x20filesystem:\n\
-         \x20\x20\x20\x20write_paths: [\"{storage_yaml}\"]\n\
-         \x20\x20\x20\x20read_paths: [\"{storage_yaml}\"]\n\
-         \x20\x20inference:\n\
-         \x20\x20\x20\x20allow: [\"*\"]\n\
-         ---\n\nbody\n",
+        .map(|i| (i.title.len() + i.abstract_text.len()) as u64)
+        .sum()
+}
+
+fn fetch_outcome_label(e: &FetchError) -> String {
+    match e {
+        FetchError::Denied {
+            source: HttpAccessDenied::Egress(_),
+            ..
+        } => "egress_denied".to_string(),
+        FetchError::Denied {
+            source: HttpAccessDenied::RateLimit(_),
+            ..
+        } => "rate_limited".to_string(),
+        FetchError::HttpStatus { status, .. } => format!("http_error_{}", status),
+        FetchError::Network { .. } => "network_error".to_string(),
+        FetchError::Parse { .. } => "parse_error".to_string(),
+    }
+}
+
+fn host_of(url: &str) -> String {
+    url::Url::parse(url)
+        .ok()
+        .and_then(|u| u.host_str().map(|s| s.to_string()))
+        .unwrap_or_default()
+}
+
+fn emit(
+    session_log: Option<&Arc<dyn SessionLog>>,
+    handle: Option<&SessionHandle<OwnSession>>,
+    event: SessionEvent,
+) {
+    if let (Some(log), Some(handle)) = (session_log, handle) {
+        if let Err(e) = log.append(handle, TrustLevel::System, event) {
+            tracing::warn!("zirkel audit append failed: {e}");
+        }
+    }
+}
+
+fn emit_http_fetch(
+    session_log: Option<&Arc<dyn SessionLog>>,
+    handle: Option<&SessionHandle<OwnSession>>,
+    source: &SourceEntry,
+    outcome: &str,
+    bytes: u64,
+    run_id: &str,
+) {
+    emit(
+        session_log,
+        handle,
+        SessionEvent::HttpFetch {
+            source: source.name.clone(),
+            host: host_of(&source.endpoint),
+            url: source.endpoint.clone(),
+            outcome: outcome.to_string(),
+            bytes,
+            run_id: Some(run_id.to_string()),
+        },
     );
-    std::fs::write(dest.join("skills/aggregator/SKILL.md"), aggregator_md)?;
-    std::fs::write(
-        dest.join("sources.toml"),
-        format!(
-            "[[source]]\n\
-             name = \"test-source\"\n\
-             host = \"127.0.0.1\"\n\
-             method = \"json-api\"\n\
-             endpoint = \"{source_url}\"\n",
-        ),
-    )?;
-    Ok(())
+}
+
+fn emit_skip(
+    session_log: Option<&Arc<dyn SessionLog>>,
+    handle: Option<&SessionHandle<OwnSession>>,
+    run_id: &str,
+    item: &FetchedItem,
+    url_hash: &str,
+    reason: &str,
+) {
+    emit(
+        session_log,
+        handle,
+        SessionEvent::CandidateSkipped {
+            run_id: run_id.to_string(),
+            url_hash: HashHex(url_hash.to_string()),
+            source: item.source_name.clone(),
+            reason: reason.to_string(),
+        },
+    );
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Arc;
+    use std::path::Path;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::net::TcpListener;
+    use wirken_audit::SqliteSessionLog;
 
-    /// Spin up a tiny local HTTP server that accepts one connection
-    /// and responds with `body`. Returns the bound URL like
-    /// `http://127.0.0.1:<port>/`.
+    /// One-shot HTTP server that responds with a fixed body.
     async fn one_shot_server(body: &'static str) -> String {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
@@ -290,7 +518,7 @@ mod tests {
                 let mut buf = [0u8; 4096];
                 let _ = sock.read(&mut buf).await;
                 let resp = format!(
-                    "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nContent-Type: text/plain\r\n\r\n{}",
+                    "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nContent-Type: application/xml\r\n\r\n{}",
                     body.len(),
                     body
                 );
@@ -301,93 +529,351 @@ mod tests {
         url
     }
 
-    /// Keystone test: orchestrator fetches one source via the policed
-    /// transport, writes a candidate row to the per-skill SQLite,
-    /// returns a summary. End-to-end through the layers we built.
-    #[tokio::test]
-    async fn fetches_one_source_and_writes_one_candidate() {
-        let body = "hello from fixture source";
-        let url = one_shot_server(body).await;
+    /// Multi-shot server that serves the same body N times.
+    async fn multi_shot_server(body: &'static str, count: usize) -> String {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let url = format!("http://{}/", addr);
+        tokio::spawn(async move {
+            for _ in 0..count {
+                if let Ok((mut sock, _)) = listener.accept().await {
+                    let mut buf = [0u8; 4096];
+                    let _ = sock.read(&mut buf).await;
+                    let resp = format!(
+                        "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nContent-Type: application/xml\r\n\r\n{}",
+                        body.len(),
+                        body
+                    );
+                    let _ = sock.write_all(resp.as_bytes()).await;
+                    let _ = sock.shutdown().await;
+                }
+            }
+        });
+        url
+    }
 
+    fn write_fixture_preset(
+        dest: &Path,
+        storage_dir: &Path,
+        egress_allowlist: &[&str],
+        sources_toml: &str,
+    ) {
+        std::fs::create_dir_all(dest.join("skills/aggregator")).unwrap();
+        std::fs::write(
+            dest.join("preset.toml"),
+            r#"
+[preset]
+name = "test-preset"
+description = "fixture for orchestrator tests"
+version = "0.0.1"
+skills = ["aggregator"]
+"#,
+        )
+        .unwrap();
+        let domains_yaml = egress_allowlist
+            .iter()
+            .map(|d| format!("      - {d}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let storage_yaml = storage_dir.display().to_string();
+        let aggregator_md = format!(
+            "---\n\
+             name: aggregator\n\
+             description: fixture aggregator\n\
+             disable-model-invocation: true\n\
+             permissions:\n\
+             \x20\x20tools:\n\
+             \x20\x20\x20\x20allow: [exec]\n\
+             \x20\x20egress:\n\
+             \x20\x20\x20\x20mode: allowlist\n\
+             \x20\x20\x20\x20domains:\n{domains_yaml}\n\
+             \x20\x20filesystem:\n\
+             \x20\x20\x20\x20write_paths: [\"{storage_yaml}\"]\n\
+             \x20\x20\x20\x20read_paths: [\"{storage_yaml}\"]\n\
+             \x20\x20inference:\n\
+             \x20\x20\x20\x20allow: [\"*\"]\n\
+             ---\n\nbody\n",
+        );
+        std::fs::write(dest.join("skills/aggregator/SKILL.md"), aggregator_md).unwrap();
+        std::fs::write(dest.join("sources.toml"), sources_toml).unwrap();
+    }
+
+    fn write_interests(path: &Path, raw: &str) {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        std::fs::write(path, raw).unwrap();
+    }
+
+    const FTC_FIXTURE: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0"><channel>
+<title>FTC</title><link>https://www.ftc.gov</link><description>x</description>
+<item>
+  <title>FTC sues data broker over Section 5 unfairness</title>
+  <link>https://www.ftc.gov/news/2026/04/data-broker</link>
+  <pubDate>Tue, 28 Apr 2026 14:00:00 GMT</pubDate>
+  <description>The Federal Trade Commission today filed suit against ExampleCorp under Section 5 of the FTC Act for unfair data broker practices.</description>
+</item>
+<item>
+  <title>Cookie banner enforcement update</title>
+  <link>https://www.ftc.gov/news/2026/04/cookie-banner</link>
+  <pubDate>Mon, 27 Apr 2026 09:30:00 GMT</pubDate>
+  <description>The FTC announces updates to cookie banner standards.</description>
+</item>
+<item>
+  <title>Generic news about birds</title>
+  <link>https://www.ftc.gov/news/2026/04/birds</link>
+  <pubDate>Sun, 26 Apr 2026 09:30:00 GMT</pubDate>
+  <description>Birds are an underexplored area of FTC interest.</description>
+</item>
+</channel></rss>"#;
+
+    fn config_with_log(
+        preset_dir: PathBuf,
+        storage_dir: PathBuf,
+        interests_path: PathBuf,
+        log: Option<Arc<dyn SessionLog>>,
+    ) -> OrchestratorConfig {
+        OrchestratorConfig {
+            preset_dir,
+            storage_dir,
+            interests_path,
+            rate_limit: RateLimitConfig::unrestricted_for_tests(),
+            session_log: log,
+        }
+    }
+
+    /// Keystone test for the C-foundation slice: orchestrator fetches an
+    /// RSS feed, parses three items, drops the cookie-banner one for
+    /// exclusion match, drops the bird one for score zero, keeps the
+    /// data-broker item, writes its candidate row with matched_keywords
+    /// and keyword_match_score.
+    #[tokio::test]
+    async fn fetches_rss_screens_and_writes_kept_candidates() {
+        let url = one_shot_server(FTC_FIXTURE).await;
         let tmp = tempfile::tempdir().unwrap();
         let preset_dir = tmp.path().join("preset");
         let storage_dir = tmp.path().join("storage");
         std::fs::create_dir_all(&storage_dir).unwrap();
-        write_fixture_preset(&preset_dir, &storage_dir, &["127.0.0.1"], &url).unwrap();
+        let sources_toml = format!(
+            "[[source]]\nname=\"ftc\"\nendpoint=\"{url}\"\nmethod=\"rss\"\n",
+            url = url
+        );
+        write_fixture_preset(&preset_dir, &storage_dir, &["127.0.0.1"], &sources_toml);
+        let interests_path = storage_dir.join("interests.toml");
+        write_interests(
+            &interests_path,
+            r#"keywords = ["data broker", "Section 5"]
+exclusions = ["cookie banner"]"#,
+        );
 
-        let summary = run(OrchestratorConfig {
+        let summary = run(config_with_log(
             preset_dir,
-            storage_dir: storage_dir.clone(),
-            rate_limit: RateLimitConfig::unrestricted_for_tests(),
-        })
+            storage_dir.clone(),
+            interests_path,
+            None,
+        ))
         .await
         .unwrap();
 
-        assert_eq!(summary.source_name, "test-source");
-        assert_eq!(summary.bytes_fetched, body.len());
+        assert_eq!(summary.sources_attempted, 1);
+        assert_eq!(summary.sources_succeeded, 1);
+        assert_eq!(summary.items_seen, 3);
+        assert_eq!(summary.items_new, 3);
+        assert_eq!(summary.items_excluded, 1);
+        assert_eq!(summary.items_score_zero, 1);
+        assert_eq!(summary.items_kept, 1);
+        assert_eq!(summary.kept_candidate_ids.len(), 1);
 
-        // Verify the candidate row landed in SQLite.
-        let db_path = storage_dir.join("aggregator.db");
-        assert!(db_path.exists());
-        let conn = rusqlite::Connection::open(&db_path).unwrap();
-        let (saved_url, saved_body): (String, String) = conn
+        let conn = rusqlite::Connection::open(storage_dir.join("aggregator.db")).unwrap();
+        let (title, score, matched, run_id_col): (String, i64, String, String) = conn
             .query_row(
-                "SELECT url, body FROM candidates WHERE id = ?1",
-                rusqlite::params![summary.candidate_id],
-                |row| Ok((row.get(0)?, row.get(1)?)),
+                "SELECT title, keyword_match_score, matched_keywords, run_id \
+                 FROM candidates WHERE id = ?1",
+                rusqlite::params![summary.kept_candidate_ids[0]],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
             )
             .unwrap();
-        assert_eq!(saved_url, summary.source_url);
-        assert_eq!(saved_body, body);
+        assert!(title.contains("data broker"));
+        assert_eq!(score, 2);
+        assert!(matched.contains("data broker"));
+        assert!(matched.contains("Section 5"));
+        assert_eq!(run_id_col, summary.run_id);
     }
 
-    /// A request to a non-allowlisted host fails fast at egress
-    /// without consuming rate-limit budget — the layering invariant
-    /// from Phase 1 still holds when the orchestrator drives.
+    /// A second run against the same fixture sees zero new items —
+    /// dedup-against-seen takes effect.
     #[tokio::test]
-    async fn non_allowlisted_host_fails_at_egress() {
-        // Server on 127.0.0.1 but the allowlist names a DIFFERENT host.
-        let body = "should not be fetched";
-        let url = one_shot_server(body).await;
-
+    async fn second_run_dedups_against_seen() {
+        let url = multi_shot_server(FTC_FIXTURE, 2).await;
         let tmp = tempfile::tempdir().unwrap();
         let preset_dir = tmp.path().join("preset");
         let storage_dir = tmp.path().join("storage");
         std::fs::create_dir_all(&storage_dir).unwrap();
-        write_fixture_preset(&preset_dir, &storage_dir, &["allowed.example.com"], &url).unwrap();
+        let sources_toml =
+            format!("[[source]]\nname=\"ftc\"\nendpoint=\"{url}\"\nmethod=\"rss\"\n");
+        write_fixture_preset(&preset_dir, &storage_dir, &["127.0.0.1"], &sources_toml);
+        let interests_path = storage_dir.join("interests.toml");
+        write_interests(
+            &interests_path,
+            r#"keywords = ["data broker"]
+exclusions = []"#,
+        );
 
-        let err = run(OrchestratorConfig {
-            preset_dir,
-            storage_dir: storage_dir.clone(),
-            rate_limit: RateLimitConfig::unrestricted_for_tests(),
-        })
+        let first = run(config_with_log(
+            preset_dir.clone(),
+            storage_dir.clone(),
+            interests_path.clone(),
+            None,
+        ))
         .await
-        .unwrap_err();
+        .unwrap();
+        let second = run(config_with_log(
+            preset_dir,
+            storage_dir.clone(),
+            interests_path,
+            None,
+        ))
+        .await
+        .unwrap();
 
-        match err {
-            OrchestratorError::HttpDenied {
-                source: HttpAccessDenied::Egress(_),
-                ..
-            } => {}
-            other => panic!("expected HttpDenied(Egress), got {other:?}"),
-        }
-
-        // No candidate row should have been written.
-        let db_path = storage_dir.join("aggregator.db");
-        if db_path.exists() {
-            let conn = rusqlite::Connection::open(&db_path).unwrap();
-            // The schema migration may or may not have run depending on
-            // ordering; if the table exists, it must be empty.
-            let count: Option<i64> = conn
-                .query_row("SELECT COUNT(*) FROM candidates", [], |row| row.get(0))
-                .ok();
-            assert_eq!(count.unwrap_or(0), 0);
-        }
+        assert_eq!(first.items_new, 3);
+        assert_eq!(second.items_seen, 3, "second run sees the same 3 items");
+        assert_eq!(second.items_new, 0, "but dedup drops them all");
+        assert_eq!(second.items_kept, 0);
     }
 
-    /// Sanity: aggregator skill missing from the preset is a typed
-    /// error, not a panic. Catches future preset edits that drop the
-    /// aggregator without updating the orchestrator's expectations.
+    /// Source method `json-api` is recorded as unsupported; the run
+    /// continues for the other sources rather than aborting.
+    #[tokio::test]
+    async fn unsupported_method_is_recorded_as_skipped() {
+        let url = one_shot_server(FTC_FIXTURE).await;
+        let tmp = tempfile::tempdir().unwrap();
+        let preset_dir = tmp.path().join("preset");
+        let storage_dir = tmp.path().join("storage");
+        std::fs::create_dir_all(&storage_dir).unwrap();
+        let sources_toml = format!(
+            "[[source]]\nname=\"ftc\"\nendpoint=\"{url}\"\nmethod=\"rss\"\n\
+             [[source]]\nname=\"congress\"\nendpoint=\"https://api.congress.gov/v3/\"\nmethod=\"json-api\"\n"
+        );
+        write_fixture_preset(
+            &preset_dir,
+            &storage_dir,
+            &["127.0.0.1", "api.congress.gov"],
+            &sources_toml,
+        );
+        let interests_path = storage_dir.join("interests.toml");
+        write_interests(&interests_path, r#"keywords = ["data broker"]"#);
+
+        let summary = run(config_with_log(
+            preset_dir,
+            storage_dir,
+            interests_path,
+            None,
+        ))
+        .await
+        .unwrap();
+
+        assert_eq!(summary.sources_attempted, 2);
+        assert_eq!(summary.sources_succeeded, 1);
+        assert_eq!(summary.sources_unsupported, vec!["congress".to_string()]);
+        assert_eq!(summary.items_kept, 1);
+    }
+
+    /// Egress denial fails fast WITHOUT consuming budget. The
+    /// orchestrator logs the failure and moves on; one source's
+    /// allowlist mismatch doesn't abort the run.
+    #[tokio::test]
+    async fn egress_denied_source_is_recorded_as_failed_run_continues() {
+        // Server bound on 127.0.0.1, but egress allowlist names a
+        // different host. The fetch fails at egress.
+        let url = one_shot_server(FTC_FIXTURE).await;
+        let tmp = tempfile::tempdir().unwrap();
+        let preset_dir = tmp.path().join("preset");
+        let storage_dir = tmp.path().join("storage");
+        std::fs::create_dir_all(&storage_dir).unwrap();
+        let sources_toml =
+            format!("[[source]]\nname=\"ftc\"\nendpoint=\"{url}\"\nmethod=\"rss\"\n");
+        write_fixture_preset(
+            &preset_dir,
+            &storage_dir,
+            &["allowed.example.com"],
+            &sources_toml,
+        );
+        let interests_path = storage_dir.join("interests.toml");
+        write_interests(&interests_path, r#"keywords = ["data broker"]"#);
+
+        let summary = run(config_with_log(
+            preset_dir,
+            storage_dir,
+            interests_path,
+            None,
+        ))
+        .await
+        .unwrap();
+
+        assert_eq!(summary.sources_attempted, 1);
+        assert_eq!(summary.sources_succeeded, 0);
+        assert_eq!(summary.sources_failed.len(), 1);
+        assert_eq!(summary.items_kept, 0);
+    }
+
+    /// Audit emission integration: HttpFetch and CandidateScored
+    /// events land in the supplied SessionLog with the expected
+    /// `kind` discriminators. The chain stays whole.
+    #[tokio::test]
+    async fn audit_events_are_emitted_for_fetch_and_score() {
+        let url = one_shot_server(FTC_FIXTURE).await;
+        let tmp = tempfile::tempdir().unwrap();
+        let preset_dir = tmp.path().join("preset");
+        let storage_dir = tmp.path().join("storage");
+        std::fs::create_dir_all(&storage_dir).unwrap();
+        let sources_toml =
+            format!("[[source]]\nname=\"ftc\"\nendpoint=\"{url}\"\nmethod=\"rss\"\n");
+        write_fixture_preset(&preset_dir, &storage_dir, &["127.0.0.1"], &sources_toml);
+        let interests_path = storage_dir.join("interests.toml");
+        write_interests(
+            &interests_path,
+            r#"keywords = ["data broker", "Section 5"]
+exclusions = ["cookie banner"]"#,
+        );
+
+        let log: Arc<dyn SessionLog> =
+            Arc::new(SqliteSessionLog::open_in_memory().expect("in-memory session log"));
+        let summary = run(config_with_log(
+            preset_dir,
+            storage_dir,
+            interests_path,
+            Some(log.clone()),
+        ))
+        .await
+        .unwrap();
+
+        let handle = log.handle_for(SessionId::new(summary.run_id.clone()));
+        let events = log.get_since(&handle, 0).unwrap();
+        let kinds: Vec<&str> = events
+            .iter()
+            .filter_map(|e| extract_kind(&e.event))
+            .collect();
+        assert!(kinds.contains(&"HttpFetch"));
+        assert!(kinds.contains(&"CandidateScored"));
+        assert!(kinds.contains(&"CandidateSkipped"));
+    }
+
+    fn extract_kind(event: &SessionEvent) -> Option<&'static str> {
+        // Names match the enum variant; serde serializes them via
+        // `#[serde(tag = "kind")]` at the wire layer, but in tests we
+        // can match the Rust variants directly.
+        Some(match event {
+            SessionEvent::HttpFetch { .. } => "HttpFetch",
+            SessionEvent::CandidateScored { .. } => "CandidateScored",
+            SessionEvent::CandidateSkipped { .. } => "CandidateSkipped",
+            SessionEvent::CandidateKept { .. } => "CandidateKept",
+            SessionEvent::InterestsEdited { .. } => "InterestsEdited",
+            _ => return None,
+        })
+    }
+
     #[tokio::test]
     async fn missing_aggregator_skill_errors() {
         let tmp = tempfile::tempdir().unwrap();
@@ -411,26 +897,42 @@ skills = ["other"]
         .unwrap();
         std::fs::write(
             preset_dir.join("sources.toml"),
-            "[[source]]\nname=\"x\"\nhost=\"x\"\nmethod=\"x\"\nendpoint=\"http://x\"\n",
+            "[[source]]\nname=\"x\"\nendpoint=\"http://x\"\nmethod=\"rss\"\n",
         )
         .unwrap();
-
         let storage = tmp.path().join("storage");
         std::fs::create_dir_all(&storage).unwrap();
+        let interests_path = storage.join("interests.toml");
+        write_interests(&interests_path, r#"keywords = ["X"]"#);
 
-        let err = run(OrchestratorConfig {
-            preset_dir,
-            storage_dir: storage,
-            rate_limit: RateLimitConfig::unrestricted_for_tests(),
-        })
-        .await
-        .unwrap_err();
+        let err = run(config_with_log(preset_dir, storage, interests_path, None))
+            .await
+            .unwrap_err();
         assert!(matches!(err, OrchestratorError::AggregatorSkillMissing));
     }
 
-    // Suppress unused-import warning when skill_perms isn't otherwise used.
-    #[allow(dead_code)]
-    fn _force_link() -> Arc<()> {
-        Arc::new(())
+    #[tokio::test]
+    async fn missing_interests_file_errors() {
+        let tmp = tempfile::tempdir().unwrap();
+        let preset_dir = tmp.path().join("preset");
+        let storage_dir = tmp.path().join("storage");
+        std::fs::create_dir_all(&storage_dir).unwrap();
+        write_fixture_preset(
+            &preset_dir,
+            &storage_dir,
+            &["127.0.0.1"],
+            "[[source]]\nname=\"x\"\nendpoint=\"http://x\"\nmethod=\"rss\"\n",
+        );
+        let interests_path = storage_dir.join("interests.toml");
+        // Deliberately not writing the file.
+        let err = run(config_with_log(
+            preset_dir,
+            storage_dir,
+            interests_path,
+            None,
+        ))
+        .await
+        .unwrap_err();
+        assert!(matches!(err, OrchestratorError::LoadInterests(_)));
     }
 }

--- a/crates/zirkel/src/schema.rs
+++ b/crates/zirkel/src/schema.rs
@@ -1,0 +1,72 @@
+//! Per-skill SQLite schema for the Zirkel aggregator.
+//!
+//! Migrations are versioned by index in the slice. The runner records
+//! applied indexes in `_migrations` and is idempotent. **Append-only**
+//! — never reorder or replace existing entries; the recorded indexes
+//! would point at different SQL.
+//!
+//! ## Score column naming
+//!
+//! `keyword_match_score INTEGER` is named explicitly to make its
+//! semantics legible at SQL-query time: it is the count of distinct
+//! keyword matches against title + abstract, not a 0–100 relevance
+//! rating. C-LLM adds a separate `llm_relevance_score REAL` column;
+//! both will coexist so downstream queries can filter on either.
+
+/// Append-only migration list. Index 0 was Scope B (one-source
+/// smoke-test schema); indexes 1+ are the foundation slice's
+/// expansion to per-item rows, dedup, screening, snapshots.
+pub const AGGREGATOR_MIGRATIONS: &[&str] = &[
+    // 0 — Scope B: original `candidates` table. Per-fetch row whose
+    // `body` was the entire HTTP response. Kept as-is so the
+    // migration runner doesn't need to re-create.
+    "CREATE TABLE candidates ( \
+        id           INTEGER PRIMARY KEY AUTOINCREMENT, \
+        source_name  TEXT NOT NULL, \
+        url          TEXT NOT NULL, \
+        fetched_at   TEXT NOT NULL DEFAULT (datetime('now')), \
+        body         TEXT NOT NULL \
+    )",
+    // 1 — repurpose `candidates` for per-item rows. Existing rows
+    // from Scope B smoke testing have `run_id = ''`; the orchestrator
+    // queries by `run_id != ''` so they don't pollute results.
+    "ALTER TABLE candidates ADD COLUMN run_id TEXT NOT NULL DEFAULT ''",
+    "ALTER TABLE candidates ADD COLUMN title TEXT NOT NULL DEFAULT ''",
+    "ALTER TABLE candidates ADD COLUMN published_at TEXT",
+    "ALTER TABLE candidates ADD COLUMN matched_keywords TEXT NOT NULL DEFAULT '[]'",
+    "ALTER TABLE candidates ADD COLUMN keyword_match_score INTEGER NOT NULL DEFAULT 0",
+    // 2 — dedup state. URL hash (SHA-256 hex) is what the orchestrator
+    // checks before scoring; `url` is kept verbatim for human
+    // inspection.
+    "CREATE TABLE seen ( \
+        url          TEXT PRIMARY KEY, \
+        url_hash     TEXT NOT NULL, \
+        first_seen   TEXT NOT NULL DEFAULT (datetime('now')) \
+    )",
+    "CREATE INDEX idx_seen_hash ON seen(url_hash)",
+    // 3 — interests file snapshots, one per run. The file's bytes
+    // are stored verbatim so a future replay can reconstruct the
+    // exact screening / scoring decisions.
+    "CREATE TABLE interests_snapshots ( \
+        id           INTEGER PRIMARY KEY AUTOINCREMENT, \
+        run_id       TEXT NOT NULL, \
+        file_hash    TEXT NOT NULL, \
+        contents     TEXT NOT NULL, \
+        created_at   TEXT NOT NULL DEFAULT (datetime('now')) \
+    )",
+    "CREATE INDEX idx_interests_snapshots_run ON interests_snapshots(run_id)",
+    // 4 — items dropped before scoring (exclusion match, dedup hit,
+    // unsupported source method). Kept compact — no body, just the
+    // metadata needed to verify the funnel reconciles.
+    "CREATE TABLE skipped_log ( \
+        id           INTEGER PRIMARY KEY AUTOINCREMENT, \
+        run_id       TEXT NOT NULL, \
+        url_hash     TEXT NOT NULL, \
+        url          TEXT NOT NULL, \
+        source_name  TEXT NOT NULL, \
+        fetched_at   TEXT NOT NULL DEFAULT (datetime('now')), \
+        reason       TEXT NOT NULL, \
+        detail       TEXT \
+    )",
+    "CREATE INDEX idx_skipped_log_run ON skipped_log(run_id)",
+];

--- a/crates/zirkel/src/score.rs
+++ b/crates/zirkel/src/score.rs
@@ -1,0 +1,205 @@
+//! Keyword and exclusion screening.
+//!
+//! Both axes are case-insensitive substring matches against the
+//! candidate's `title + " " + abstract_text`. This is the user's
+//! actual interface — what she'd write on paper if she were doing
+//! this manually. The C-LLM slice adds an LLM-relevance scorer in a
+//! separate axis (`llm_relevance_score REAL`) that runs on top.
+//!
+//! Scoring semantics in this slice:
+//! - `keyword_match_score = number of distinct keywords matched`.
+//! - Threshold for inclusion in the candidates table: `score >= 1`.
+//! - Items with no keyword match land in `skipped_log` with reason
+//!   `score_zero`, not in `candidates`.
+//! - Exclusion takes precedence over keyword match: if any exclusion
+//!   matches, the item lands in `skipped_log` with reason
+//!   `exclusion_match`, regardless of keyword matches.
+
+/// What [`Item::haystack`] is matched against.
+pub trait Item {
+    /// Concatenated text the matchers operate over. Caller composes
+    /// from title + abstract; the trait keeps the matcher independent
+    /// of the underlying record shape.
+    fn haystack(&self) -> String;
+}
+
+/// Outcome of running an item through both screens.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Screened {
+    /// Drop: an exclusion phrase matched. Caller writes a
+    /// `skipped_log` row with `reason = "exclusion_match"` and the
+    /// matched phrase in `detail`.
+    Excluded { matched_exclusion: String },
+    /// Drop: no keyword matched (score 0). Caller writes a
+    /// `skipped_log` row with `reason = "score_zero"`.
+    Zero,
+    /// Keep: at least one keyword matched. Caller writes a
+    /// `candidates` row with `matched_keywords` (JSON-encoded) and
+    /// `keyword_match_score`.
+    Kept {
+        matched_keywords: Vec<String>,
+        keyword_match_score: u32,
+    },
+}
+
+/// Run an item through exclusion-first then keyword screening.
+/// Exclusions are checked in declaration order; the first match
+/// wins and short-circuits the rest.
+pub fn screen<I: Item>(item: &I, keywords: &[String], exclusions: &[String]) -> Screened {
+    let haystack = item.haystack().to_lowercase();
+    for ex in exclusions {
+        if ex.is_empty() {
+            continue;
+        }
+        if haystack.contains(&ex.to_lowercase()) {
+            return Screened::Excluded {
+                matched_exclusion: ex.clone(),
+            };
+        }
+    }
+    let mut matched: Vec<String> = Vec::new();
+    for kw in keywords {
+        if kw.is_empty() {
+            continue;
+        }
+        if haystack.contains(&kw.to_lowercase()) && !matched.iter().any(|m| m == kw) {
+            matched.push(kw.clone());
+        }
+    }
+    if matched.is_empty() {
+        Screened::Zero
+    } else {
+        let score = matched.len() as u32;
+        Screened::Kept {
+            matched_keywords: matched,
+            keyword_match_score: score,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct TestItem(String);
+    impl Item for TestItem {
+        fn haystack(&self) -> String {
+            self.0.clone()
+        }
+    }
+    fn item(text: &str) -> TestItem {
+        TestItem(text.to_string())
+    }
+
+    #[test]
+    fn no_match_returns_zero() {
+        let result = screen(
+            &item("Some random article about cats"),
+            &["BIPA".to_string()],
+            &[],
+        );
+        assert_eq!(result, Screened::Zero);
+    }
+
+    #[test]
+    fn one_match_returns_kept_with_score_1() {
+        let result = screen(&item("BIPA enforcement update"), &["BIPA".to_string()], &[]);
+        assert_eq!(
+            result,
+            Screened::Kept {
+                matched_keywords: vec!["BIPA".to_string()],
+                keyword_match_score: 1,
+            }
+        );
+    }
+
+    #[test]
+    fn multiple_distinct_matches_score_each_once() {
+        let result = screen(
+            &item("BIPA, Section 5, and data broker registry"),
+            &[
+                "BIPA".to_string(),
+                "Section 5".to_string(),
+                "data broker".to_string(),
+            ],
+            &[],
+        );
+        match result {
+            Screened::Kept {
+                matched_keywords,
+                keyword_match_score,
+            } => {
+                assert_eq!(keyword_match_score, 3);
+                assert!(matched_keywords.contains(&"BIPA".to_string()));
+                assert!(matched_keywords.contains(&"Section 5".to_string()));
+                assert!(matched_keywords.contains(&"data broker".to_string()));
+            }
+            other => panic!("expected Kept, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn case_insensitive() {
+        let result = screen(&item("bipa enforcement"), &["BIPA".to_string()], &[]);
+        assert!(matches!(result, Screened::Kept { .. }));
+    }
+
+    #[test]
+    fn repeated_match_counts_once() {
+        let result = screen(&item("BIPA BIPA BIPA"), &["BIPA".to_string()], &[]);
+        match result {
+            Screened::Kept {
+                matched_keywords,
+                keyword_match_score,
+            } => {
+                assert_eq!(keyword_match_score, 1);
+                assert_eq!(matched_keywords, vec!["BIPA".to_string()]);
+            }
+            other => panic!("expected Kept score 1, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn exclusion_takes_precedence_over_keyword_match() {
+        let result = screen(
+            &item("BIPA cookie banner enforcement"),
+            &["BIPA".to_string()],
+            &["cookie banner".to_string()],
+        );
+        assert_eq!(
+            result,
+            Screened::Excluded {
+                matched_exclusion: "cookie banner".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn first_exclusion_match_wins_over_later_exclusions() {
+        let result = screen(
+            &item("alpha beta gamma"),
+            &[],
+            &["alpha".to_string(), "beta".to_string()],
+        );
+        assert_eq!(
+            result,
+            Screened::Excluded {
+                matched_exclusion: "alpha".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn empty_keyword_or_exclusion_strings_skipped() {
+        // An empty string in `contains` matches everything; ensure
+        // our screen doesn't misfire on empties.
+        let result = screen(
+            &item("anything"),
+            &["".to_string(), "needle".to_string()],
+            &["".to_string()],
+        );
+        // The empty exclusion should NOT trigger Excluded.
+        // The empty keyword should NOT contribute a match.
+        assert_eq!(result, Screened::Zero);
+    }
+}


### PR DESCRIPTION
First slice of Scope C. The pieces independent of the LLM/Signal/HDBSCAN dependency cluster, landed as a coherent unit so the dependency-cluster slices (C-LLM, C-Signal, C-API/scrape, C-Librarian) can each ship without burying compromises in a foundation PR.

## What's here

- **Interests file** (`~/.wirken/zirkel/interests.toml`): hand-edited TOML with `keywords` and `exclusions`. Loaded on every run, snapshotted into `interests_snapshots` (file_hash + verbatim contents) for reproducibility. The hash is compared with the prior run's snapshot; on change, an `InterestsEdited` audit event fires.
- **Schema migrations** (append-only): per-item columns on `candidates` (`title`, `published_at`, `matched_keywords`, `keyword_match_score`, `run_id`); new tables `seen` (URL hash dedup), `interests_snapshots`, `skipped_log`.
- **Multi-source orchestrator**: loops every entry in `sources.toml`, dispatches by `method` field (RSS / Atom → fetcher; api / scrape → recorded as unsupported in this slice). Per-source failure logs and continues — one flaky source doesn't abort the run.
- **RSS fetcher** (RSS 2.0 + Atom via `feed-rs`): no `Fetcher` trait yet, deliberately. The trait shape lands when the C-API and C-scrape slices add a real second implementation; introducing the abstraction now would shape it around an uncommitted boundary.
- **Keyword + exclusion screen**: case-insensitive substring match against `title + abstract`. Exclusions short-circuit before keyword matching. Items with score 0 land in `skipped_log` with reason `score_zero`; exclusion-matched items land with reason `exclusion_match`. `keyword_match_score` is the count of distinct keyword matches.
- **7 audit event variants** added to `SessionEvent`: `HttpFetch`, `CandidateScored`, `CandidateKept`, `CandidateSkipped`, `ThemeNamed`, `DigestPushed`, `InterestsEdited`. This slice emits `HttpFetch`, `CandidateScored`, `CandidateSkipped`, `InterestsEdited`; the rest are added now so future slices don't churn the enum and DB schema.

## What's deferred

This slice doesn't push to Signal. The lawyer doesn't see anything yet — the kept-candidates pipeline is populated, the audit chain records what was kept and what was dropped and why, but no digest is rendered. **C-Signal makes it visible.**

Other deferrals:
- LLM relevance scoring (C-LLM): `keyword_match_score` is a transparent first filter, not a 0–100 rating. C-LLM adds a separate `llm_relevance_score REAL` column.
- Clustering + theme naming (C-LLM): no theme grouping in the digest yet.
- API and scrape fetchers (C-API): congress.gov, govinfo.gov, Federal Register, committee scrapes, state AG pages.
- Librarian skill agent-attached (C-Librarian).

## Score field semantics, plainly

The `keyword_match_score INTEGER` column is the count of distinct user-keywords that matched the item's title + abstract. **Not a 0–100 relevance rating.** `score = 3` means three keywords matched, not three-out-of-100. The C-LLM slice adds `llm_relevance_score REAL` for the LLM-driven pass; both columns will coexist so downstream queries can filter on either.

The `score.rs` module-doc and the `schema.rs` comment both spell this out so future-readers don't have to infer the semantic from the column type.

## Tests

- `interests`: full block, only-keywords, only-exclusions, empty, malformed, unknown-field rejection, hash determinism, snapshot idempotence, last-snapshot lookup. 9 tests.
- `score`: no match, one match, multiple distinct, case insensitivity, repeated-match-counts-once, exclusion-precedes-keyword, first-exclusion-wins, empty-string handling. 8 tests.
- `fetcher`: Atom parse, RSS 2.0 parse, malformed feed parse error, entries-without-link skipped. 4 tests.
- `orchestrator`: keystone (RSS fetch + screen + write), second-run dedup, unsupported-method-skipped, egress-denial-recorded-and-run-continues, audit-events-emitted-for-fetch-and-score, missing-aggregator-skill, missing-interests-file. 7 tests.
- 28 zirkel tests; 614 across the workspace, all green. `cargo fmt --check` clean. `cargo clippy --workspace --tests -- -D warnings` clean.

## Bypass invariant unchanged

The orchestrator's `EgressClient` is constructed from the aggregator skill's `permissions.egress` allow-set; the rate limiter is the inner layer per the documented composition. A non-allowlisted host fails fast with `EgressDenied` before any TCP. `SkillStore::open` refuses paths outside `permissions.filesystem.write_paths`. The aggregator is loaded by `PresetLoader` for its permissions block but never agent-attached — the orchestrator is pure Rust through the policed transport. No new bypass surface.