### PR TITLE
zirkel scope c-llm: structured-output scoring, ollama embeddings, hdbscan clustering, theme naming

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1839,6 +1839,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "hdbscan"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "466aa8bfaa22c81efcf67c84e6ad046de13a05c6cc9d41a5094361bff464247a"
+dependencies = [
+ "kdtree",
+ "num-traits",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2412,6 +2422,16 @@ dependencies = [
  "sha2",
  "signature",
  "simple_asn1",
+]
+
+[[package]]
+name = "kdtree"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f0a0e9f770b65bac9aad00f97a67ab5c5319effed07f6da385da3c2115e47ba"
+dependencies = [
+ "num-traits",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -6661,6 +6681,7 @@ version = "0.9.1"
 dependencies = [
  "chrono",
  "feed-rs",
+ "hdbscan",
  "reqwest 0.13.2",
  "rusqlite",
  "serde",

--- a/crates/audit/src/session_log.rs
+++ b/crates/audit/src/session_log.rs
@@ -275,8 +275,11 @@ pub enum SessionEvent {
     },
     /// Zirkel: a fetched item passed exclusion + keyword screening and
     /// landed in the candidates table with its keyword-match score.
-    /// `score` is the count of distinct keyword matches in this slice;
-    /// the LLM-relevance score lives in a separate event under C-LLM.
+    /// `keyword_match_score` is the count of distinct keyword matches.
+    /// The LLM-relevance pass emits a separate `CandidateLlmScored`
+    /// event after this one — the two-event split keeps each pass
+    /// independently auditable, so a failed LLM pass leaves the
+    /// keyword event in the chain rather than orphaning the candidate.
     /// `matched_keywords` is the JSON-encoded list, kept verbatim so
     /// the chain-verifier can replay the screening decision.
     CandidateScored {
@@ -284,6 +287,18 @@ pub enum SessionEvent {
         candidate_id: i64,
         keyword_match_score: u32,
         matched_keywords: String,
+    },
+    /// Zirkel: the LLM relevance pass scored a candidate.
+    /// `llm_relevance_score` is 0–100. `matched_keyword` is the single
+    /// user keyword the LLM identified as the strongest signal (one of
+    /// the keywords in the matched-keywords list from the keyword
+    /// pass). `why_surfaced` is the LLM's one-line rationale.
+    CandidateLlmScored {
+        run_id: String,
+        candidate_id: i64,
+        llm_relevance_score: u32,
+        matched_keyword: String,
+        why_surfaced: String,
     },
     /// Zirkel: the user marked a candidate as kept from the digest.
     /// Emitted by C-Signal when the keep button (or numbered reply) is

--- a/crates/cli/src/commands/zirkel.rs
+++ b/crates/cli/src/commands/zirkel.rs
@@ -11,8 +11,10 @@
 use std::sync::Arc;
 
 use anyhow::{Result, anyhow};
+use wirken_agent::llm::{LlmClient, LlmConfig};
 use wirken_agent::rate_limit::RateLimitConfig;
 use wirken_audit::{SessionLog, SqliteSessionLog};
+use wirken_zirkel::embedding::DEFAULT_EMBEDDING_MODEL;
 use wirken_zirkel::orchestrator::{OrchestratorConfig, run as orchestrator_run};
 
 /// `wirken zirkel run` — load the installed Zirkel preset, run the
@@ -50,12 +52,22 @@ pub async fn run() -> Result<()> {
             .map_err(|e| anyhow!("open audit log at {}: {e}", audit_path.display()))?,
     );
 
+    // LLM defaults per docs/zirkel/DESIGN.md: Ollama llama3.1:8b for
+    // scoring + theme naming, nomic-embed-text:v1.5 for embedding.
+    // Both at the local Ollama base URL.
+    let llm_cfg = LlmConfig::ollama("llama3.1:8b");
+    let llm = Arc::new(LlmClient::new(llm_cfg).map_err(|e| anyhow!("construct LLM client: {e}"))?);
+
     let summary = orchestrator_run(OrchestratorConfig {
         preset_dir,
         storage_dir,
         interests_path,
         rate_limit: RateLimitConfig::default(),
         session_log: Some(session_log),
+        llm: Some(llm),
+        llm_api_key: None,
+        ollama_embed_base: "http://127.0.0.1:11434".to_string(),
+        embed_model: DEFAULT_EMBEDDING_MODEL.to_string(),
     })
     .await
     .map_err(|e| anyhow!("zirkel orchestrator: {e}"))?;
@@ -80,9 +92,25 @@ pub async fn run() -> Result<()> {
     println!("  items excluded:      {}", summary.items_excluded);
     println!("  items score 0:       {}", summary.items_score_zero);
     println!("  items kept:          {}", summary.items_kept);
+    println!("  items LLM-scored:    {}", summary.items_llm_scored);
+    println!("  themes named:        {}", summary.themes_named);
+    if !summary.llm_score_failures.is_empty() {
+        println!(
+            "  LLM scoring failures: {}",
+            summary.llm_score_failures.len()
+        );
+    }
+    if !summary.theme_stage_failures.is_empty() {
+        println!(
+            "  theme stage failures: {}",
+            summary.theme_stage_failures.len()
+        );
+    }
     if summary.interests_changed {
         println!("  interests changed:   yes (audit event emitted)");
     }
-    println!("(C-foundation: keyword screen only. LLM relevance scoring is the next slice.)");
+    println!(
+        "(C-LLM: keyword screen + LLM relevance + clustering + theme naming. Digest push is the next slice.)"
+    );
     Ok(())
 }

--- a/crates/zirkel/Cargo.toml
+++ b/crates/zirkel/Cargo.toml
@@ -23,6 +23,7 @@ feed-rs = "2"
 chrono = { workspace = true }
 uuid = { version = "1", features = ["v4"] }
 url = "2"
+hdbscan = "0.12"
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/zirkel/src/cluster.rs
+++ b/crates/zirkel/src/cluster.rs
@@ -1,0 +1,207 @@
+//! HDBSCAN clustering wrapper.
+//!
+//! Thin wrapper over the [`hdbscan`] crate (tom-whitehead/hdbscan,
+//! v0.12). Per the C-LLM pre-checks: focused API, recently
+//! maintained, output shape exactly matches the design's
+//! "cluster id + noise" model.
+//!
+//! ## Single-cluster fallback policy lives elsewhere
+//!
+//! Per `docs/zirkel/DESIGN.md`: "if HDBSCAN returns no clusters or
+//! only noise, all candidates land in a single 'ungrouped' theme."
+//! That fallback is the orchestrator's job, not this wrapper's.
+//! The wrapper returns the unmodified label vector — the
+//! orchestrator decides whether an all-noise result becomes a real
+//! "ungrouped" theme row or just leaves the cluster_id NULL on
+//! every candidate.
+//!
+//! ## Defaults
+//!
+//! `min_cluster_size = 2`, `min_samples = 1` per the design doc.
+//! Distance metric defaults to Euclidean — fine for normalized
+//! embedding vectors from `nomic-embed-text`.
+//!
+//! ## HDBSCAN needs contrast
+//!
+//! Density-based clustering requires *contrast* between regions to
+//! distinguish core points from noise. A single tight cluster of N
+//! points (no other lower-density region) is classified as all-noise
+//! regardless of N — there's no comparison density to validate the
+//! cluster against. In practice, Zirkel's daily runs surface enough
+//! topical variety that this case is rare; when it does happen, the
+//! orchestrator's "ungrouped" fallback handles it.
+
+use hdbscan::{Hdbscan, HdbscanHyperParams};
+use thiserror::Error;
+
+/// Cluster label for one point. `Cluster(n)` is a real cluster
+/// (n ≥ 0); `Noise` is an unassigned point (`-1` from HDBSCAN).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ClusterLabel {
+    Cluster(u32),
+    Noise,
+}
+
+impl ClusterLabel {
+    pub fn is_noise(&self) -> bool {
+        matches!(self, ClusterLabel::Noise)
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum ClusterError {
+    #[error("hdbscan: {0}")]
+    Hdbscan(String),
+}
+
+/// Cluster a slice of embeddings. Returns one [`ClusterLabel`] per
+/// input vector, in the same order. Empty input returns an empty
+/// vector — the caller decides whether to treat that as "no
+/// candidates to cluster" or as an error condition.
+///
+/// `min_cluster_size`: smallest number of points that count as a
+/// real cluster. Default per design: 2.
+/// `min_samples`: density parameter. Default per design: 1.
+pub fn cluster(
+    embeddings: &[Vec<f32>],
+    min_cluster_size: usize,
+    min_samples: usize,
+) -> Result<Vec<ClusterLabel>, ClusterError> {
+    if embeddings.is_empty() {
+        return Ok(Vec::new());
+    }
+    // Single-point case: HDBSCAN refuses (you can't form clusters
+    // out of one point). The orchestrator's "ungrouped" fallback
+    // handles this by treating one-candidate runs as one Noise
+    // label, which lands the candidate under the ungrouped section
+    // in the digest.
+    if embeddings.len() < 2 {
+        return Ok(vec![ClusterLabel::Noise; embeddings.len()]);
+    }
+    let params = HdbscanHyperParams::builder()
+        .min_cluster_size(min_cluster_size)
+        .min_samples(min_samples)
+        .build();
+    let clusterer = Hdbscan::new(embeddings, params);
+    let labels = clusterer
+        .cluster()
+        .map_err(|e| ClusterError::Hdbscan(format!("{e:?}")))?;
+    Ok(labels
+        .into_iter()
+        .map(|n| {
+            if n < 0 {
+                ClusterLabel::Noise
+            } else {
+                ClusterLabel::Cluster(n as u32)
+            }
+        })
+        .collect())
+}
+
+/// Group a `(label, payload)` set by cluster id, dropping noise
+/// points. Useful for the orchestrator's per-theme work where it
+/// needs every candidate that landed in cluster N for theme naming.
+pub fn group_by_cluster<T: Clone>(
+    labels: &[ClusterLabel],
+    payloads: &[T],
+) -> std::collections::BTreeMap<u32, Vec<T>> {
+    let mut groups: std::collections::BTreeMap<u32, Vec<T>> = Default::default();
+    for (label, payload) in labels.iter().zip(payloads.iter()) {
+        if let ClusterLabel::Cluster(n) = label {
+            groups.entry(*n).or_default().push(payload.clone());
+        }
+    }
+    groups
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Two well-separated clusters of 3 points each in 2D. HDBSCAN
+    /// should identify both clusters and put no points in noise.
+    #[test]
+    fn two_clear_clusters_get_distinct_labels() {
+        // Cluster A around (0, 0); cluster B around (10, 10).
+        let data = vec![
+            vec![0.0, 0.0],
+            vec![0.1, 0.1],
+            vec![-0.05, 0.05],
+            vec![10.0, 10.0],
+            vec![10.1, 9.9],
+            vec![9.95, 10.05],
+        ];
+        let labels = cluster(&data, 2, 1).unwrap();
+        assert_eq!(labels.len(), 6);
+        // No two cluster ids should be Noise — both groups form a
+        // valid cluster at min_cluster_size=2.
+        let noise_count = labels.iter().filter(|l| l.is_noise()).count();
+        assert!(
+            noise_count <= 1,
+            "expected at most one noise point; got {noise_count}: {labels:?}"
+        );
+        // The two halves should land in different clusters (whichever
+        // ids HDBSCAN assigned).
+        let first_three: Vec<_> = labels[..3].iter().filter(|l| !l.is_noise()).collect();
+        let last_three: Vec<_> = labels[3..].iter().filter(|l| !l.is_noise()).collect();
+        if let (Some(a), Some(b)) = (first_three.first(), last_three.first()) {
+            assert_ne!(
+                a, b,
+                "the two well-separated halves should not share a cluster id"
+            );
+        } else {
+            panic!("expected at least one non-noise label per half: {labels:?}");
+        }
+    }
+
+    /// Empty input → empty output, not an error.
+    #[test]
+    fn empty_input_returns_empty_output() {
+        let labels = cluster(&[], 2, 1).unwrap();
+        assert!(labels.is_empty());
+    }
+
+    /// One-point case is degenerate — HDBSCAN can't run on it.
+    /// The wrapper returns a single Noise label, leaving the
+    /// orchestrator to decide what to do (typically: render
+    /// ungrouped).
+    #[test]
+    fn single_point_is_noise() {
+        let data = vec![vec![1.0, 2.0]];
+        let labels = cluster(&data, 2, 1).unwrap();
+        assert_eq!(labels, vec![ClusterLabel::Noise]);
+    }
+
+    /// All-noise behavior: HDBSCAN with high min_cluster_size on a
+    /// scattered set returns mostly noise. The orchestrator will
+    /// promote this to an "ungrouped" theme.
+    #[test]
+    fn high_min_cluster_size_yields_noise() {
+        let data = vec![
+            vec![0.0, 0.0],
+            vec![10.0, 0.0],
+            vec![0.0, 10.0],
+            vec![10.0, 10.0],
+        ];
+        // min_cluster_size = 10 means no cluster of size 4 can form.
+        let labels = cluster(&data, 10, 1).unwrap();
+        assert!(labels.iter().all(|l| l.is_noise()));
+    }
+
+    #[test]
+    fn group_by_cluster_drops_noise() {
+        let labels = vec![
+            ClusterLabel::Cluster(0),
+            ClusterLabel::Noise,
+            ClusterLabel::Cluster(0),
+            ClusterLabel::Cluster(1),
+            ClusterLabel::Noise,
+        ];
+        let payloads = vec!["a", "b", "c", "d", "e"];
+        let groups = group_by_cluster(&labels, &payloads);
+        assert_eq!(groups.len(), 2);
+        assert_eq!(groups[&0], vec!["a", "c"]);
+        assert_eq!(groups[&1], vec!["d"]);
+        assert!(!groups.contains_key(&2));
+    }
+}

--- a/crates/zirkel/src/embedding.rs
+++ b/crates/zirkel/src/embedding.rs
@@ -1,0 +1,238 @@
+//! Ollama embedding helper.
+//!
+//! Calls Ollama's `/api/embed` endpoint through the policed
+//! [`wirken_agent::egress::EgressClient`]. Per the C-LLM pre-checks
+//! (Path C), this is a Zirkel-internal helper rather than an
+//! abstraction in the agent crate. If a second skill ever needs
+//! embeddings, the right shape becomes a small `EmbeddingClient`
+//! struct in `wirken-agent`; until then, YAGNI.
+//!
+//! ## Egress
+//!
+//! Ollama runs at `127.0.0.1:11434` by default. The aggregator
+//! skill's `egress.domains` allow-set must include `127.0.0.1` for
+//! the embedding fetch to pass the policed transport. The bypass
+//! invariant is preserved — adding a host to the allowlist expands
+//! what's allowed, not how enforcement works. The `127.0.0.1` entry
+//! in `preset/zirkel/skills/aggregator/SKILL.md` carries a one-line
+//! comment explaining the why so future readers don't read it as a
+//! generic local-network exception.
+//!
+//! ## API shape
+//!
+//! Ollama's `/api/embed` accepts a JSON body with `model` and `input`
+//! (a string or array of strings). Response carries `model` and
+//! `embeddings` (array of float arrays). One round-trip per call;
+//! the helper exposes both single and batch forms.
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+use wirken_agent::egress::{EgressClient, HttpAccessDenied};
+
+/// Default embedding model. Per `docs/zirkel/DESIGN.md`:
+/// nomic-embed-text v1.5 — small (~137M params), CPU-fast, 768-dim.
+pub const DEFAULT_EMBEDDING_MODEL: &str = "nomic-embed-text:v1.5";
+
+#[derive(Debug, Error)]
+pub enum EmbeddingError {
+    #[error("HTTP denied for {url}: {source}")]
+    Denied {
+        url: String,
+        #[source]
+        source: HttpAccessDenied,
+    },
+    #[error("HTTP non-success for {url}: status {status}")]
+    HttpStatus { url: String, status: u16 },
+    #[error("network error for {url}: {source}")]
+    Network {
+        url: String,
+        #[source]
+        source: reqwest::Error,
+    },
+    #[error("decode embed response: {0}")]
+    Decode(#[from] serde_json::Error),
+    #[error("embed response shape mismatch: expected {expected} embeddings, got {actual}")]
+    ShapeMismatch { expected: usize, actual: usize },
+}
+
+#[derive(Debug, Serialize)]
+struct EmbedRequest<'a> {
+    model: &'a str,
+    input: Vec<&'a str>,
+}
+
+#[derive(Debug, Deserialize)]
+struct EmbedResponse {
+    embeddings: Vec<Vec<f32>>,
+}
+
+/// Embed a single text. Convenience wrapper over [`embed_batch`].
+pub async fn embed_one(
+    http: &EgressClient,
+    ollama_base: &str,
+    model: &str,
+    text: &str,
+) -> Result<Vec<f32>, EmbeddingError> {
+    let mut vecs = embed_batch(http, ollama_base, model, &[text]).await?;
+    if vecs.len() != 1 {
+        return Err(EmbeddingError::ShapeMismatch {
+            expected: 1,
+            actual: vecs.len(),
+        });
+    }
+    Ok(vecs.pop().unwrap())
+}
+
+/// Embed a batch of texts. Order of returned vectors matches the
+/// input order. One HTTP round trip; Ollama's `/api/embed` natively
+/// accepts arrays.
+pub async fn embed_batch(
+    http: &EgressClient,
+    ollama_base: &str,
+    model: &str,
+    texts: &[&str],
+) -> Result<Vec<Vec<f32>>, EmbeddingError> {
+    if texts.is_empty() {
+        return Ok(Vec::new());
+    }
+    let url = format!("{}/api/embed", ollama_base.trim_end_matches('/'));
+    let body = EmbedRequest {
+        model,
+        input: texts.to_vec(),
+    };
+    let builder = http.post(&url).await.map_err(|e| EmbeddingError::Denied {
+        url: url.clone(),
+        source: e,
+    })?;
+    let resp = builder
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| EmbeddingError::Network {
+            url: url.clone(),
+            source: e,
+        })?;
+    let status = resp.status();
+    if !status.is_success() {
+        return Err(EmbeddingError::HttpStatus {
+            url,
+            status: status.as_u16(),
+        });
+    }
+    let parsed: EmbedResponse = resp.json().await.map_err(|e| EmbeddingError::Network {
+        url: url.clone(),
+        source: e,
+    })?;
+    if parsed.embeddings.len() != texts.len() {
+        return Err(EmbeddingError::ShapeMismatch {
+            expected: texts.len(),
+            actual: parsed.embeddings.len(),
+        });
+    }
+    Ok(parsed.embeddings)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeSet;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+    use wirken_agent::egress::EgressEnforcement;
+
+    /// One-shot HTTP server that returns a fixed JSON body.
+    async fn one_shot_json(body: &'static str) -> String {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let url = format!("http://{}", addr);
+        tokio::spawn(async move {
+            if let Ok((mut sock, _)) = listener.accept().await {
+                let mut buf = [0u8; 4096];
+                let _ = sock.read(&mut buf).await;
+                let resp = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nContent-Type: application/json\r\n\r\n{}",
+                    body.len(),
+                    body
+                );
+                let _ = sock.write_all(resp.as_bytes()).await;
+                let _ = sock.shutdown().await;
+            }
+        });
+        url
+    }
+
+    fn allowlist_localhost() -> EgressClient {
+        let c = EgressClient::new();
+        c.set_enforcement(EgressEnforcement::Allowlist(BTreeSet::from([
+            "127.0.0.1".to_string()
+        ])));
+        c
+    }
+
+    #[tokio::test]
+    async fn embed_one_returns_a_single_vector() {
+        let body = r#"{"model":"nomic-embed-text:v1.5","embeddings":[[0.1, 0.2, 0.3]]}"#;
+        let base = one_shot_json(body).await;
+        let c = allowlist_localhost();
+        let v = embed_one(&c, &base, DEFAULT_EMBEDDING_MODEL, "hello world")
+            .await
+            .unwrap();
+        assert_eq!(v, vec![0.1, 0.2, 0.3]);
+    }
+
+    #[tokio::test]
+    async fn embed_batch_preserves_order() {
+        let body =
+            r#"{"model":"nomic-embed-text:v1.5","embeddings":[[1.0,0.0],[0.0,1.0],[0.5,0.5]]}"#;
+        let base = one_shot_json(body).await;
+        let c = allowlist_localhost();
+        let v = embed_batch(&c, &base, "nomic-embed-text:v1.5", &["a", "b", "c"])
+            .await
+            .unwrap();
+        assert_eq!(v.len(), 3);
+        assert_eq!(v[0], vec![1.0, 0.0]);
+        assert_eq!(v[1], vec![0.0, 1.0]);
+        assert_eq!(v[2], vec![0.5, 0.5]);
+    }
+
+    #[tokio::test]
+    async fn embed_empty_input_is_empty_output() {
+        let c = allowlist_localhost();
+        let v = embed_batch(&c, "http://does-not-matter", "m", &[])
+            .await
+            .unwrap();
+        assert!(v.is_empty());
+    }
+
+    #[tokio::test]
+    async fn shape_mismatch_returns_error() {
+        // Server returns 2 embeddings for 3 inputs.
+        let body = r#"{"model":"x","embeddings":[[1.0],[0.0]]}"#;
+        let base = one_shot_json(body).await;
+        let c = allowlist_localhost();
+        let err = embed_batch(&c, &base, "m", &["a", "b", "c"])
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            EmbeddingError::ShapeMismatch {
+                expected: 3,
+                actual: 2
+            }
+        ));
+    }
+
+    #[tokio::test]
+    async fn egress_denial_for_non_allowlisted_host() {
+        // Allowlist explicitly excludes 127.0.0.1 — the embed call
+        // must fail at egress, not at the network.
+        let c = EgressClient::new();
+        c.set_enforcement(EgressEnforcement::Allowlist(BTreeSet::from([
+            "other.example.com".to_string(),
+        ])));
+        let err = embed_one(&c, "http://127.0.0.1:11434", "m", "x")
+            .await
+            .unwrap_err();
+        assert!(matches!(err, EmbeddingError::Denied { .. }));
+    }
+}

--- a/crates/zirkel/src/lib.rs
+++ b/crates/zirkel/src/lib.rs
@@ -13,8 +13,13 @@
 //! No LLM call (relevance scoring is Scope C). No clustering, no theme
 //! naming, no digest push.
 
+pub mod cluster;
+pub mod embedding;
 pub mod fetcher;
 pub mod interests;
+pub mod llm_score;
 pub mod orchestrator;
 pub mod schema;
 pub mod score;
+pub mod synthetic_tool;
+pub mod themes;

--- a/crates/zirkel/src/llm_score.rs
+++ b/crates/zirkel/src/llm_score.rs
@@ -1,0 +1,128 @@
+//! LLM relevance scoring for Zirkel candidates.
+//!
+//! One LLM call per candidate using the
+//! [`crate::synthetic_tool::score_candidate_tool`] structured-output
+//! channel. Returns a 0–100 relevance rating plus a one-line
+//! `why_surfaced` rationale and the matched user keyword.
+//!
+//! The keyword pre-filter (Scope C-foundation) already guaranteed
+//! every input here matched at least one user keyword; this pass
+//! adds the LLM's nuance — e.g. "matched 'biometric' but the paper
+//! is about consumer authentication, score lower" — that a literal
+//! substring match can't make.
+
+use thiserror::Error;
+use wirken_agent::llm::LlmClient;
+
+use crate::fetcher::FetchedItem;
+use crate::interests::Interests;
+use crate::synthetic_tool::{
+    ScoreCandidateArgs, SyntheticToolError, call_structured, score_candidate_tool,
+};
+
+/// Per-call error. `Synthetic` wraps the structured-output failure
+/// modes (LLM didn't call the tool, parse failure, etc.); `Llm`
+/// wraps lower-level transport / provider failures.
+#[derive(Debug, Error)]
+pub enum LlmScoreError {
+    #[error("synthetic-tool call failed: {0}")]
+    Synthetic(#[from] SyntheticToolError),
+}
+
+/// Score one candidate against the user's interests.
+pub async fn score_candidate(
+    llm: &LlmClient,
+    api_key: Option<&str>,
+    item: &FetchedItem,
+    interests: &Interests,
+) -> Result<ScoreCandidateArgs, LlmScoreError> {
+    let system = system_prompt();
+    let user = build_user_prompt(item, interests);
+    let args: ScoreCandidateArgs =
+        call_structured(llm, api_key, &system, &user, score_candidate_tool()).await?;
+    Ok(args)
+}
+
+fn system_prompt() -> String {
+    r#"You are Zirkel's relevance scorer. The user is a privacy lawyer who has hand-curated a list of interest keywords and exclusion phrases. The orchestrator has already filtered out items that don't match any keyword, so every item you see has at least one literal keyword match.
+
+Your job is to add nuance the literal match cannot:
+- A high score (80–100) means the candidate substantively addresses the matched keyword.
+- A medium score (40–79) means the keyword appears but the candidate's main subject is adjacent.
+- A low score (1–39) means the keyword appears incidentally (a casual mention, an unrelated pun on the term).
+- Score 0 is for cases where the candidate is, on closer reading, a false positive — the keyword matched but the content has no real bearing on the user's interest.
+
+You MUST call the zirkel_score_candidate tool. Do not respond with text."#
+        .to_string()
+}
+
+fn build_user_prompt(item: &FetchedItem, interests: &Interests) -> String {
+    let keywords = interests.keywords.join(", ");
+    let exclusions = if interests.exclusions.is_empty() {
+        "(none)".to_string()
+    } else {
+        interests.exclusions.join(", ")
+    };
+    format!(
+        "User keywords:\n  {keywords}\n\
+         User exclusions (already pre-filtered against — for context):\n  {exclusions}\n\n\
+         Candidate:\n\
+         Source: {source}\n\
+         Title:  {title}\n\
+         Abstract: {abstract_text}\n",
+        keywords = keywords,
+        exclusions = exclusions,
+        source = item.source_name,
+        title = item.title,
+        abstract_text = item.abstract_text,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fixture_item() -> FetchedItem {
+        FetchedItem {
+            source_name: "ftc".to_string(),
+            url: "https://www.ftc.gov/x".to_string(),
+            title: "FTC sues data broker".to_string(),
+            abstract_text: "Section 5 unfairness against ExampleCorp.".to_string(),
+            published_at: "2026-04-28T00:00:00Z".to_string(),
+        }
+    }
+
+    fn fixture_interests() -> Interests {
+        Interests {
+            keywords: vec!["data broker".to_string(), "Section 5".to_string()],
+            exclusions: vec!["cookie banner".to_string()],
+            file_hash: "fixture".to_string(),
+            raw_contents: String::new(),
+        }
+    }
+
+    #[test]
+    fn user_prompt_includes_candidate_and_interests() {
+        let p = build_user_prompt(&fixture_item(), &fixture_interests());
+        assert!(p.contains("data broker"));
+        assert!(p.contains("Section 5"));
+        assert!(p.contains("cookie banner"));
+        assert!(p.contains("FTC sues data broker"));
+        assert!(p.contains("Section 5 unfairness against ExampleCorp"));
+    }
+
+    #[test]
+    fn user_prompt_handles_empty_exclusions_cleanly() {
+        let mut interests = fixture_interests();
+        interests.exclusions.clear();
+        let p = build_user_prompt(&fixture_item(), &interests);
+        assert!(p.contains("(none)"));
+    }
+
+    // End-to-end with a mocked LLM is exercised in
+    // `crate::orchestrator::tests` — running `score_candidate` here
+    // would require either a local OpenAI-compatible HTTP server or
+    // a refactor of LlmClient to accept an injected transport. The
+    // orchestrator integration test gives better coverage for less
+    // duplicated setup.
+}

--- a/crates/zirkel/src/orchestrator.rs
+++ b/crates/zirkel/src/orchestrator.rs
@@ -47,10 +47,16 @@ use wirken_audit::{
 };
 use wirken_skill_store::{SkillStore, SkillStoreError};
 
+use wirken_agent::llm::LlmClient;
+
+use crate::cluster::{ClusterLabel, cluster as cluster_embeddings, group_by_cluster};
+use crate::embedding::embed_batch;
 use crate::fetcher::{FetchError, FetchedItem, fetch_rss};
 use crate::interests::{InterestsError, last_snapshot_hash, load as load_interests, snapshot};
+use crate::llm_score::score_candidate;
 use crate::schema::AGGREGATOR_MIGRATIONS;
 use crate::score::{Item, Screened, screen};
+use crate::themes::{ClusterMember, name_theme};
 
 const AGGREGATOR_SKILL_NAME: &str = "aggregator";
 
@@ -75,6 +81,27 @@ pub struct OrchestratorConfig {
     /// `Arc<dyn SessionLog>` the rest of Wirken uses so the chain is
     /// continuous across orchestrator runs and agent sessions.
     pub session_log: Option<Arc<dyn SessionLog>>,
+    /// LLM client for the relevance-scoring + theme-naming passes.
+    /// `None` disables both passes — kept items still land in the
+    /// database with `llm_relevance_score` NULL and no `themes` rows.
+    /// Production threads an `LlmClient` configured for the agent's
+    /// `inference.default` provider; tests pass `None` (skip) or a
+    /// client pointing at a local mock server.
+    pub llm: Option<Arc<LlmClient>>,
+    /// API key for the LLM provider. `None` is correct for Ollama
+    /// (no auth) and for tests with a mock server.
+    pub llm_api_key: Option<String>,
+    /// Base URL for Ollama's `/api/embed` endpoint (the embedding
+    /// pass for clustering). The orchestrator hits this through the
+    /// policed [`EgressClient`] — `127.0.0.1` must be in the
+    /// aggregator's `egress.domains` allow-set. Empty string disables
+    /// embedding + clustering even when `llm` is set; useful for
+    /// tests of the LLM-scoring path in isolation.
+    pub ollama_embed_base: String,
+    /// Embedding model name for the `/api/embed` request. Defaults to
+    /// [`crate::embedding::DEFAULT_EMBEDDING_MODEL`] in the CLI; tests
+    /// can pass any string the mock server will echo.
+    pub embed_model: String,
 }
 
 /// Outcome of one orchestrator run, by category.
@@ -96,6 +123,26 @@ pub struct RunSummary {
     pub items_kept: usize,
     pub kept_candidate_ids: Vec<i64>,
     pub interests_changed: bool,
+    /// Count of candidates the LLM relevance pass scored. Equals
+    /// `items_kept` on a clean run; less if the LLM failed for some
+    /// candidates (which is logged but doesn't abort the run).
+    pub items_llm_scored: usize,
+    /// `themes` rows written by the theme-naming pass. Zero when LLM
+    /// is disabled, embedding fails, all items land in noise, or
+    /// fewer than 2 items survived the filter (clustering is skipped).
+    pub themes_named: usize,
+    /// Per-candidate LLM-call failures during the relevance pass.
+    /// Audit chain has the kept-item event but no LLM event for these.
+    pub llm_score_failures: Vec<LlmStageFailure>,
+    /// Embedding / clustering / theme-naming failures. Logged here
+    /// for the CLI summary; the run completes regardless.
+    pub theme_stage_failures: Vec<LlmStageFailure>,
+}
+
+#[derive(Debug, Clone)]
+pub struct LlmStageFailure {
+    pub candidate_id: Option<i64>,
+    pub reason: String,
 }
 
 #[derive(Debug, Clone)]
@@ -402,7 +449,282 @@ pub async fn run(config: OrchestratorConfig) -> Result<RunSummary, OrchestratorE
         }
     }
 
+    // ----- LLM relevance scoring pass --------------------------------
+    // One LLM call per kept candidate. Failures are logged in the run
+    // summary but don't abort the run — the keyword pass already
+    // recorded the candidate; the LLM pass adds nuance, not gating.
+    if let Some(llm) = config.llm.as_ref() {
+        run_llm_score_pass(
+            &store,
+            llm,
+            config.llm_api_key.as_deref(),
+            &interests,
+            &run_id,
+            config.session_log.as_ref(),
+            audit_handle.as_ref(),
+            &mut summary,
+        )
+        .await;
+
+        // ----- Embedding + clustering + theme naming -----------------
+        // Skipped when fewer than 2 candidates landed in this run
+        // (HDBSCAN can't cluster a single point) or when the operator
+        // explicitly disabled embedding by passing an empty
+        // `ollama_embed_base`.
+        if summary.items_kept >= 2 && !config.ollama_embed_base.is_empty() {
+            run_theme_pass(
+                &store,
+                &http,
+                llm,
+                config.llm_api_key.as_deref(),
+                &config.ollama_embed_base,
+                &config.embed_model,
+                &run_id,
+                config.session_log.as_ref(),
+                audit_handle.as_ref(),
+                &mut summary,
+            )
+            .await;
+        }
+    }
+
     Ok(summary)
+}
+
+/// Iterate this run's kept candidates, call the LLM relevance scorer
+/// for each, write the result back, emit the audit event. Per-candidate
+/// failures land in `summary.llm_score_failures` and the run continues.
+#[allow(clippy::too_many_arguments)]
+async fn run_llm_score_pass(
+    store: &SkillStore,
+    llm: &LlmClient,
+    api_key: Option<&str>,
+    interests: &crate::interests::Interests,
+    run_id: &str,
+    session_log: Option<&Arc<dyn SessionLog>>,
+    handle: Option<&SessionHandle<OwnSession>>,
+    summary: &mut RunSummary,
+) {
+    let candidates: Vec<(i64, FetchedItem)> = match collect_run_candidates(store, run_id) {
+        Ok(c) => c,
+        Err(e) => {
+            summary.theme_stage_failures.push(LlmStageFailure {
+                candidate_id: None,
+                reason: format!("read run candidates: {e}"),
+            });
+            return;
+        }
+    };
+
+    for (cid, item) in candidates {
+        match score_candidate(llm, api_key, &item, interests).await {
+            Ok(score) => {
+                let res = store.conn().execute(
+                    "UPDATE candidates SET llm_relevance_score = ?1, llm_why_surfaced = ?2 \
+                     WHERE id = ?3",
+                    rusqlite::params![score.score as i64, score.why_surfaced, cid],
+                );
+                if let Err(e) = res {
+                    summary.llm_score_failures.push(LlmStageFailure {
+                        candidate_id: Some(cid),
+                        reason: format!("update candidate row: {e}"),
+                    });
+                    continue;
+                }
+                summary.items_llm_scored += 1;
+                emit(
+                    session_log,
+                    handle,
+                    SessionEvent::CandidateLlmScored {
+                        run_id: run_id.to_string(),
+                        candidate_id: cid,
+                        llm_relevance_score: score.score,
+                        matched_keyword: score.matched_keyword,
+                        why_surfaced: score.why_surfaced,
+                    },
+                );
+            }
+            Err(e) => {
+                tracing::warn!("LLM scoring failed for candidate {cid}: {e}");
+                summary.llm_score_failures.push(LlmStageFailure {
+                    candidate_id: Some(cid),
+                    reason: e.to_string(),
+                });
+            }
+        }
+    }
+}
+
+/// Embed every kept candidate, cluster, name each cluster, write the
+/// `themes` rows and update each candidate's `cluster_id`. Stage-level
+/// failures (embedding HTTP errors, clustering failure, individual
+/// theme-naming failures) land in `summary.theme_stage_failures` and
+/// the run completes regardless.
+#[allow(clippy::too_many_arguments)]
+async fn run_theme_pass(
+    store: &SkillStore,
+    http: &EgressClient,
+    llm: &LlmClient,
+    api_key: Option<&str>,
+    ollama_embed_base: &str,
+    embed_model: &str,
+    run_id: &str,
+    session_log: Option<&Arc<dyn SessionLog>>,
+    handle: Option<&SessionHandle<OwnSession>>,
+    summary: &mut RunSummary,
+) {
+    // Pull (id, title, abstract, matched_keywords_json) for clustering.
+    let rows: Vec<(i64, String, String, String)> = match collect_cluster_rows(store, run_id) {
+        Ok(r) => r,
+        Err(e) => {
+            summary.theme_stage_failures.push(LlmStageFailure {
+                candidate_id: None,
+                reason: format!("query cluster rows: {e}"),
+            });
+            return;
+        }
+    };
+
+    if rows.len() < 2 {
+        return;
+    }
+
+    let texts: Vec<String> = rows
+        .iter()
+        .map(|(_, title, abs_, _)| format!("{title}\n\n{abs_}"))
+        .collect();
+    let text_refs: Vec<&str> = texts.iter().map(|s| s.as_str()).collect();
+    let embeddings = match embed_batch(http, ollama_embed_base, embed_model, &text_refs).await {
+        Ok(e) => e,
+        Err(e) => {
+            summary.theme_stage_failures.push(LlmStageFailure {
+                candidate_id: None,
+                reason: format!("embed batch: {e}"),
+            });
+            return;
+        }
+    };
+
+    let labels = match cluster_embeddings(&embeddings, 2, 1) {
+        Ok(l) => l,
+        Err(e) => {
+            summary.theme_stage_failures.push(LlmStageFailure {
+                candidate_id: None,
+                reason: format!("hdbscan: {e}"),
+            });
+            return;
+        }
+    };
+
+    // Build `(label, candidate_id, ClusterMember)` triples for grouping.
+    let mut by_cluster: std::collections::BTreeMap<u32, Vec<(i64, ClusterMember)>> =
+        Default::default();
+    for ((row, label), _) in rows.iter().zip(labels.iter()).zip(0..) {
+        if let ClusterLabel::Cluster(n) = label {
+            let kws: Vec<String> = serde_json::from_str(&row.3).unwrap_or_default();
+            by_cluster.entry(*n).or_default().push((
+                row.0,
+                ClusterMember {
+                    title: row.1.clone(),
+                    matched_keywords: kws,
+                },
+            ));
+        }
+    }
+
+    // Use group_by_cluster to confirm parity with the expected shape.
+    // (Functionally redundant with the loop above; kept as the public
+    // API entry the cluster module exposes.)
+    let _check = group_by_cluster(&labels, &rows);
+
+    for (_cluster_label, members) in by_cluster.iter() {
+        let cluster_members: Vec<ClusterMember> = members.iter().map(|(_, m)| m.clone()).collect();
+        match name_theme(llm, api_key, &cluster_members).await {
+            Ok(theme) => {
+                let member_count = cluster_members.len() as i64;
+                let res = store.conn().execute(
+                    "INSERT INTO themes (run_id, name, member_count) VALUES (?1, ?2, ?3)",
+                    rusqlite::params![run_id, &theme.name, member_count],
+                );
+                let theme_id = match res {
+                    Ok(_) => store.conn().last_insert_rowid(),
+                    Err(e) => {
+                        summary.theme_stage_failures.push(LlmStageFailure {
+                            candidate_id: None,
+                            reason: format!("insert theme: {e}"),
+                        });
+                        continue;
+                    }
+                };
+                for (cid, _) in members {
+                    let _ = store.conn().execute(
+                        "UPDATE candidates SET cluster_id = ?1 WHERE id = ?2",
+                        rusqlite::params![theme_id, cid],
+                    );
+                }
+                summary.themes_named += 1;
+                emit(
+                    session_log,
+                    handle,
+                    SessionEvent::ThemeNamed {
+                        run_id: run_id.to_string(),
+                        theme_id,
+                        name: theme.name,
+                        member_count: member_count as u32,
+                    },
+                );
+            }
+            Err(e) => {
+                tracing::warn!("theme naming failed for cluster: {e}");
+                summary.theme_stage_failures.push(LlmStageFailure {
+                    candidate_id: None,
+                    reason: format!("name_theme: {e}"),
+                });
+            }
+        }
+    }
+}
+
+fn collect_cluster_rows(
+    store: &SkillStore,
+    run_id: &str,
+) -> Result<Vec<(i64, String, String, String)>, rusqlite::Error> {
+    let conn = store.conn();
+    let mut stmt =
+        conn.prepare("SELECT id, title, body, matched_keywords FROM candidates WHERE run_id = ?1")?;
+    stmt.query_map(rusqlite::params![run_id], |row| {
+        Ok((
+            row.get::<_, i64>(0)?,
+            row.get::<_, String>(1)?,
+            row.get::<_, String>(2)?,
+            row.get::<_, String>(3)?,
+        ))
+    })?
+    .collect()
+}
+
+fn collect_run_candidates(
+    store: &SkillStore,
+    run_id: &str,
+) -> Result<Vec<(i64, FetchedItem)>, rusqlite::Error> {
+    let conn = store.conn();
+    let mut stmt = conn.prepare(
+        "SELECT id, source_name, url, title, body, COALESCE(published_at, '') \
+         FROM candidates WHERE run_id = ?1",
+    )?;
+    let rows = stmt.query_map(rusqlite::params![run_id], |row| {
+        Ok((
+            row.get::<_, i64>(0)?,
+            FetchedItem {
+                source_name: row.get::<_, String>(1)?,
+                url: row.get::<_, String>(2)?,
+                title: row.get::<_, String>(3)?,
+                abstract_text: row.get::<_, String>(4)?,
+                published_at: row.get::<_, String>(5)?,
+            },
+        ))
+    })?;
+    rows.collect()
 }
 
 fn sha256_hex(s: &str) -> String {
@@ -640,6 +962,14 @@ skills = ["aggregator"]
             interests_path,
             rate_limit: RateLimitConfig::unrestricted_for_tests(),
             session_log: log,
+            // C-LLM fields default to "off" for the C-foundation tests:
+            // none of them exercise the LLM-scoring or theme-naming
+            // passes. The C-LLM tests construct their own config with
+            // the LLM client and embed base populated.
+            llm: None,
+            llm_api_key: None,
+            ollama_embed_base: String::new(),
+            embed_model: String::new(),
         }
     }
 
@@ -934,5 +1264,382 @@ skills = ["other"]
         .await
         .unwrap_err();
         assert!(matches!(err, OrchestratorError::LoadInterests(_)));
+    }
+
+    // ----- C-LLM tests -----------------------------------------------
+
+    /// Multi-request mock server. Dispatches by URL path:
+    /// - `/feed` → returns the RSS fixture body
+    /// - `/v1/chat/completions` → returns an OpenAI-shaped tool_call
+    ///   response. Tool name is detected from the request body so
+    ///   the same server can stand in for both score and theme calls.
+    /// - `/api/embed` → returns canned vectors.
+    ///
+    /// Stays alive serving up to `max_requests` connections, then
+    /// stops. Returns the bound base URL like `http://127.0.0.1:<port>`.
+    async fn mock_llm_and_feed_server(
+        feed_body: &'static str,
+        embed_vectors: Vec<Vec<f32>>,
+        max_requests: usize,
+    ) -> String {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let url = format!("http://{}", addr);
+        tokio::spawn(async move {
+            for _ in 0..max_requests {
+                let Ok((mut sock, _)) = listener.accept().await else {
+                    return;
+                };
+                let mut buf = vec![0u8; 65536];
+                let n = match sock.read(&mut buf).await {
+                    Ok(n) => n,
+                    Err(_) => continue,
+                };
+                let req = String::from_utf8_lossy(&buf[..n]).to_string();
+                let body = match req.find("\r\n\r\n") {
+                    Some(idx) => &req[idx + 4..],
+                    None => "",
+                };
+
+                let response_body: String = if req.contains("POST /feed") {
+                    feed_body.to_string()
+                } else if req.contains("POST /v1/chat/completions")
+                    || req.contains("POST /chat/completions")
+                {
+                    if body.contains("zirkel_score_candidate") {
+                        canned_score_response()
+                    } else if body.contains("zirkel_name_theme") {
+                        canned_theme_response()
+                    } else {
+                        // Unrecognized — fail loudly so the test
+                        // shows what shape the request actually had.
+                        panic!("mock LLM saw no known synthetic-tool name in request body: {body}")
+                    }
+                } else if req.contains("POST /api/embed") {
+                    canned_embed_response(&embed_vectors)
+                } else {
+                    // Any GET request (e.g. RSS feed served via GET).
+                    if req.contains("GET /feed") {
+                        feed_body.to_string()
+                    } else {
+                        format!("not found: {}", req.lines().next().unwrap_or(""))
+                    }
+                };
+
+                let content_type = if req.contains("/feed") {
+                    "application/xml"
+                } else {
+                    "application/json"
+                };
+                let resp = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nContent-Type: {}\r\n\r\n{}",
+                    response_body.len(),
+                    content_type,
+                    response_body
+                );
+                let _ = sock.write_all(resp.as_bytes()).await;
+                let _ = sock.shutdown().await;
+            }
+        });
+        url
+    }
+
+    fn canned_score_response() -> String {
+        // OpenAI chat-completions shape with one tool_call to
+        // zirkel_score_candidate. Same fixed score for every request
+        // — the test asserts whatever lands in the DB matches.
+        r#"{
+  "id": "test-1",
+  "object": "chat.completion",
+  "choices": [{
+    "index": 0,
+    "message": {
+      "role": "assistant",
+      "content": null,
+      "tool_calls": [{
+        "id": "call_score_1",
+        "type": "function",
+        "function": {
+          "name": "zirkel_score_candidate",
+          "arguments": "{\"score\":80,\"why_surfaced\":\"matched 'data broker' — substantively about FTC enforcement against a broker\",\"matched_keyword\":\"data broker\"}"
+        }
+      }]
+    },
+    "finish_reason": "tool_calls"
+  }]
+}"#
+        .to_string()
+    }
+
+    fn canned_theme_response() -> String {
+        r#"{
+  "id": "test-2",
+  "object": "chat.completion",
+  "choices": [{
+    "index": 0,
+    "message": {
+      "role": "assistant",
+      "content": null,
+      "tool_calls": [{
+        "id": "call_theme_1",
+        "type": "function",
+        "function": {
+          "name": "zirkel_name_theme",
+          "arguments": "{\"name\":\"FTC enforcement\"}"
+        }
+      }]
+    },
+    "finish_reason": "tool_calls"
+  }]
+}"#
+        .to_string()
+    }
+
+    fn canned_embed_response(vectors: &[Vec<f32>]) -> String {
+        let v_str = vectors
+            .iter()
+            .map(|v| {
+                let inner = v
+                    .iter()
+                    .map(|f| format!("{}", f))
+                    .collect::<Vec<_>>()
+                    .join(",");
+                format!("[{inner}]")
+            })
+            .collect::<Vec<_>>()
+            .join(",");
+        format!(
+            "{{\"model\":\"nomic-embed-text:v1.5\",\"embeddings\":[{}]}}",
+            v_str
+        )
+    }
+
+    fn config_for_llm_e2e(
+        preset_dir: PathBuf,
+        storage_dir: PathBuf,
+        interests_path: PathBuf,
+        log: Option<Arc<dyn SessionLog>>,
+        llm_base: &str,
+        embed_base: &str,
+    ) -> OrchestratorConfig {
+        let llm_cfg = wirken_agent::llm::LlmConfig {
+            provider: "ollama".to_string(),
+            model: "llama3.1:8b".to_string(),
+            base_url: format!("{llm_base}/v1"),
+            max_tokens: 1024,
+            temperature: 0.0,
+            region: None,
+            tools_enabled: true,
+            context_window: 8192,
+        };
+        let llm = Arc::new(LlmClient::new(llm_cfg).unwrap());
+        OrchestratorConfig {
+            preset_dir,
+            storage_dir,
+            interests_path,
+            rate_limit: RateLimitConfig::unrestricted_for_tests(),
+            session_log: log,
+            llm: Some(llm),
+            llm_api_key: None,
+            ollama_embed_base: embed_base.to_string(),
+            embed_model: "nomic-embed-text:v1.5".to_string(),
+        }
+    }
+
+    /// LLM relevance-scoring pass writes `llm_relevance_score` and
+    /// `llm_why_surfaced` to the candidate row and emits the
+    /// `CandidateLlmScored` audit event. Single-source single-item
+    /// fixture: clustering is skipped (need ≥2 items), so this test
+    /// isolates the LLM-scoring path.
+    #[tokio::test]
+    async fn llm_scoring_pass_writes_relevance_and_emits_event() {
+        let single_item_feed = r#"<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0"><channel>
+<title>FTC</title><link>https://x</link><description>x</description>
+<item>
+  <title>FTC sues data broker over Section 5 unfairness</title>
+  <link>https://www.ftc.gov/x/data-broker</link>
+  <description>The FTC sued ExampleCorp under Section 5.</description>
+</item>
+</channel></rss>"#;
+        // Connections expected: 1 feed GET + 1 score chat-completion.
+        let server = mock_llm_and_feed_server(single_item_feed, vec![], 4).await;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let preset_dir = tmp.path().join("preset");
+        let storage_dir = tmp.path().join("storage");
+        std::fs::create_dir_all(&storage_dir).unwrap();
+        let sources_toml =
+            format!("[[source]]\nname=\"ftc\"\nendpoint=\"{server}/feed\"\nmethod=\"rss\"\n");
+        write_fixture_preset(&preset_dir, &storage_dir, &["127.0.0.1"], &sources_toml);
+        let interests_path = storage_dir.join("interests.toml");
+        write_interests(&interests_path, r#"keywords = ["data broker"]"#);
+
+        let log: Arc<dyn SessionLog> =
+            Arc::new(SqliteSessionLog::open_in_memory().expect("in-memory session log"));
+
+        let summary = run(config_for_llm_e2e(
+            preset_dir,
+            storage_dir.clone(),
+            interests_path,
+            Some(log.clone()),
+            &server,
+            "", // empty embed base disables clustering for this test
+        ))
+        .await
+        .unwrap();
+
+        assert_eq!(summary.items_kept, 1);
+        assert_eq!(summary.items_llm_scored, 1);
+        assert_eq!(summary.themes_named, 0);
+
+        // Candidate row carries the LLM fields.
+        let conn = rusqlite::Connection::open(storage_dir.join("aggregator.db")).unwrap();
+        let (relevance, why): (f64, String) = conn
+            .query_row(
+                "SELECT llm_relevance_score, llm_why_surfaced FROM candidates LIMIT 1",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(relevance as i64, 80);
+        assert!(why.contains("data broker"));
+
+        // Audit chain has the CandidateLlmScored event.
+        let handle = log.handle_for(SessionId::new(summary.run_id.clone()));
+        let events = log.get_since(&handle, 0).unwrap();
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e.event, SessionEvent::CandidateLlmScored { .. })),
+            "expected CandidateLlmScored event in chain"
+        );
+    }
+
+    /// Full C-LLM pipeline end-to-end. HDBSCAN's density-based
+    /// algorithm needs *contrast* between clusters to identify any
+    /// of them as non-noise — a single tightly-packed group of N
+    /// points yields all-noise regardless of N. The fixture provides
+    /// 6 items that the mock embed returns as two distinct clusters
+    /// of 3, which HDBSCAN reliably partitions. Both clusters get
+    /// named by the (single) canned theme response.
+    /// Assert: `themes_named = 2`, all 6 candidates have a non-NULL
+    /// `cluster_id`, audit chain has `ThemeNamed`.
+    #[tokio::test]
+    async fn clustering_and_theme_naming_e2e() {
+        let six_kept_feed = r#"<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0"><channel>
+<title>FTC</title><link>https://x</link><description>x</description>
+<item>
+  <title>FTC sues data broker A</title>
+  <link>https://www.ftc.gov/a</link>
+  <description>Section 5 data broker enforcement.</description>
+</item>
+<item>
+  <title>FTC announces data broker rule B</title>
+  <link>https://www.ftc.gov/b</link>
+  <description>Data broker registry rule.</description>
+</item>
+<item>
+  <title>FTC investigates data broker C</title>
+  <link>https://www.ftc.gov/c</link>
+  <description>Data broker investigation.</description>
+</item>
+<item>
+  <title>FTC settles data broker case D</title>
+  <link>https://www.ftc.gov/d</link>
+  <description>Data broker settlement reached.</description>
+</item>
+<item>
+  <title>FTC issues data broker order E</title>
+  <link>https://www.ftc.gov/e</link>
+  <description>Data broker compliance order.</description>
+</item>
+<item>
+  <title>FTC closes data broker probe F</title>
+  <link>https://www.ftc.gov/f</link>
+  <description>Data broker probe concluded.</description>
+</item>
+</channel></rss>"#;
+        // Two well-separated clusters of 3 in 2D feature space.
+        let embed_vectors = vec![
+            vec![1.0, 0.0],
+            vec![1.05, 0.05],
+            vec![0.95, -0.05],
+            vec![10.0, 10.0],
+            vec![10.05, 10.05],
+            vec![9.95, 9.95],
+        ];
+        // 1 feed + 6 score requests + 1 embed + 2 theme = 10 minimum.
+        let server = mock_llm_and_feed_server(six_kept_feed, embed_vectors, 20).await;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let preset_dir = tmp.path().join("preset");
+        let storage_dir = tmp.path().join("storage");
+        std::fs::create_dir_all(&storage_dir).unwrap();
+        let sources_toml =
+            format!("[[source]]\nname=\"ftc\"\nendpoint=\"{server}/feed\"\nmethod=\"rss\"\n");
+        write_fixture_preset(&preset_dir, &storage_dir, &["127.0.0.1"], &sources_toml);
+        let interests_path = storage_dir.join("interests.toml");
+        write_interests(&interests_path, r#"keywords = ["data broker"]"#);
+
+        let log: Arc<dyn SessionLog> =
+            Arc::new(SqliteSessionLog::open_in_memory().expect("in-memory session log"));
+
+        let summary = run(config_for_llm_e2e(
+            preset_dir,
+            storage_dir.clone(),
+            interests_path,
+            Some(log.clone()),
+            &server,
+            &server, // same mock answers /api/embed too
+        ))
+        .await
+        .unwrap();
+
+        assert_eq!(summary.items_kept, 6);
+        assert_eq!(summary.items_llm_scored, 6);
+        assert_eq!(
+            summary.themes_named, 2,
+            "two well-separated 3-point clusters should produce two themes; failures: {:?}",
+            summary.theme_stage_failures
+        );
+
+        let conn = rusqlite::Connection::open(storage_dir.join("aggregator.db")).unwrap();
+
+        // Both themes carry the LLM-supplied name (mock returns the
+        // same canned name for every theme call).
+        let names: Vec<String> = conn
+            .prepare("SELECT name FROM themes ORDER BY id")
+            .unwrap()
+            .query_map([], |row| row.get::<_, String>(0))
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        assert_eq!(names.len(), 2);
+        for n in &names {
+            assert_eq!(n, "FTC enforcement");
+        }
+
+        // All 6 candidates have a non-NULL cluster_id pointing at one
+        // of the themes.
+        let with_cluster: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM candidates WHERE cluster_id IS NOT NULL",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(with_cluster, 6);
+
+        // Audit chain has ThemeNamed.
+        let handle = log.handle_for(SessionId::new(summary.run_id.clone()));
+        let events = log.get_since(&handle, 0).unwrap();
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e.event, SessionEvent::ThemeNamed { .. })),
+            "expected ThemeNamed event in chain"
+        );
     }
 }

--- a/crates/zirkel/src/schema.rs
+++ b/crates/zirkel/src/schema.rs
@@ -69,4 +69,28 @@ pub const AGGREGATOR_MIGRATIONS: &[&str] = &[
         detail       TEXT \
     )",
     "CREATE INDEX idx_skipped_log_run ON skipped_log(run_id)",
+    // 5 — C-LLM additions. The keyword and LLM scores live in
+    // separate columns so a query can filter on either axis. The
+    // keyword column stays a count (`keyword_match_score INTEGER`);
+    // `llm_relevance_score REAL` is the LLM-driven 0–100 rating.
+    // Both nullable on legacy rows; the C-LLM orchestrator pass fills
+    // the LLM column on every keep.
+    "ALTER TABLE candidates ADD COLUMN llm_relevance_score REAL",
+    "ALTER TABLE candidates ADD COLUMN llm_why_surfaced TEXT",
+    // Cluster assignment: NULL for noise / ungrouped items. Real
+    // cluster ids reference `themes.id`. The digest renderer's
+    // "ungrouped" section is the union of NULL-cluster_id rows.
+    "ALTER TABLE candidates ADD COLUMN cluster_id INTEGER",
+    // 6 — themes table. Per-run; cross-run theme stability is
+    // explicitly out of scope (see DESIGN.md). One row per
+    // HDBSCAN cluster, populated after theme naming.
+    "CREATE TABLE themes ( \
+        id           INTEGER PRIMARY KEY AUTOINCREMENT, \
+        run_id       TEXT NOT NULL, \
+        name         TEXT NOT NULL, \
+        member_count INTEGER NOT NULL, \
+        created_at   TEXT NOT NULL DEFAULT (datetime('now')) \
+    )",
+    "CREATE INDEX idx_themes_run ON themes(run_id)",
+    "CREATE INDEX idx_candidates_cluster ON candidates(cluster_id)",
 ];

--- a/crates/zirkel/src/synthetic_tool.rs
+++ b/crates/zirkel/src/synthetic_tool.rs
@@ -1,0 +1,252 @@
+//! Synthetic tool calls as a structured-output channel.
+//!
+//! ## Why this exists
+//!
+//! C-LLM scoring and theme naming need structured LLM output. The
+//! existing [`wirken_agent::llm::LlmClient`] does not (yet) plumb a
+//! `response_format` / JSON-mode knob through any provider; its only
+//! structured output path is the `tool_calls` mechanism that's
+//! already wired end-to-end. Per the C-LLM pre-checks (Path B),
+//! Zirkel uses synthetic tools — tools the orchestrator knows the
+//! LLM will never actually execute — as a structured-output channel.
+//! The LLM "calls" the tool with strongly-typed arguments; the
+//! orchestrator parses the call's `arguments` JSON into the
+//! caller-chosen Rust type.
+//!
+//! ## This is a Zirkel-internal idiom
+//!
+//! The `zirkel_`-prefixed tool names (`zirkel_score_candidate`,
+//! `zirkel_name_theme`) mark this as Zirkel-specific, not a
+//! Wirken-wide convention. Future skills should not reach for this
+//! pattern casually. **A third consumer doing the same thing is the
+//! signal to extract real JSON-mode support into `LlmClient`** —
+//! provider-by-provider work, but the right shape once there are
+//! multiple real consumers.
+//!
+//! Until then, the synthetic-tool channel is good enough for two
+//! Zirkel call sites, and adding generic JSON mode to LlmClient
+//! preemptively would shape that surface around an uncommitted
+//! second-consumer boundary.
+//!
+//! ## Risk: weaker tool-calling models
+//!
+//! The OpenAI / Anthropic / Gemini tool-calling APIs are strict
+//! enough that a competent model called with this synthetic tool
+//! and a clear prompt will reliably emit a tool call. Local Ollama
+//! models with weaker tool support may sometimes return text
+//! instead, producing [`SyntheticToolError::ExpectedToolCallGotText`].
+//! The default Ollama model for Zirkel (`llama3.1:8b`) handles this
+//! reliably; weaker models are not currently supported.
+
+use serde::Deserialize;
+use serde::de::DeserializeOwned;
+use thiserror::Error;
+use wirken_agent::conversation::{Message, Role};
+use wirken_agent::error::AgentError;
+use wirken_agent::llm::{LlmClient, LlmResponse};
+use wirken_agent::tool::ToolDef;
+
+/// Tool def for `zirkel_score_candidate` — used by the LLM relevance
+/// scorer. Output type: [`ScoreCandidateArgs`].
+pub fn score_candidate_tool() -> ToolDef {
+    ToolDef {
+        name: "zirkel_score_candidate".to_string(),
+        description: "Return a structured relevance score for the candidate item against the user's interests. \
+                      You MUST call this tool with the score, why-surfaced rationale, and matched keyword. \
+                      Do not respond with text.".to_string(),
+        parameters: serde_json::json!({
+            "type": "object",
+            "properties": {
+                "score": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 100,
+                    "description": "Relevance score 0–100. 0 = irrelevant. 50 = matches a user interest broadly. 100 = directly addresses a user keyword in a substantive way."
+                },
+                "why_surfaced": {
+                    "type": "string",
+                    "description": "One-line rationale (≤140 chars). Cite the matched user interest by name and how the candidate's content relates to it."
+                },
+                "matched_keyword": {
+                    "type": "string",
+                    "description": "The single user keyword that best characterizes the match. Must be one of the user keywords provided in the prompt."
+                }
+            },
+            "required": ["score", "why_surfaced", "matched_keyword"]
+        }),
+    }
+}
+
+/// Output shape for [`score_candidate_tool`].
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+pub struct ScoreCandidateArgs {
+    pub score: u32,
+    pub why_surfaced: String,
+    pub matched_keyword: String,
+}
+
+/// Tool def for `zirkel_name_theme` — used by the theme naming pass.
+/// Output type: [`NameThemeArgs`].
+pub fn name_theme_tool() -> ToolDef {
+    ToolDef {
+        name: "zirkel_name_theme".to_string(),
+        description: "Return a 2–5 word theme name for a cluster of related candidates. \
+                      You MUST call this tool. Do not respond with text or quotes."
+            .to_string(),
+        parameters: serde_json::json!({
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "2–5 word theme name. Examples: 'FTC enforcement', 'EU AI Act', 'biometric privacy in employment'. No cluster ids, no jargon, no quotes."
+                }
+            },
+            "required": ["name"]
+        }),
+    }
+}
+
+/// Output shape for [`name_theme_tool`].
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+pub struct NameThemeArgs {
+    pub name: String,
+}
+
+#[derive(Debug, Error)]
+pub enum SyntheticToolError {
+    #[error("LLM call failed: {0}")]
+    Llm(#[source] AgentError),
+    #[error("expected a tool call to '{expected}' but the LLM responded with text: {text}")]
+    ExpectedToolCallGotText { expected: String, text: String },
+    #[error("LLM returned an empty response")]
+    EmptyResponse,
+    #[error("LLM made tool calls but none were to '{expected}'; calls: {actual:?}")]
+    ToolNotCalled {
+        expected: String,
+        actual: Vec<String>,
+    },
+    #[error("could not parse '{tool}' arguments as the expected shape: {error}; raw: {raw}")]
+    ParseArguments {
+        tool: String,
+        error: String,
+        raw: String,
+    },
+}
+
+/// Run a structured-output LLM call. Builds a 2-message conversation
+/// (system + user), passes the supplied synthetic tool, and parses
+/// the LLM's tool-call arguments into `T`.
+///
+/// `T` must `derive(Deserialize)` matching the tool's `parameters`
+/// JSON schema.
+pub async fn call_structured<T: DeserializeOwned>(
+    llm: &LlmClient,
+    api_key: Option<&str>,
+    system_prompt: &str,
+    user_prompt: &str,
+    tool: ToolDef,
+) -> Result<T, SyntheticToolError> {
+    let tool_name = tool.name.clone();
+    let messages = vec![
+        Message {
+            role: Role::System,
+            content: system_prompt.to_string(),
+            tool_call_id: None,
+            tool_name: None,
+            tool_calls: None,
+        },
+        Message {
+            role: Role::User,
+            content: user_prompt.to_string(),
+            tool_call_id: None,
+            tool_name: None,
+            tool_calls: None,
+        },
+    ];
+    let resp = llm
+        .complete(&messages, &[tool], api_key)
+        .await
+        .map_err(SyntheticToolError::Llm)?;
+    match resp {
+        LlmResponse::ToolCalls(calls) => {
+            let actual: Vec<String> = calls.iter().map(|c| c.name.clone()).collect();
+            let call = calls.iter().find(|c| c.name == tool_name).ok_or_else(|| {
+                SyntheticToolError::ToolNotCalled {
+                    expected: tool_name.clone(),
+                    actual,
+                }
+            })?;
+            serde_json::from_str::<T>(&call.arguments).map_err(|e| {
+                SyntheticToolError::ParseArguments {
+                    tool: tool_name,
+                    error: e.to_string(),
+                    raw: call.arguments.clone(),
+                }
+            })
+        }
+        LlmResponse::Text(t) => Err(SyntheticToolError::ExpectedToolCallGotText {
+            expected: tool_name,
+            text: t,
+        }),
+        LlmResponse::Empty => Err(SyntheticToolError::EmptyResponse),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn score_candidate_tool_def_has_required_fields() {
+        let tool = score_candidate_tool();
+        assert_eq!(tool.name, "zirkel_score_candidate");
+        let required = tool
+            .parameters
+            .get("required")
+            .and_then(|v| v.as_array())
+            .unwrap()
+            .iter()
+            .map(|v| v.as_str().unwrap().to_string())
+            .collect::<Vec<_>>();
+        assert!(required.contains(&"score".to_string()));
+        assert!(required.contains(&"why_surfaced".to_string()));
+        assert!(required.contains(&"matched_keyword".to_string()));
+    }
+
+    #[test]
+    fn name_theme_tool_def_requires_name() {
+        let tool = name_theme_tool();
+        assert_eq!(tool.name, "zirkel_name_theme");
+        let required = tool
+            .parameters
+            .get("required")
+            .and_then(|v| v.as_array())
+            .unwrap();
+        assert_eq!(required.len(), 1);
+        assert_eq!(required[0].as_str().unwrap(), "name");
+    }
+
+    #[test]
+    fn score_args_round_trip_through_serde() {
+        let json = r#"{"score": 75, "why_surfaced": "matched 'BIPA' — biometric enforcement", "matched_keyword": "BIPA"}"#;
+        let parsed: ScoreCandidateArgs = serde_json::from_str(json).unwrap();
+        assert_eq!(parsed.score, 75);
+        assert_eq!(parsed.matched_keyword, "BIPA");
+        assert!(parsed.why_surfaced.contains("biometric"));
+    }
+
+    #[test]
+    fn theme_name_args_round_trip() {
+        let json = r#"{"name": "FTC enforcement"}"#;
+        let parsed: NameThemeArgs = serde_json::from_str(json).unwrap();
+        assert_eq!(parsed.name, "FTC enforcement");
+    }
+
+    // Live LlmClient end-to-end is exercised by the orchestrator-
+    // level test in `crate::orchestrator::tests` against a mocked
+    // OpenAI-compatible HTTP server. Unit-testing call_structured in
+    // isolation would require either spinning up a similar server
+    // here or refactoring LlmClient to accept an injected transport;
+    // the orchestrator integration test gives better coverage for
+    // less code.
+}

--- a/crates/zirkel/src/themes.rs
+++ b/crates/zirkel/src/themes.rs
@@ -1,0 +1,123 @@
+//! Theme naming for Zirkel clusters.
+//!
+//! One LLM call per cluster using the
+//! [`crate::synthetic_tool::name_theme_tool`] structured-output
+//! channel. Input: the cluster's member titles plus the union of
+//! `matched_keywords` across members. Output: a 2–5 word theme
+//! name like "FTC enforcement" or "biometric privacy in employment".
+//!
+//! Per `docs/zirkel/DESIGN.md`: names should read like prose, not
+//! cluster ids or jargon. The synthetic tool's parameter description
+//! and the system prompt both reinforce that constraint.
+
+use thiserror::Error;
+use wirken_agent::llm::LlmClient;
+
+use crate::synthetic_tool::{NameThemeArgs, SyntheticToolError, call_structured, name_theme_tool};
+
+/// One cluster member, as the orchestrator hands it to
+/// [`name_theme`]. `matched_keywords` is the JSON array stored on
+/// the candidate row (parsed by the orchestrator before calling).
+#[derive(Debug, Clone)]
+pub struct ClusterMember {
+    pub title: String,
+    pub matched_keywords: Vec<String>,
+}
+
+#[derive(Debug, Error)]
+pub enum ThemeNameError {
+    #[error("synthetic-tool call failed: {0}")]
+    Synthetic(#[from] SyntheticToolError),
+    #[error("cluster has no members; cannot name an empty cluster")]
+    EmptyCluster,
+}
+
+pub async fn name_theme(
+    llm: &LlmClient,
+    api_key: Option<&str>,
+    members: &[ClusterMember],
+) -> Result<NameThemeArgs, ThemeNameError> {
+    if members.is_empty() {
+        return Err(ThemeNameError::EmptyCluster);
+    }
+    let system = system_prompt();
+    let user = build_user_prompt(members);
+    let args: NameThemeArgs =
+        call_structured(llm, api_key, &system, &user, name_theme_tool()).await?;
+    Ok(args)
+}
+
+fn system_prompt() -> String {
+    r#"You are Zirkel's theme namer. You will be given a small cluster of related candidates (titles + the user keywords each one matched). Return a 2–5 word theme name that captures what the cluster is about, written in prose-style (e.g. "FTC enforcement", "biometric privacy in employment", "data broker registry"). Never return a cluster id, the literal user keywords as a list, or jargon-only labels.
+
+You MUST call the zirkel_name_theme tool. Do not respond with text."#
+        .to_string()
+}
+
+fn build_user_prompt(members: &[ClusterMember]) -> String {
+    let mut all_keywords: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+    for m in members {
+        for k in &m.matched_keywords {
+            all_keywords.insert(k.clone());
+        }
+    }
+    let keywords_csv = all_keywords.into_iter().collect::<Vec<_>>().join(", ");
+
+    let mut s = String::new();
+    s.push_str("Cluster members:\n");
+    for (i, m) in members.iter().enumerate() {
+        s.push_str(&format!("  {}. {}\n", i + 1, m.title));
+    }
+    s.push_str("\nUnion of user keywords matched across members: ");
+    s.push_str(&keywords_csv);
+    s.push('\n');
+    s
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn members() -> Vec<ClusterMember> {
+        vec![
+            ClusterMember {
+                title: "FTC sues data broker over Section 5 unfairness".to_string(),
+                matched_keywords: vec!["data broker".to_string(), "Section 5".to_string()],
+            },
+            ClusterMember {
+                title: "FTC announces new data broker registration rule".to_string(),
+                matched_keywords: vec!["data broker".to_string()],
+            },
+        ]
+    }
+
+    #[test]
+    fn user_prompt_includes_titles_and_union_keywords() {
+        let p = build_user_prompt(&members());
+        assert!(p.contains("FTC sues data broker"));
+        assert!(p.contains("FTC announces new data broker"));
+        // Union of keywords across members.
+        assert!(p.contains("data broker"));
+        assert!(p.contains("Section 5"));
+    }
+
+    #[tokio::test]
+    async fn empty_cluster_is_a_typed_error() {
+        // We can't reach a real LlmClient in a unit test; building a
+        // dummy one with a localhost base_url is cheap and we never
+        // make a request because the empty-cluster check short-circuits.
+        let cfg = wirken_agent::llm::LlmConfig {
+            provider: "ollama".into(),
+            model: "llama3.1:8b".into(),
+            base_url: "http://127.0.0.1:11434/v1".into(),
+            max_tokens: 1024,
+            temperature: 0.7,
+            region: None,
+            tools_enabled: true,
+            context_window: 32_000,
+        };
+        let llm = LlmClient::new(cfg).unwrap();
+        let err = name_theme(&llm, None, &[]).await.unwrap_err();
+        assert!(matches!(err, ThemeNameError::EmptyCluster));
+    }
+}

--- a/preset/zirkel/skills/aggregator/SKILL.md
+++ b/preset/zirkel/skills/aggregator/SKILL.md
@@ -22,6 +22,13 @@ permissions:
       # loader derives one from the other, both are maintained by hand
       # in this preset. Adding a source means editing both files in the
       # same commit. Mismatch is an attach-time error in a later scope.
+      #
+      # Ollama embedding endpoint: 127.0.0.1 is in the allowlist
+      # specifically so the orchestrator's POST to <ollama>/api/embed
+      # passes the policed transport. This is NOT a generic
+      # local-network exception — only the orchestrator's embedding
+      # pass uses it (per the C-LLM pre-checks Path C decision).
+      - 127.0.0.1
       - export.arxiv.org
       - papers.ssrn.com
       - www.ftc.gov


### PR DESCRIPTION
Second slice of Scope C. Lands the LLM-dependent stages on top of the C-foundation pipeline: relevance scoring, embedding, clustering, theme naming. Digest push to Signal is the next slice (C-Signal); the orchestrator's output here is candidates with `llm_relevance_score` populated and `themes` rows linking clusters of related items.

## Synthetic-tool structured output (Path B from yesterday's pre-checks)

The existing `LlmClient` does not (yet) plumb a `response_format` / JSON-mode knob through any provider; its only structured output path is the `tool_calls` mechanism that's already wired end-to-end. Per the C-LLM pre-checks, Zirkel uses **synthetic tools** — tools the orchestrator knows the LLM will never actually execute — as a structured-output channel. The LLM "calls" the tool with strongly-typed arguments; the orchestrator parses the call's `arguments` JSON.

**This is a Zirkel-internal idiom, not a Wirken-wide convention.** The `zirkel_`-prefixed names (`zirkel_score_candidate`, `zirkel_name_theme`) mark it explicitly. **A third consumer doing the same thing is the signal to extract real JSON-mode support into `LlmClient`** — provider-by-provider work, but the right shape once there are multiple real consumers. Until then, the synthetic-tool channel is good enough for two Zirkel call sites, and adding generic JSON mode to LlmClient preemptively would shape that surface around an uncommitted second-consumer boundary. The `synthetic_tool.rs` module-doc spells this out so future readers don't reach for it casually.

## Ollama embedding (Path C from yesterday's pre-checks)

Zirkel-internal helper hitting `<ollama>/api/embed` through the policed `EgressClient` directly. Not abstracted into `wirken-agent` — YAGNI on cross-crate abstraction until a second consumer needs embeddings. If Lyrik or a future skill ever does, the right shape becomes a small `EmbeddingClient` struct in the agent crate at that point.

The aggregator skill's `egress.domains` adds `127.0.0.1` with a one-line comment in SKILL.md explaining *Ollama embedding endpoint*, not generic local-network exception. The bypass invariant is preserved — adding an allowed host expands what's allowed, not how enforcement works.

## HDBSCAN clustering (`hdbscan` crate v0.12)

Pure-Rust HDBSCAN. Defaults `min_cluster_size = 2`, `min_samples = 1` per the design doc. Output: cluster labels (`Cluster(n)`) and noise (`Noise`); the orchestrator's "ungrouped" fallback handles the all-noise case by leaving `cluster_id` NULL on every candidate.

One thing worth noting: HDBSCAN's density-based algorithm needs *contrast* between regions to identify any cluster as non-noise. A single tightly-packed group of N points yields all-noise regardless of N. The `cluster.rs` module-doc has a paragraph on this so the empirical surprise is documented.

## Two-axis scoring, dual columns

`candidates` table now carries both:
- `keyword_match_score INTEGER` — count of distinct keyword matches (Scope C-foundation)
- `llm_relevance_score REAL` — 0–100 LLM rating (this slice)

Plus `llm_why_surfaced TEXT` for the rationale. Both columns coexist; downstream queries (digest threshold, librarian retrieval) can filter on either or both.

## New audit event variant: `CandidateLlmScored`

The keyword pass and the LLM pass each emit their own event. Two-event split keeps each pass independently auditable — a failed LLM pass leaves the keyword event in the chain rather than orphaning the candidate. New variant fields: `run_id`, `candidate_id`, `llm_relevance_score`, `matched_keyword`, `why_surfaced`.

## Pipeline order

```
fetch → dedup → keyword screen → write candidates [+ CandidateScored audit]
        ↓
LLM scoring pass: per-candidate score_candidate() → UPDATE row [+ CandidateLlmScored audit]
        ↓
embed all kept candidates → cluster → group by cluster id
        ↓
per cluster: name_theme() → INSERT theme [+ ThemeNamed audit] → UPDATE candidates.cluster_id
```

Per-candidate LLM failures land in `summary.llm_score_failures`; theme-stage failures (embedding HTTP error, cluster crate failure, individual theme-naming failure) land in `summary.theme_stage_failures`. The run completes regardless. Egress denial for the embedding endpoint is a structural failure (handled the same way as any source's egress denial in C-foundation).

## Tests

- `synthetic_tool`: tool-def shape verification + serde round-trip for both args types. 4 tests.
- `embedding`: single + batch + empty-input + shape-mismatch + egress-denial. 5 tests.
- `cluster`: two clear clusters, empty input, single point, all-noise from high `min_cluster_size`, group-by-cluster-drops-noise. 5 tests.
- `llm_score`: prompt-construction tests (the LLM call itself is exercised end-to-end). 2 tests.
- `themes`: prompt-construction + empty-cluster typed error. 2 tests.
- `orchestrator`:
  - `llm_scoring_pass_writes_relevance_and_emits_event` — single-item fixture, mocked LLM, asserts `llm_relevance_score` and `llm_why_surfaced` on the row + `CandidateLlmScored` event in chain.
  - `clustering_and_theme_naming_e2e` — 6-item fixture, two well-separated clusters of 3, mocked embed + LLM, asserts `themes_named = 2`, all 6 candidates have non-NULL `cluster_id`, `ThemeNamed` events in chain.

48 zirkel tests; 658 across the workspace, all green. `cargo fmt --check` clean. `cargo clippy --workspace --tests -- -D warnings` clean.

## Bypass invariant unchanged

The orchestrator constructs an `EgressClient` from the aggregator skill's `permissions.egress` allow-set; egress denials short-circuit at the outer layer and never enter the rate-limit budget. Embedding requests go through that same client. The LLM client uses its own `reqwest::Client` (separate transport — bypass invariant for LLM is via the inference-allow provider gate, not the egress allowlist). `127.0.0.1` is now in the egress allowlist with explicit comment naming why; the pattern (named hosts with explicit reason) is what every future allowlist addition should follow.

## What ships next (C-Signal)

- Render the daily digest from candidates + themes
- Push to Signal via the existing channel adapter
- Interactive Keep/Skip (buttons if Signal supports them; numbered reply parsing as fallback)
- `CandidateKept` / `CandidateSkipped` (via=user) / `DigestPushed` audit events