### PR TITLE
zirkel scope c-signal: digest push, keep/skip interceptor, bind CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6543,8 +6543,10 @@ dependencies = [
  "console",
  "dialoguer",
  "ed25519-dalek",
+ "libc",
  "openssl",
  "reqwest 0.13.2",
+ "rusqlite",
  "rustls 0.23.38",
  "serde",
  "serde_json",
@@ -6696,6 +6698,7 @@ dependencies = [
  "uuid",
  "wirken-agent",
  "wirken-audit",
+ "wirken-ipc",
  "wirken-skill-store",
 ]
 

--- a/crates/agent/src/factory.rs
+++ b/crates/agent/src/factory.rs
@@ -144,6 +144,16 @@ pub struct AgentStaticConfig {
     /// `provider.json` (or per-agent config in a future pass). The
     /// factory clones this into every waked Agent's `ToolRegistry`.
     pub sandbox: crate::sandbox::SandboxConfig,
+    /// Additional [`InboundInterceptor`]s registered on every waked
+    /// Agent for this agent_id, in registration order, after the
+    /// built-in slash interceptor. The Arc is shared across wakes —
+    /// interceptors hold their own internal state (SQLite handle,
+    /// etc.) and are `Send + Sync`. Empty by default; the gateway's
+    /// startup wire-up populates this from `wirken_zirkel`'s
+    /// bindings table when zirkel is configured.
+    ///
+    /// [`InboundInterceptor`]: crate::inbound_interceptor::InboundInterceptor
+    pub extra_interceptors: Vec<Arc<dyn crate::inbound_interceptor::InboundInterceptor>>,
 }
 
 /// Cache mode resolved at factory construction time. Tests pass it
@@ -330,6 +340,9 @@ impl AgentFactory {
         // the gateway config store.
         agent.attach_factory(self.weak());
         agent.attach_subagent_ceilings(cfg.allowed_subagents.clone());
+        for interceptor in &cfg.extra_interceptors {
+            agent.attach_interceptor(interceptor.clone());
+        }
 
         let arc = Arc::new(AsyncMutex::new(agent));
 

--- a/crates/agent/src/inbound_interceptor.rs
+++ b/crates/agent/src/inbound_interceptor.rs
@@ -1,0 +1,203 @@
+//! Pre-LLM inbound message interceptors.
+//!
+//! When a user message arrives at [`crate::runtime::Agent::process_message`],
+//! the agent runs it through a chain of registered interceptors before
+//! the LLM ever sees it. Each interceptor can:
+//!
+//! - **Pass** — the message isn't relevant to this interceptor; the chain
+//!   continues to the next one.
+//! - **Rewrite** — transform the message and pass it down the chain (the
+//!   rewritten form is what later interceptors and the LLM see).
+//! - **Handle** — fully handle the message, returning a reply text and
+//!   audit events. The LLM is not invoked for this turn; the agent's
+//!   outbound is the interceptor's reply.
+//!
+//! ## Why this exists
+//!
+//! The slash-command surface from #79 was the first consumer
+//! (`Agent::preprocess_slash_invocation` → `crate::slash::parse`).
+//! Zirkel's keep/skip reply parser is the second. The refactor from
+//! a hardcoded slash-only call to a registered chain happens **because
+//! Zirkel needs it** — not as speculative cleanup. A second real
+//! consumer earns the abstraction; one consumer doesn't.
+//!
+//! ## First-match-wins semantics
+//!
+//! The chain stops at the first non-`Pass` result. Interceptors
+//! should be designed to be orthogonal: slash invocations look
+//! nothing like keep/skip replies. Order doesn't matter for
+//! correctness, but registration order is the tiebreaker if two
+//! interceptors ever match the same shape.
+
+use crate::error::AgentError;
+use crate::skill::Skill;
+use wirken_audit::SessionEvent;
+
+/// Result of running one interceptor over a message.
+#[derive(Debug)]
+pub enum InterceptResult {
+    /// Not for me; pass through unchanged. Chain continues.
+    Pass,
+    /// Rewrote the message; chain continues with the rewritten form,
+    /// and the rewritten form is what the LLM ultimately sees.
+    Rewrite(String),
+    /// Fully handled. The agent emits `reply` to the channel and
+    /// records `audit_events` to the session log; the LLM is **not**
+    /// invoked for this turn.
+    Handle {
+        reply: String,
+        audit_events: Vec<SessionEvent>,
+    },
+    /// Refuse the message — surface to the channel as an error.
+    /// Used by slash for unknown skill names; could be used by
+    /// keep/skip for out-of-range numbers.
+    Reject(AgentError),
+}
+
+/// Context passed to every interceptor. Contains the data interceptors
+/// commonly need without coupling them to the full agent state.
+pub struct InterceptorContext<'a> {
+    pub agent_id: &'a str,
+    pub skills: &'a [Skill],
+}
+
+/// One pre-LLM interceptor. Implementors live in their own crates
+/// (slash in `wirken-agent`, keep/skip in `wirken-zirkel`) and
+/// register with the agent at startup.
+///
+/// Synchronous by design — the trait stays light. Implementors that
+/// need I/O (Zirkel's keep/skip touches SQLite) do it inside the
+/// call without holding `.await` across operations.
+pub trait InboundInterceptor: Send + Sync {
+    /// A short identifier for tracing / debugging. Not load-bearing
+    /// for routing.
+    fn name(&self) -> &'static str;
+
+    fn intercept(&self, message: &str, ctx: &InterceptorContext<'_>) -> InterceptResult;
+}
+
+/// Run an inbound message through every interceptor in order, stopping
+/// at the first non-`Pass` result. Helper for [`Agent::process_message_inner`]
+/// and [`Agent::process_message_stream`] — the two callsites that need
+/// to apply the chain identically.
+pub fn run_chain(
+    interceptors: &[Box<dyn InboundInterceptor>],
+    message: &str,
+    ctx: &InterceptorContext<'_>,
+) -> InterceptResult {
+    let mut current = message.to_string();
+    for interceptor in interceptors {
+        match interceptor.intercept(&current, ctx) {
+            InterceptResult::Pass => continue,
+            InterceptResult::Rewrite(s) => current = s,
+            InterceptResult::Handle {
+                reply,
+                audit_events,
+            } => {
+                return InterceptResult::Handle {
+                    reply,
+                    audit_events,
+                };
+            }
+            InterceptResult::Reject(e) => return InterceptResult::Reject(e),
+        }
+    }
+    if current == message {
+        InterceptResult::Pass
+    } else {
+        InterceptResult::Rewrite(current)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct PassThrough;
+    impl InboundInterceptor for PassThrough {
+        fn name(&self) -> &'static str {
+            "pass"
+        }
+        fn intercept(&self, _: &str, _: &InterceptorContext<'_>) -> InterceptResult {
+            InterceptResult::Pass
+        }
+    }
+
+    struct AlwaysRewrite(&'static str);
+    impl InboundInterceptor for AlwaysRewrite {
+        fn name(&self) -> &'static str {
+            "rewrite"
+        }
+        fn intercept(&self, msg: &str, _: &InterceptorContext<'_>) -> InterceptResult {
+            InterceptResult::Rewrite(format!("{msg} {}", self.0))
+        }
+    }
+
+    struct AlwaysHandle(&'static str);
+    impl InboundInterceptor for AlwaysHandle {
+        fn name(&self) -> &'static str {
+            "handle"
+        }
+        fn intercept(&self, _: &str, _: &InterceptorContext<'_>) -> InterceptResult {
+            InterceptResult::Handle {
+                reply: self.0.to_string(),
+                audit_events: vec![],
+            }
+        }
+    }
+
+    fn ctx<'a>() -> InterceptorContext<'a> {
+        InterceptorContext {
+            agent_id: "test",
+            skills: &[],
+        }
+    }
+
+    #[test]
+    fn empty_chain_returns_pass() {
+        let r = run_chain(&[], "hello", &ctx());
+        assert!(matches!(r, InterceptResult::Pass));
+    }
+
+    #[test]
+    fn all_pass_returns_pass() {
+        let chain: Vec<Box<dyn InboundInterceptor>> =
+            vec![Box::new(PassThrough), Box::new(PassThrough)];
+        let r = run_chain(&chain, "hello", &ctx());
+        assert!(matches!(r, InterceptResult::Pass));
+    }
+
+    #[test]
+    fn rewrites_compose_in_order() {
+        let chain: Vec<Box<dyn InboundInterceptor>> = vec![
+            Box::new(AlwaysRewrite("alpha")),
+            Box::new(AlwaysRewrite("beta")),
+        ];
+        match run_chain(&chain, "start", &ctx()) {
+            InterceptResult::Rewrite(s) => assert_eq!(s, "start alpha beta"),
+            other => panic!("expected Rewrite, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn handle_short_circuits_chain() {
+        let chain: Vec<Box<dyn InboundInterceptor>> = vec![
+            Box::new(AlwaysHandle("done")),
+            Box::new(AlwaysRewrite("never-runs")),
+        ];
+        match run_chain(&chain, "hello", &ctx()) {
+            InterceptResult::Handle { reply, .. } => assert_eq!(reply, "done"),
+            other => panic!("expected Handle, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn pass_then_rewrite_yields_rewrite() {
+        let chain: Vec<Box<dyn InboundInterceptor>> =
+            vec![Box::new(PassThrough), Box::new(AlwaysRewrite("end"))];
+        match run_chain(&chain, "hi", &ctx()) {
+            InterceptResult::Rewrite(s) => assert_eq!(s, "hi end"),
+            other => panic!("expected Rewrite, got {other:?}"),
+        }
+    }
+}

--- a/crates/agent/src/inbound_interceptor.rs
+++ b/crates/agent/src/inbound_interceptor.rs
@@ -81,7 +81,7 @@ pub trait InboundInterceptor: Send + Sync {
 /// and [`Agent::process_message_stream`] — the two callsites that need
 /// to apply the chain identically.
 pub fn run_chain(
-    interceptors: &[Box<dyn InboundInterceptor>],
+    interceptors: &[std::sync::Arc<dyn InboundInterceptor>],
     message: &str,
     ctx: &InterceptorContext<'_>,
 ) -> InterceptResult {
@@ -161,17 +161,19 @@ mod tests {
 
     #[test]
     fn all_pass_returns_pass() {
-        let chain: Vec<Box<dyn InboundInterceptor>> =
-            vec![Box::new(PassThrough), Box::new(PassThrough)];
+        use std::sync::Arc;
+        let chain: Vec<Arc<dyn InboundInterceptor>> =
+            vec![Arc::new(PassThrough), Arc::new(PassThrough)];
         let r = run_chain(&chain, "hello", &ctx());
         assert!(matches!(r, InterceptResult::Pass));
     }
 
     #[test]
     fn rewrites_compose_in_order() {
-        let chain: Vec<Box<dyn InboundInterceptor>> = vec![
-            Box::new(AlwaysRewrite("alpha")),
-            Box::new(AlwaysRewrite("beta")),
+        use std::sync::Arc;
+        let chain: Vec<Arc<dyn InboundInterceptor>> = vec![
+            Arc::new(AlwaysRewrite("alpha")),
+            Arc::new(AlwaysRewrite("beta")),
         ];
         match run_chain(&chain, "start", &ctx()) {
             InterceptResult::Rewrite(s) => assert_eq!(s, "start alpha beta"),
@@ -181,9 +183,10 @@ mod tests {
 
     #[test]
     fn handle_short_circuits_chain() {
-        let chain: Vec<Box<dyn InboundInterceptor>> = vec![
-            Box::new(AlwaysHandle("done")),
-            Box::new(AlwaysRewrite("never-runs")),
+        use std::sync::Arc;
+        let chain: Vec<Arc<dyn InboundInterceptor>> = vec![
+            Arc::new(AlwaysHandle("done")),
+            Arc::new(AlwaysRewrite("never-runs")),
         ];
         match run_chain(&chain, "hello", &ctx()) {
             InterceptResult::Handle { reply, .. } => assert_eq!(reply, "done"),
@@ -193,8 +196,9 @@ mod tests {
 
     #[test]
     fn pass_then_rewrite_yields_rewrite() {
-        let chain: Vec<Box<dyn InboundInterceptor>> =
-            vec![Box::new(PassThrough), Box::new(AlwaysRewrite("end"))];
+        use std::sync::Arc;
+        let chain: Vec<Arc<dyn InboundInterceptor>> =
+            vec![Arc::new(PassThrough), Arc::new(AlwaysRewrite("end"))];
         match run_chain(&chain, "hi", &ctx()) {
             InterceptResult::Rewrite(s) => assert_eq!(s, "hi end"),
             other => panic!("expected Rewrite, got {other:?}"),

--- a/crates/agent/src/lib.rs
+++ b/crates/agent/src/lib.rs
@@ -7,6 +7,7 @@ pub mod egress;
 pub mod error;
 pub mod factory;
 pub mod identity;
+pub mod inbound_interceptor;
 pub mod llm;
 pub mod llm_stream;
 pub mod mcp;

--- a/crates/agent/src/runtime.rs
+++ b/crates/agent/src/runtime.rs
@@ -32,6 +32,18 @@ enum FsAxis {
     Write,
 }
 
+/// Returned by [`Agent::apply_interceptors`]. Either the chain wants
+/// processing to continue with a (possibly rewritten) message, or an
+/// interceptor handled the message in full — the LLM is skipped and
+/// the agent's outbound is the interceptor's reply.
+enum InterceptorOutcome {
+    Continue(String),
+    Handled {
+        reply: String,
+        audit_events: Vec<wirken_audit::SessionEvent>,
+    },
+}
+
 /// Item 6 slice 1 — hard cap on the depth of `spawn_subagent` calls,
 /// independent of any per-ceiling configuration. Even with badly
 /// configured ceilings the harness refuses to nest deeper than this.
@@ -173,6 +185,12 @@ pub struct Agent {
     /// (transitional during the migration window). Enforcement is
     /// per-agent, not per-skill — see gebruder/wirken#76.
     effective_permissions: crate::skill_perms::EffectiveProfile,
+    /// Pre-LLM inbound interceptors. The slash-command interceptor
+    /// (#79) is registered by default; additional interceptors plug
+    /// in via [`Self::attach_interceptor`]. The chain runs at the
+    /// top of every `process_message` / `process_message_stream`
+    /// invocation; first non-`Pass` result wins.
+    interceptors: Vec<Box<dyn crate::inbound_interceptor::InboundInterceptor>>,
 }
 
 impl Agent {
@@ -245,6 +263,7 @@ impl Agent {
             auto_deny_above_tier: None,
             restrict_tools: None,
             effective_permissions: crate::skill_perms::EffectiveProfile::Legacy,
+            interceptors: vec![Box::new(crate::slash::SlashInterceptor)],
         })
     }
 
@@ -323,6 +342,7 @@ impl Agent {
             auto_deny_above_tier: None,
             restrict_tools: None,
             effective_permissions: crate::skill_perms::EffectiveProfile::Legacy,
+            interceptors: vec![Box::new(crate::slash::SlashInterceptor)],
         })
     }
 
@@ -575,22 +595,46 @@ impl Agent {
         Some((axis, absolute))
     }
 
-    /// #79: rewrite a slash-invoked user message so the LLM sees the
-    /// invoked skill's body before the user's actual request. Returns
-    /// the original message unchanged when no slash prefix is present.
-    /// Returns `Err(AgentError::UnknownSlashSkill)` when the prefix
-    /// names a skill that isn't loaded — the channel surfaces this
-    /// back to the user so they can correct the typo.
-    fn preprocess_slash_invocation(&self, message: &str) -> Result<String, AgentError> {
-        match crate::slash::parse(message, &self.skills) {
-            crate::slash::SlashResult::None => Ok(message.to_string()),
-            crate::slash::SlashResult::Invoked { skill, remainder } => {
-                Ok(crate::slash::rewrite_with_skill_body(skill, &remainder))
+    /// Register a pre-LLM inbound interceptor. Runs after the slash
+    /// interceptor that's registered by default; for keep/skip-style
+    /// skill-specific replies (Zirkel's case), the consumer
+    /// constructs the interceptor with whatever state it needs (a
+    /// SkillStore handle, etc.) and registers it on the agent at
+    /// startup. Order matters only when two interceptors could match
+    /// the same shape — registration order is the tiebreaker.
+    pub fn attach_interceptor(
+        &mut self,
+        interceptor: Box<dyn crate::inbound_interceptor::InboundInterceptor>,
+    ) {
+        self.interceptors.push(interceptor);
+    }
+
+    /// Apply the interceptor chain to an inbound message. Returns
+    /// either the (possibly rewritten) message to continue processing
+    /// with, or an early `ProcessResult` if an interceptor fully
+    /// handled the message. Callers (`process_message_inner` and
+    /// `process_message_stream`) propagate the early result to the
+    /// caller without invoking the LLM.
+    fn apply_interceptors(&self, message: &str) -> Result<InterceptorOutcome, AgentError> {
+        let ctx = crate::inbound_interceptor::InterceptorContext {
+            agent_id: &self.id,
+            skills: &self.skills,
+        };
+        match crate::inbound_interceptor::run_chain(&self.interceptors, message, &ctx) {
+            crate::inbound_interceptor::InterceptResult::Pass => {
+                Ok(InterceptorOutcome::Continue(message.to_string()))
             }
-            crate::slash::SlashResult::UnknownSkill { name } => {
-                let known: Vec<String> = self.skills.iter().map(|s| s.name.clone()).collect();
-                Err(AgentError::UnknownSlashSkill { name, known })
+            crate::inbound_interceptor::InterceptResult::Rewrite(s) => {
+                Ok(InterceptorOutcome::Continue(s))
             }
+            crate::inbound_interceptor::InterceptResult::Handle {
+                reply,
+                audit_events,
+            } => Ok(InterceptorOutcome::Handled {
+                reply,
+                audit_events,
+            }),
+            crate::inbound_interceptor::InterceptResult::Reject(e) => Err(e),
         }
     }
 
@@ -1072,11 +1116,42 @@ impl Agent {
         // exact conversation prefix that was hashed into LlmRequest.
         self.maybe_log_system_prompt()?;
 
-        // #79: detect `/<skill-name>` slash invocation and inline the
-        // named skill's body so the LLM has its instructions for this
-        // turn even though the skill is excluded from the auto-pickable
-        // system prompt.
-        let user_message = self.preprocess_slash_invocation(user_message)?;
+        // Run pre-LLM interceptor chain (slash, Zirkel keep/skip,
+        // future skill-specific). Three outcomes:
+        //   - Continue(msg): proceed to LLM with msg.
+        //   - Handled: interceptor fully replied; emit its audit events
+        //     and return without an LLM round-trip.
+        //   - Err: an interceptor rejected the message (e.g. unknown
+        //     slash skill). Surface to the channel.
+        let user_message = match self.apply_interceptors(user_message)? {
+            InterceptorOutcome::Continue(s) => s,
+            InterceptorOutcome::Handled {
+                reply,
+                audit_events,
+            } => {
+                self.current_trigger = Some(reply.clone());
+                self.log_event(
+                    TrustLevel::User,
+                    SessionEvent::UserMessage {
+                        content: user_message.to_string(),
+                        inbound_id: Some(inbound_id),
+                    },
+                )?;
+                for event in audit_events {
+                    self.log_event(TrustLevel::System, event)?;
+                }
+                self.log_event(
+                    TrustLevel::System,
+                    SessionEvent::AssistantMessage {
+                        content: reply.clone(),
+                    },
+                )?;
+                return Ok(ProcessResult {
+                    response: reply,
+                    denials: Vec::new(),
+                });
+            }
+        };
         self.current_trigger = Some(user_message.clone());
         self.conversation.add_user_message(&user_message);
         self.log_event(
@@ -1315,10 +1390,42 @@ impl Agent {
         // Item 10 follow-up — see process_message_inner.
         self.maybe_log_system_prompt()?;
 
-        // #79: same slash-invocation pre-processing as the non-streaming
-        // path. Done before adding to the conversation so the recorded
-        // user message reflects what the LLM actually saw.
-        let user_message = self.preprocess_slash_invocation(user_message)?;
+        // Run pre-LLM interceptor chain. Same shape as
+        // `process_message_inner`. Stream path returns `Done` to the
+        // client without further LLM streaming when an interceptor
+        // handles the message.
+        let user_message = match self.apply_interceptors(user_message)? {
+            InterceptorOutcome::Continue(s) => s,
+            InterceptorOutcome::Handled {
+                reply,
+                audit_events,
+            } => {
+                self.current_trigger = Some(reply.clone());
+                self.log_event(
+                    TrustLevel::User,
+                    SessionEvent::UserMessage {
+                        content: user_message.to_string(),
+                        inbound_id: Some(inbound_id),
+                    },
+                )?;
+                for event in audit_events {
+                    self.log_event(TrustLevel::System, event)?;
+                }
+                self.log_event(
+                    TrustLevel::System,
+                    SessionEvent::AssistantMessage {
+                        content: reply.clone(),
+                    },
+                )?;
+                let _ = tx
+                    .send(StreamEvent::Done(LlmResponse::Text(reply.clone())))
+                    .await;
+                return Ok(ProcessResult {
+                    response: reply,
+                    denials: Vec::new(),
+                });
+            }
+        };
         self.current_trigger = Some(user_message.clone());
         self.conversation.add_user_message(&user_message);
         self.log_event(

--- a/crates/agent/src/runtime.rs
+++ b/crates/agent/src/runtime.rs
@@ -190,7 +190,7 @@ pub struct Agent {
     /// in via [`Self::attach_interceptor`]. The chain runs at the
     /// top of every `process_message` / `process_message_stream`
     /// invocation; first non-`Pass` result wins.
-    interceptors: Vec<Box<dyn crate::inbound_interceptor::InboundInterceptor>>,
+    interceptors: Vec<Arc<dyn crate::inbound_interceptor::InboundInterceptor>>,
 }
 
 impl Agent {
@@ -263,7 +263,7 @@ impl Agent {
             auto_deny_above_tier: None,
             restrict_tools: None,
             effective_permissions: crate::skill_perms::EffectiveProfile::Legacy,
-            interceptors: vec![Box::new(crate::slash::SlashInterceptor)],
+            interceptors: vec![Arc::new(crate::slash::SlashInterceptor)],
         })
     }
 
@@ -342,7 +342,7 @@ impl Agent {
             auto_deny_above_tier: None,
             restrict_tools: None,
             effective_permissions: crate::skill_perms::EffectiveProfile::Legacy,
-            interceptors: vec![Box::new(crate::slash::SlashInterceptor)],
+            interceptors: vec![Arc::new(crate::slash::SlashInterceptor)],
         })
     }
 
@@ -604,7 +604,7 @@ impl Agent {
     /// the same shape — registration order is the tiebreaker.
     pub fn attach_interceptor(
         &mut self,
-        interceptor: Box<dyn crate::inbound_interceptor::InboundInterceptor>,
+        interceptor: Arc<dyn crate::inbound_interceptor::InboundInterceptor>,
     ) {
         self.interceptors.push(interceptor);
     }

--- a/crates/agent/src/slash.rs
+++ b/crates/agent/src/slash.rs
@@ -16,7 +16,33 @@
 //! interpret `use lyrik to ...` as explicit invocation. Fuzzy invocation
 //! turns "explicit" into "unpredictable"; the slash prefix is the contract.
 
+use crate::error::AgentError;
+use crate::inbound_interceptor::{InboundInterceptor, InterceptResult, InterceptorContext};
 use crate::skill::Skill;
+
+/// [`InboundInterceptor`] that handles `/<skill-name> ...` invocations.
+/// First registered interceptor on the agent — others (e.g. Zirkel's
+/// keep/skip) plug in alongside.
+pub struct SlashInterceptor;
+
+impl InboundInterceptor for SlashInterceptor {
+    fn name(&self) -> &'static str {
+        "slash"
+    }
+
+    fn intercept(&self, message: &str, ctx: &InterceptorContext<'_>) -> InterceptResult {
+        match parse(message, ctx.skills) {
+            SlashResult::None => InterceptResult::Pass,
+            SlashResult::Invoked { skill, remainder } => {
+                InterceptResult::Rewrite(rewrite_with_skill_body(skill, &remainder))
+            }
+            SlashResult::UnknownSkill { name } => {
+                let known: Vec<String> = ctx.skills.iter().map(|s| s.name.clone()).collect();
+                InterceptResult::Reject(AgentError::UnknownSlashSkill { name, known })
+            }
+        }
+    }
+}
 
 /// Result of running [`parse`] on a user message.
 #[derive(Debug)]

--- a/crates/agent/src/tests.rs
+++ b/crates/agent/src/tests.rs
@@ -1233,6 +1233,7 @@ mod wake {
                 identity: None,
                 allowed_subagents: Default::default(),
                 sandbox: Default::default(),
+                extra_interceptors: vec![],
             },
         );
         (AgentFactory::new(configs, log, None), tmp)
@@ -1568,6 +1569,7 @@ mod wake {
                 identity: None,
                 allowed_subagents: Default::default(),
                 sandbox: Default::default(),
+                extra_interceptors: vec![],
             },
         );
         let factory = AgentFactory::with_options(configs, log, None, None, CacheMode::Drop, 64);
@@ -1631,6 +1633,7 @@ mod subagent {
                 identity: None,
                 allowed_subagents: parent_ceilings,
                 sandbox: Default::default(),
+                extra_interceptors: vec![],
             },
         );
         configs.insert(
@@ -1647,6 +1650,7 @@ mod subagent {
                 identity: None,
                 allowed_subagents: BTreeMap::new(),
                 sandbox: Default::default(),
+                extra_interceptors: vec![],
             },
         );
         (AgentFactory::new(configs, log, None), tmp)
@@ -4598,6 +4602,7 @@ mod per_channel_llm_override {
                 identity: None,
                 allowed_subagents: Default::default(),
                 sandbox: Default::default(),
+                extra_interceptors: vec![],
             },
         );
         let factory = AgentFactory::with_options(configs, log, None, None, CacheMode::Drop, 4);
@@ -4735,6 +4740,7 @@ mod per_channel_llm_override {
                 identity: None,
                 allowed_subagents: Default::default(),
                 sandbox: Default::default(),
+                extra_interceptors: vec![],
             },
         );
         let factory =
@@ -4887,6 +4893,7 @@ mod org_tool_policy {
                 identity: None,
                 allowed_subagents: Default::default(),
                 sandbox: Default::default(),
+                extra_interceptors: vec![],
             },
         );
         let factory =

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -43,6 +43,8 @@ tracing-subscriber = { workspace = true }
 anyhow = { workspace = true }
 chrono = { workspace = true }
 openssl = { workspace = true }
+libc = "0.2"
+rusqlite = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -13,8 +13,10 @@ use wirken_audit::{AuditEvent, AuditWriter, SiemConfig, SiemTarget};
 use wirken_gateway::adapter_registry::AdapterRegistry;
 use wirken_gateway::agent_config::AgentConfigStore;
 use wirken_gateway::injection_detect::InjectionDetector;
+use wirken_gateway::outbound_dispatcher::OutboundDispatcher;
 use wirken_gateway::router::{RouteBinding, Router};
 use wirken_gateway::session::SessionStore;
+use wirken_ipc::orchestrator::{OrchestratorPushRequest, OrchestratorPushResponse};
 use wirken_ipc::transport::{FrameReader, FrameWriter, split_stream};
 use wirken_ipc::wirken_capnp::frame;
 use wirken_ipc::{AuthenticatedChannel, perform_gateway_handshake};
@@ -284,6 +286,7 @@ pub async fn run(port: Option<u16>) -> Result<()> {
                     identity,
                     allowed_subagents: agent_cfg.allowed_subagents.clone(),
                     sandbox: super::load_sandbox_config(&cfg.data_dir),
+                    extra_interceptors: vec![],
                 },
             );
         }
@@ -369,6 +372,7 @@ pub async fn run(port: Option<u16>) -> Result<()> {
                 identity: default_identity,
                 allowed_subagents: Default::default(),
                 sandbox: super::load_sandbox_config(&cfg.data_dir),
+                extra_interceptors: vec![],
             },
         );
     }
@@ -581,6 +585,53 @@ pub async fn run(port: Option<u16>) -> Result<()> {
         };
         println!("  Org tool policy: allowed={allowed}; blocked={blocked}");
     }
+
+    // --- Wire zirkel keep/skip interceptors -------------------------
+    //
+    // Read zirkel's bindings table once at startup and attach a
+    // KeepSkipInterceptor to each bound agent. Live re-bind doesn't
+    // reach already-running agents — `wirken zirkel bind` warns
+    // when this daemon is up. This loop runs before the factory is
+    // built so the interceptors land in the agent's
+    // extra_interceptors list.
+    let zirkel_db = cfg.data_dir.join("zirkel").join("aggregator.db");
+    if zirkel_db.exists() {
+        match rusqlite::Connection::open(&zirkel_db) {
+            Ok(zconn) => match wirken_zirkel::binding::list_all(&zconn) {
+                Ok(bindings) => {
+                    for binding in bindings {
+                        let Some(static_cfg) = static_configs.get_mut(&binding.agent_id) else {
+                            tracing::warn!(
+                                "zirkel binding for agent '{}' has no matching agent config; \
+                                 keep/skip interceptor not attached. Run `wirken agents add` or \
+                                 fix the binding with `wirken zirkel bind --agent ...`.",
+                                binding.agent_id,
+                            );
+                            continue;
+                        };
+                        match wirken_zirkel::keep_skip_interceptor::KeepSkipInterceptor::open(
+                            &zirkel_db,
+                        ) {
+                            Ok(interceptor) => {
+                                static_cfg.extra_interceptors.push(Arc::new(interceptor));
+                                println!(
+                                    "  Zirkel: keep/skip on agent '{}' (channel '{}')",
+                                    binding.agent_id, binding.channel
+                                );
+                            }
+                            Err(e) => tracing::warn!(
+                                "open keep/skip interceptor at {}: {e}",
+                                zirkel_db.display()
+                            ),
+                        }
+                    }
+                }
+                Err(e) => tracing::warn!("list zirkel bindings: {e}"),
+            },
+            Err(e) => tracing::warn!("open zirkel db {}: {e}", zirkel_db.display()),
+        }
+    }
+
     let factory = AgentFactory::with_options(
         static_configs,
         session_log.clone(),
@@ -673,6 +724,14 @@ pub async fn run(port: Option<u16>) -> Result<()> {
     // --- Injection detector (shared, stateless) ---
     let detector = Arc::new(InjectionDetector::new());
 
+    // --- Outbound dispatcher (orchestrator push rendezvous) ---
+    //
+    // Holds the live capnp writer for each connected adapter, keyed
+    // by channel. Per-adapter handlers register on auth and
+    // unregister on disconnect; the orchestrator-push listener below
+    // looks up the writer when forwarding a push.
+    let dispatcher = Arc::new(OutboundDispatcher::new());
+
     // --- Accept adapter connections ---
     let accept_registry = registry.clone();
     let accept_factory = factory.clone();
@@ -680,6 +739,7 @@ pub async fn run(port: Option<u16>) -> Result<()> {
     let accept_sessions = sessions.clone();
     let accept_router = router.clone();
     let accept_detector = detector.clone();
+    let accept_dispatcher = dispatcher.clone();
 
     let accept_handle = tokio::spawn(async move {
         loop {
@@ -691,10 +751,12 @@ pub async fn run(port: Option<u16>) -> Result<()> {
                     let sess = accept_sessions.clone();
                     let rtr = accept_router.clone();
                     let det = accept_detector.clone();
+                    let disp = accept_dispatcher.clone();
 
                     tokio::spawn(async move {
                         if let Err(e) =
-                            handle_adapter_connection(stream, reg, fact, au, sess, rtr, det).await
+                            handle_adapter_connection(stream, reg, fact, au, sess, rtr, det, disp)
+                                .await
                         {
                             tracing::error!("Adapter connection error: {e}");
                         }
@@ -702,6 +764,76 @@ pub async fn run(port: Option<u16>) -> Result<()> {
                 }
                 Err(e) => {
                     tracing::error!("Accept error: {e}");
+                }
+            }
+        }
+    });
+
+    // --- Orchestrator-push listener (Zirkel C-Signal) ---
+    //
+    // This is not an adapter — adapters cross a trust boundary, this
+    // doesn't. Local-only outbound channel: the zirkel CLI process
+    // runs as the same UID that owns this data dir, builds its
+    // daily digest, and pushes via this socket. The gateway forwards
+    // each push to the live adapter writer for the named channel.
+    //
+    // Posture: 0600 file perms is the primary gate; SO_PEERCRED on
+    // accept is defense-in-depth in case the perms are accidentally
+    // permissive. JSON line in, JSON line out — no capnp, no
+    // handshake, no signature. See crates/ipc/src/orchestrator.rs.
+    let orchestrator_socket_path = cfg.socket_dir().join("orchestrator.sock");
+    if orchestrator_socket_path.exists() {
+        let _ = std::fs::remove_file(&orchestrator_socket_path);
+    }
+    let orchestrator_listener = UnixListener::bind(&orchestrator_socket_path).context(format!(
+        "Failed to bind orchestrator UDS at {}",
+        orchestrator_socket_path.display()
+    ))?;
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(
+            &orchestrator_socket_path,
+            std::fs::Permissions::from_mode(0o600),
+        )
+        .context("Failed to chmod orchestrator socket to 0600")?;
+    }
+    println!(
+        "  Orchestrator socket: {}",
+        orchestrator_socket_path.display()
+    );
+
+    let orchestrator_dispatcher = dispatcher.clone();
+    let orchestrator_audit = audit.clone();
+    // SAFETY: `geteuid` is always-safe FFI; documented as never
+    // failing and never invoking user-space callbacks.
+    let orchestrator_uid = unsafe { libc::geteuid() };
+    let orchestrator_handle = tokio::spawn(async move {
+        loop {
+            match orchestrator_listener.accept().await {
+                Ok((stream, _)) => {
+                    let peer_uid = match stream.peer_cred() {
+                        Ok(c) => c.uid(),
+                        Err(e) => {
+                            tracing::warn!("orchestrator: peer_cred unavailable, refusing: {e}");
+                            continue;
+                        }
+                    };
+                    if peer_uid != orchestrator_uid {
+                        tracing::warn!(
+                            "orchestrator: refusing peer uid={peer_uid} (expected {orchestrator_uid})"
+                        );
+                        continue;
+                    }
+                    let disp = orchestrator_dispatcher.clone();
+                    let au = orchestrator_audit.clone();
+                    tokio::spawn(async move {
+                        if let Err(e) = handle_orchestrator_push(stream, disp, au).await {
+                            tracing::error!("orchestrator push handler error: {e}");
+                        }
+                    });
+                }
+                Err(e) => {
+                    tracing::error!("orchestrator accept error: {e}");
                 }
             }
         }
@@ -722,6 +854,7 @@ pub async fn run(port: Option<u16>) -> Result<()> {
     }
     mcp_proxy_handle.abort();
     accept_handle.abort();
+    orchestrator_handle.abort();
     webchat_handle.abort();
     scheduler_handle.abort();
 
@@ -732,12 +865,14 @@ pub async fn run(port: Option<u16>) -> Result<()> {
     // Cleanup sockets
     let _ = std::fs::remove_file(&socket_path);
     let _ = std::fs::remove_file(&mcp_proxy_socket);
+    let _ = std::fs::remove_file(&orchestrator_socket_path);
 
     println!("  Gateway stopped.");
     Ok(())
 }
 
 /// Handle a single adapter connection: handshake, then message loop.
+#[allow(clippy::too_many_arguments)]
 async fn handle_adapter_connection(
     stream: UnixStream,
     registry: Arc<Mutex<AdapterRegistry>>,
@@ -746,6 +881,7 @@ async fn handle_adapter_connection(
     sessions: Arc<Mutex<SessionStore>>,
     router: Arc<Router>,
     detector: Arc<InjectionDetector>,
+    dispatcher: Arc<OutboundDispatcher>,
 ) -> Result<()> {
     let (mut reader, mut writer) = split_stream(stream);
 
@@ -801,6 +937,11 @@ async fn handle_adapter_connection(
 
     let writer = Arc::new(Mutex::new(writer));
 
+    // Register the live writer with the orchestrator-push
+    // dispatcher so zirkel's daily digest (and any other
+    // orchestrator) can find this adapter by channel name.
+    dispatcher.register(authenticated_channel.as_str(), writer.clone());
+
     // Message loop
     let result = message_loop(
         &adapter_id,
@@ -815,6 +956,7 @@ async fn handle_adapter_connection(
     )
     .await;
 
+    dispatcher.unregister(authenticated_channel.as_str());
     registry.lock().await.set_connected(&adapter_id, false);
     audit
         .log(
@@ -825,6 +967,97 @@ async fn handle_adapter_connection(
 
     tracing::info!("Adapter '{adapter_id}' disconnected");
     result
+}
+
+/// Handle one orchestrator-push connection: read one JSON request,
+/// look up the live adapter writer for the requested channel,
+/// forward as a capnp Outbound frame, write one JSON response.
+///
+/// This handler runs only after `peer_cred()` has confirmed the
+/// peer UID matches the gateway's. No further authentication.
+async fn handle_orchestrator_push(
+    stream: UnixStream,
+    dispatcher: Arc<OutboundDispatcher>,
+    audit: Arc<AuditWriter>,
+) -> Result<()> {
+    use tokio::io::{AsyncBufReadExt, BufReader};
+    let (reader, mut writer) = stream.into_split();
+    let mut br = BufReader::new(reader);
+    let mut line = String::new();
+    let n = br
+        .read_line(&mut line)
+        .await
+        .context("orchestrator: read request")?;
+    if n == 0 {
+        return Ok(());
+    }
+    let req: OrchestratorPushRequest = match serde_json::from_str(line.trim_end()) {
+        Ok(r) => r,
+        Err(e) => {
+            let resp = OrchestratorPushResponse {
+                ok: false,
+                error: Some(format!("invalid request JSON: {e}")),
+            };
+            let _ = write_orchestrator_response(&mut writer, &resp).await;
+            return Ok(());
+        }
+    };
+
+    let resp = match dispatcher.writer_for(&req.channel) {
+        Some(w) => {
+            let mut reply = capnp::message::Builder::new_default();
+            {
+                let fb = reply.init_root::<frame::Builder<'_>>();
+                let mut outbound = fb.init_outbound();
+                outbound.set_conversation_id(&req.conversation_id);
+                outbound.set_text(&req.text);
+                outbound.set_reply_to_id(&req.reply_to_id);
+                outbound.set_metadata("{}");
+            }
+            let mut w = w.lock().await;
+            match w.write_message(&reply).await {
+                Ok(()) => {
+                    let _ = audit
+                        .log(
+                            AuditEvent::new("orchestrator", "message.outbound", &req.text)
+                                .with_channel(&req.channel)
+                                .with_session(&req.conversation_id),
+                        )
+                        .await;
+                    OrchestratorPushResponse {
+                        ok: true,
+                        error: None,
+                    }
+                }
+                Err(e) => OrchestratorPushResponse {
+                    ok: false,
+                    error: Some(format!("write to adapter failed: {e}")),
+                },
+            }
+        }
+        None => OrchestratorPushResponse {
+            ok: false,
+            error: Some(format!("no adapter connected on channel '{}'", req.channel)),
+        },
+    };
+
+    write_orchestrator_response(&mut writer, &resp).await?;
+    Ok(())
+}
+
+async fn write_orchestrator_response(
+    writer: &mut tokio::net::unix::OwnedWriteHalf,
+    resp: &OrchestratorPushResponse,
+) -> Result<()> {
+    use tokio::io::AsyncWriteExt;
+    let mut line = serde_json::to_string(resp).context("serialize push response")?;
+    line.push('\n');
+    writer
+        .write_all(line.as_bytes())
+        .await
+        .context("write push response")?;
+    writer.shutdown().await.ok();
+    Ok(())
 }
 
 /// Main message loop: read inbound from adapter, route to agent, send response back.

--- a/crates/cli/src/commands/session.rs
+++ b/crates/cli/src/commands/session.rs
@@ -267,6 +267,7 @@ pub async fn verify(session_id: &str, strict: bool) -> Result<()> {
             // rather than loading provider.json to keep verify
             // independent of the runtime sandbox selection.
             sandbox: Default::default(),
+            extra_interceptors: vec![],
         },
     );
     let factory =

--- a/crates/cli/src/commands/zirkel.rs
+++ b/crates/cli/src/commands/zirkel.rs
@@ -11,11 +11,20 @@
 use std::sync::Arc;
 
 use anyhow::{Result, anyhow};
+use rusqlite::Connection;
 use wirken_agent::llm::{LlmClient, LlmConfig};
 use wirken_agent::rate_limit::RateLimitConfig;
 use wirken_audit::{SessionLog, SqliteSessionLog};
+use wirken_zirkel::binding::{
+    Binding, load as load_binding_for, load_first as load_binding, record as record_binding,
+    remove as remove_binding,
+};
+use wirken_zirkel::digest::{RenderOptions, load_run as load_digest_run, render as render_digest};
+use wirken_zirkel::digest_log::record_sent;
 use wirken_zirkel::embedding::DEFAULT_EMBEDDING_MODEL;
 use wirken_zirkel::orchestrator::{OrchestratorConfig, run as orchestrator_run};
+use wirken_zirkel::push_client::{PushError, push as push_to_gateway};
+use wirken_zirkel::schema::AGGREGATOR_MIGRATIONS;
 
 /// `wirken zirkel run` — load the installed Zirkel preset, run the
 /// daily fetch + screen pipeline, exit.
@@ -109,8 +118,260 @@ pub async fn run() -> Result<()> {
     if summary.interests_changed {
         println!("  interests changed:   yes (audit event emitted)");
     }
-    println!(
-        "(C-LLM: keyword screen + LLM relevance + clustering + theme naming. Digest push is the next slice.)"
-    );
+
+    // ----- Digest push (C-Signal piece 4) ----------------------------
+    //
+    // If the operator has bound a target via `wirken zirkel bind`,
+    // render the run's candidates and push to the gateway. No
+    // binding = no push (and no warning — this is the legitimate
+    // headless-test-fetch path).
+    //
+    // Push first, record the digest second: a failed push must not
+    // leave a phantom digest_log entry that the keep/skip
+    // interceptor would later resolve against an unsent message.
+    let cfg = super::config();
+    let zirkel_db = data_dir.join("zirkel").join("aggregator.db");
+    if zirkel_db.exists() {
+        let conn = Connection::open(&zirkel_db)
+            .map_err(|e| anyhow!("open zirkel db at {}: {e}", zirkel_db.display()))?;
+        match load_binding(&conn).map_err(|e| anyhow!("load binding: {e}"))? {
+            Some(binding) => {
+                println!();
+                push_digest_for_run(
+                    &cfg.socket_dir().join("orchestrator.sock"),
+                    &zirkel_db,
+                    &summary.run_id,
+                    &binding,
+                )
+                .await?;
+            }
+            None => {
+                println!();
+                println!(
+                    "  (no zirkel binding found; skipping digest push — run `wirken zirkel bind` to enable)"
+                );
+            }
+        }
+    }
     Ok(())
+}
+
+/// `wirken zirkel bind` — record (or replace, with `--force`) the
+/// digest target for `agent_id`.
+pub async fn bind(agent_id: &str, channel: &str, conversation: &str, force: bool) -> Result<()> {
+    let conn = open_zirkel_db()?;
+    let new = Binding {
+        agent_id: agent_id.into(),
+        channel: channel.into(),
+        conversation_id: conversation.into(),
+    };
+
+    match load_binding_for(&conn, agent_id).map_err(|e| anyhow!("load binding: {e}"))? {
+        Some(existing) if existing == new => {
+            println!(
+                "Already bound: agent '{}' → channel '{}' / conversation '{}'. No-op.",
+                existing.agent_id, existing.channel, existing.conversation_id
+            );
+            return Ok(());
+        }
+        Some(existing) if !force => {
+            return Err(anyhow!(
+                "agent '{}' is already bound to channel '{}' / conversation '{}'. \
+                 Re-run with --force to replace.",
+                existing.agent_id,
+                existing.channel,
+                existing.conversation_id,
+            ));
+        }
+        _ => {}
+    }
+
+    record_binding(&conn, &new).map_err(|e| anyhow!("record binding: {e}"))?;
+    println!(
+        "Bound: agent '{}' → channel '{}' / conversation '{}'.",
+        new.agent_id, new.channel, new.conversation_id
+    );
+
+    // Live-rebind detection: the keep/skip interceptor is attached
+    // to the agent at daemon startup (when `wirken run` builds its
+    // factory). A bind written while the daemon is up does not
+    // retroactively reach already-running agents — the interceptor
+    // is part of the agent's construction, not a hot-pluggable
+    // resource. Detecting the gateway socket is a best-effort
+    // signal that a daemon is running on this data dir.
+    let cfg = super::config();
+    let gateway_socket = cfg.socket_dir().join("gateway.sock");
+    if gateway_socket.exists() {
+        println!();
+        println!(
+            "Note: `wirken run` is currently up. Restart it for the new binding to take effect — \
+             the keep/skip interceptor is attached at agent startup."
+        );
+    }
+    Ok(())
+}
+
+/// `wirken zirkel unbind` — remove the binding for `agent_id`.
+pub async fn unbind(agent_id: &str) -> Result<()> {
+    let conn = open_zirkel_db()?;
+    let existing = load_binding_for(&conn, agent_id).map_err(|e| anyhow!("load binding: {e}"))?;
+    remove_binding(&conn, agent_id).map_err(|e| anyhow!("remove binding: {e}"))?;
+    match existing {
+        Some(b) => println!(
+            "Unbound: agent '{}' (was channel '{}' / conversation '{}').",
+            b.agent_id, b.channel, b.conversation_id
+        ),
+        None => println!("Agent '{agent_id}' had no binding; no-op."),
+    }
+    Ok(())
+}
+
+/// `wirken zirkel status` — print the current binding (if any).
+pub async fn status() -> Result<()> {
+    let zirkel_db = super::data_dir()?.join("zirkel").join("aggregator.db");
+    if !zirkel_db.exists() {
+        println!(
+            "No zirkel state at {} — nothing bound.",
+            zirkel_db.display()
+        );
+        return Ok(());
+    }
+    let conn =
+        Connection::open(&zirkel_db).map_err(|e| anyhow!("open {}: {e}", zirkel_db.display()))?;
+    match wirken_zirkel::binding::list_all(&conn)
+        .map_err(|e| anyhow!("list bindings: {e}"))?
+        .as_slice()
+    {
+        [] => println!("No zirkel digest binding. Run `wirken zirkel bind` to set one."),
+        rows => {
+            println!("Zirkel digest bindings:");
+            for b in rows {
+                println!(
+                    "  agent '{}' → channel '{}' / conversation '{}'",
+                    b.agent_id, b.channel, b.conversation_id
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Open `<data_dir>/zirkel/aggregator.db`, creating the dir and
+/// running migrations idempotently. The bind command may run before
+/// `wirken zirkel run` has ever fired, so it can't assume the
+/// migrations are in place.
+fn open_zirkel_db() -> Result<Connection> {
+    let data_dir = super::data_dir()?;
+    let storage_dir = data_dir.join("zirkel");
+    std::fs::create_dir_all(&storage_dir)
+        .map_err(|e| anyhow!("create {}: {e}", storage_dir.display()))?;
+    let db_path = storage_dir.join("aggregator.db");
+    let mut conn =
+        Connection::open(&db_path).map_err(|e| anyhow!("open {}: {e}", db_path.display()))?;
+    apply_aggregator_migrations(&mut conn)
+        .map_err(|e| anyhow!("apply migrations to {}: {e}", db_path.display()))?;
+    Ok(conn)
+}
+
+/// Idempotent migration application — same shape SkillStore uses.
+/// Replicated here to avoid pulling the SkillStore + permissions
+/// path into the bind command, which has nothing to do with skill
+/// permissions.
+fn apply_aggregator_migrations(conn: &mut Connection) -> rusqlite::Result<()> {
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS _migrations ( \
+            idx INTEGER PRIMARY KEY, \
+            applied_at TEXT NOT NULL DEFAULT (datetime('now')) \
+        )",
+    )?;
+    let already: std::collections::BTreeSet<i64> = {
+        let mut stmt = conn.prepare("SELECT idx FROM _migrations")?;
+        stmt.query_map([], |row| row.get::<_, i64>(0))?
+            .collect::<Result<_, _>>()?
+    };
+    let tx = conn.transaction()?;
+    for (idx, sql) in AGGREGATOR_MIGRATIONS.iter().enumerate() {
+        let idx_i64 = idx as i64;
+        if already.contains(&idx_i64) {
+            continue;
+        }
+        tx.execute_batch(sql)?;
+        tx.execute(
+            "INSERT INTO _migrations (idx) VALUES (?1)",
+            rusqlite::params![idx_i64],
+        )?;
+    }
+    tx.commit()?;
+    Ok(())
+}
+
+async fn push_digest_for_run(
+    orchestrator_socket: &std::path::Path,
+    zirkel_db: &std::path::Path,
+    run_id: &str,
+    binding: &Binding,
+) -> Result<()> {
+    let mut conn = Connection::open(zirkel_db)
+        .map_err(|e| anyhow!("open zirkel db at {}: {e}", zirkel_db.display()))?;
+    let (rows, themes) =
+        load_digest_run(&conn, run_id).map_err(|e| anyhow!("load digest rows: {e}"))?;
+    if rows.is_empty() {
+        println!("  Digest: no candidates this run; nothing to push.");
+        return Ok(());
+    }
+    let opts = RenderOptions {
+        date: Some(chrono::Local::now().format("%Y-%m-%d").to_string()),
+        ..RenderOptions::default()
+    };
+    let rendered =
+        render_digest(&rows, &themes, &opts).map_err(|e| anyhow!("render digest: {e}"))?;
+
+    println!(
+        "  Digest: {} item{} → channel '{}' / conversation '{}'",
+        rendered.ordered_candidate_ids.len(),
+        if rendered.ordered_candidate_ids.len() == 1 {
+            ""
+        } else {
+            "s"
+        },
+        binding.channel,
+        binding.conversation_id,
+    );
+
+    match push_to_gateway(
+        orchestrator_socket,
+        &binding.channel,
+        &binding.conversation_id,
+        &rendered.text,
+    )
+    .await
+    {
+        Ok(()) => {
+            // Record only after the gateway accepted the push.
+            record_sent(
+                &mut conn,
+                run_id,
+                &binding.agent_id,
+                &rendered.ordered_candidate_ids,
+            )
+            .map_err(|e| anyhow!("record digest: {e}"))?;
+            println!("  Digest pushed.");
+            Ok(())
+        }
+        Err(PushError::Connect { path, .. }) => {
+            println!(
+                "  Digest push skipped: gateway socket {} not reachable. Is `wirken run` started?",
+                path
+            );
+            Ok(())
+        }
+        Err(PushError::Rejected(msg)) => {
+            // The gateway is up but couldn't deliver — most often
+            // the bound channel's adapter isn't connected. Surface
+            // but don't fail the whole run.
+            println!("  Digest push rejected by gateway: {msg}");
+            Ok(())
+        }
+        Err(e) => Err(anyhow!("digest push failed: {e}")),
+    }
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -319,6 +319,36 @@ enum ZirkelCommands {
     /// In Scope B this is a stub that loads the installed preset and
     /// reports it's ready. Scope C wires the fetch pipeline.
     Run,
+    /// Bind the daily digest to an outbound channel + conversation.
+    /// `wirken zirkel run` reads the binding and pushes the digest
+    /// after a successful run; `wirken run`'s agent for the bound
+    /// agent_id picks up the keep/skip interceptor at startup.
+    Bind {
+        /// Channel to push digests to (e.g. `signal`, `slack`).
+        /// Must match an adapter registered with `wirken channel add`.
+        #[arg(long)]
+        channel: String,
+        /// Conversation id within that channel (Signal phone number,
+        /// Slack channel id, etc.).
+        #[arg(long)]
+        conversation: String,
+        /// Agent that owns the keep/skip interceptor for this binding.
+        /// Defaults to `default`. Should match a configured agent_id.
+        #[arg(long, default_value = "default")]
+        agent: String,
+        /// Replace an existing binding with a different target.
+        /// Required when the agent is already bound elsewhere; same-
+        /// target re-binds are always a no-op.
+        #[arg(long)]
+        force: bool,
+    },
+    /// Remove the digest binding for an agent.
+    Unbind {
+        #[arg(long, default_value = "default")]
+        agent: String,
+    },
+    /// Print the current digest binding (or a "no binding" message).
+    Status,
 }
 
 #[derive(Subcommand)]
@@ -534,6 +564,14 @@ async fn main() -> Result<()> {
         },
         Commands::Zirkel(cmd) => match cmd {
             ZirkelCommands::Run => commands::zirkel::run().await,
+            ZirkelCommands::Bind {
+                channel,
+                conversation,
+                agent,
+                force,
+            } => commands::zirkel::bind(&agent, &channel, &conversation, force).await,
+            ZirkelCommands::Unbind { agent } => commands::zirkel::unbind(&agent).await,
+            ZirkelCommands::Status => commands::zirkel::status().await,
         },
         Commands::Agents(cmd) => match cmd {
             AgentCommands::Add => commands::agents::add().await,

--- a/crates/gateway/src/lib.rs
+++ b/crates/gateway/src/lib.rs
@@ -5,6 +5,7 @@ pub mod cron;
 pub mod error;
 pub mod injection_detect;
 pub mod org;
+pub mod outbound_dispatcher;
 pub mod permissions;
 pub mod rate_limit;
 pub mod router;

--- a/crates/gateway/src/outbound_dispatcher.rs
+++ b/crates/gateway/src/outbound_dispatcher.rs
@@ -1,0 +1,106 @@
+//! Live-writer registry for orchestrator push.
+//!
+//! The adapter ↔ gateway capnp connection is created in the gateway's
+//! per-adapter handler; the [`FrameWriter`] half lives only inside
+//! that task. Orchestrator-side push (e.g. zirkel daily digest) needs
+//! to find the writer for a given channel and forward an `Outbound`
+//! frame to it. This dispatcher is the rendezvous: the per-adapter
+//! handler `register`s on auth, the orchestrator listener reads the
+//! writer via [`writer_for`], and the per-adapter handler
+//! `unregister`s on disconnect.
+//!
+//! Keyed by channel name. Today's gateway routes 1:1 between adapter
+//! and channel (one Slack adapter, one Telegram adapter, one Signal
+//! adapter), so the channel name is a sufficient discriminator. If
+//! that ever changes — multiple adapters per channel — this becomes
+//! a `(channel, adapter_id)` key and the orchestrator picks one.
+//!
+//! [`writer_for`]: OutboundDispatcher::writer_for
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use tokio::sync::Mutex as AsyncMutex;
+use wirken_ipc::transport::FrameWriter;
+
+/// Map of channel → live capnp writer for the currently connected
+/// adapter on that channel.
+#[derive(Default)]
+pub struct OutboundDispatcher {
+    writers: Mutex<HashMap<String, Arc<AsyncMutex<FrameWriter>>>>,
+}
+
+impl OutboundDispatcher {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register the live writer for a channel. If a writer is already
+    /// registered for that channel, replace it — last-connect wins,
+    /// mirroring the in-memory adapter-registry connected-flag
+    /// semantics.
+    pub fn register(&self, channel: &str, writer: Arc<AsyncMutex<FrameWriter>>) {
+        self.writers
+            .lock()
+            .unwrap()
+            .insert(channel.to_string(), writer);
+    }
+
+    /// Unregister the writer for a channel. Idempotent.
+    pub fn unregister(&self, channel: &str) {
+        self.writers.lock().unwrap().remove(channel);
+    }
+
+    /// Look up the live writer for a channel. `None` if no adapter is
+    /// currently connected on that channel.
+    pub fn writer_for(&self, channel: &str) -> Option<Arc<AsyncMutex<FrameWriter>>> {
+        self.writers.lock().unwrap().get(channel).cloned()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::net::UnixStream;
+
+    async fn make_writer() -> Arc<AsyncMutex<FrameWriter>> {
+        let (a, _b) = UnixStream::pair().unwrap();
+        let (_r, w) = a.into_split();
+        Arc::new(AsyncMutex::new(FrameWriter::new(w)))
+    }
+
+    #[tokio::test]
+    async fn register_and_lookup() {
+        let d = OutboundDispatcher::new();
+        let w = make_writer().await;
+        d.register("signal", w.clone());
+        let got = d.writer_for("signal").expect("writer present");
+        assert!(Arc::ptr_eq(&got, &w));
+    }
+
+    #[tokio::test]
+    async fn unregister_removes_writer() {
+        let d = OutboundDispatcher::new();
+        d.register("signal", make_writer().await);
+        d.unregister("signal");
+        assert!(d.writer_for("signal").is_none());
+    }
+
+    #[tokio::test]
+    async fn lookup_for_unconnected_channel_is_none() {
+        let d = OutboundDispatcher::new();
+        assert!(d.writer_for("nope").is_none());
+    }
+
+    #[tokio::test]
+    async fn second_register_replaces_first() {
+        let d = OutboundDispatcher::new();
+        let w1 = make_writer().await;
+        let w2 = make_writer().await;
+        d.register("signal", w1.clone());
+        d.register("signal", w2.clone());
+        let got = d.writer_for("signal").unwrap();
+        assert!(Arc::ptr_eq(&got, &w2));
+        assert!(!Arc::ptr_eq(&got, &w1));
+    }
+}

--- a/crates/ipc/src/lib.rs
+++ b/crates/ipc/src/lib.rs
@@ -1,6 +1,7 @@
 mod auth;
 mod channel;
 mod error;
+pub mod orchestrator;
 pub mod transport;
 
 // Generated Cap'n Proto code

--- a/crates/ipc/src/orchestrator.rs
+++ b/crates/ipc/src/orchestrator.rs
@@ -1,0 +1,93 @@
+//! Orchestrator → gateway push-message protocol.
+//!
+//! Distinct from the adapter ↔ gateway capnp transport. Orchestrators
+//! (e.g. `wirken-zirkel`) running locally as the same UID that owns
+//! the gateway data dir send outbound text through this socket. The
+//! gateway forwards each push to the live adapter writer for the
+//! named channel using the existing capnp `Outbound` frame.
+//!
+//! ## This is not an adapter
+//!
+//! Adapters cross a trust boundary: they hold third-party
+//! credentials, they're the funnel for attacker-controlled inbound
+//! text, and they authenticate over Ed25519. An orchestrator pushing
+//! a digest to the operator's own thread is not crossing a trust
+//! boundary — it lives in the same data dir, runs under the same
+//! UID, and reads the same vault. SO_PEERCRED + 0600 file perms is
+//! the gate. Wire format is line-delimited JSON; no capnp, no
+//! handshake, no signature.
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OrchestratorPushRequest {
+    pub channel: String,
+    pub conversation_id: String,
+    pub text: String,
+    /// Empty string means "no thread root" — root-level message in
+    /// the channel. Mirrors the capnp `Outbound.reply_to_id`
+    /// semantic (adapters have always treated an empty string as
+    /// "no parent").
+    #[serde(default)]
+    pub reply_to_id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OrchestratorPushResponse {
+    pub ok: bool,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub error: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn request_roundtrips() {
+        let req = OrchestratorPushRequest {
+            channel: "signal".into(),
+            conversation_id: "+15551234567".into(),
+            text: "Daily digest:\n- A\n- B".into(),
+            reply_to_id: "".into(),
+        };
+        let s = serde_json::to_string(&req).unwrap();
+        let parsed: OrchestratorPushRequest = serde_json::from_str(&s).unwrap();
+        assert_eq!(parsed.channel, "signal");
+        assert_eq!(parsed.conversation_id, "+15551234567");
+        assert_eq!(parsed.text, "Daily digest:\n- A\n- B");
+        assert_eq!(parsed.reply_to_id, "");
+    }
+
+    #[test]
+    fn request_reply_to_id_defaults_to_empty_when_missing() {
+        let s = r#"{"channel":"signal","conversation_id":"+15551234567","text":"hi"}"#;
+        let req: OrchestratorPushRequest = serde_json::from_str(s).unwrap();
+        assert_eq!(req.reply_to_id, "");
+    }
+
+    #[test]
+    fn response_skips_error_when_ok() {
+        let resp = OrchestratorPushResponse {
+            ok: true,
+            error: None,
+        };
+        let s = serde_json::to_string(&resp).unwrap();
+        assert_eq!(s, r#"{"ok":true}"#);
+    }
+
+    #[test]
+    fn response_includes_error_when_failed() {
+        let resp = OrchestratorPushResponse {
+            ok: false,
+            error: Some("no adapter connected on channel 'signal'".into()),
+        };
+        let s = serde_json::to_string(&resp).unwrap();
+        let parsed: OrchestratorPushResponse = serde_json::from_str(&s).unwrap();
+        assert!(!parsed.ok);
+        assert_eq!(
+            parsed.error.unwrap(),
+            "no adapter connected on channel 'signal'"
+        );
+    }
+}

--- a/crates/zirkel/Cargo.toml
+++ b/crates/zirkel/Cargo.toml
@@ -9,6 +9,7 @@ description = "Zirkel preset orchestrator: daily-fetch pipeline that runs throug
 [dependencies]
 wirken-agent = { path = "../agent" }
 wirken-audit = { path = "../audit" }
+wirken-ipc = { path = "../ipc" }
 wirken-skill-store = { path = "../skill-store" }
 tokio = { workspace = true }
 reqwest = { workspace = true }

--- a/crates/zirkel/src/binding.rs
+++ b/crates/zirkel/src/binding.rs
@@ -1,0 +1,195 @@
+//! Persisted target for the daily-digest push.
+//!
+//! `wirken zirkel bind` writes one row; `wirken zirkel run`'s push
+//! step reads it. The keep/skip interceptor is registered on the
+//! agent named by [`Binding::agent_id`] so the operator's reply flows
+//! through it.
+//!
+//! ## Single-binding contract today
+//!
+//! The schema permits multiple rows (one per agent), but the C-Signal
+//! slice runs with a single bound conversation per zirkel install.
+//! The CLI's idempotency / `--force` semantics enforce that on the
+//! write side — see piece 5. Read side helpers expose both `load`
+//! (by agent_id) and [`load_first`] (the single-binding shortcut).
+
+use rusqlite::{Connection, OptionalExtension, params};
+
+#[derive(Debug, thiserror::Error)]
+pub enum BindingError {
+    #[error("sqlite: {0}")]
+    Sqlite(#[from] rusqlite::Error),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Binding {
+    pub agent_id: String,
+    pub channel: String,
+    pub conversation_id: String,
+}
+
+/// Insert or replace a binding for `agent_id`. Replacement is
+/// blanket — call from a CLI that has already done its idempotency
+/// check.
+pub fn record(conn: &Connection, binding: &Binding) -> Result<(), BindingError> {
+    conn.execute(
+        "INSERT OR REPLACE INTO bindings (agent_id, channel, conversation_id, bound_at) \
+         VALUES (?1, ?2, ?3, datetime('now'))",
+        params![
+            &binding.agent_id,
+            &binding.channel,
+            &binding.conversation_id
+        ],
+    )?;
+    Ok(())
+}
+
+/// Read the binding for a specific agent. `None` if no row exists.
+pub fn load(conn: &Connection, agent_id: &str) -> Result<Option<Binding>, BindingError> {
+    let row = conn
+        .query_row(
+            "SELECT agent_id, channel, conversation_id FROM bindings WHERE agent_id = ?1",
+            params![agent_id],
+            |r| {
+                Ok(Binding {
+                    agent_id: r.get(0)?,
+                    channel: r.get(1)?,
+                    conversation_id: r.get(2)?,
+                })
+            },
+        )
+        .optional()?;
+    Ok(row)
+}
+
+/// Read the only binding row, ordered deterministically by `agent_id`.
+/// `None` if no row exists. Convenience for the run path which
+/// today expects exactly one binding.
+pub fn load_first(conn: &Connection) -> Result<Option<Binding>, BindingError> {
+    let row = conn
+        .query_row(
+            "SELECT agent_id, channel, conversation_id FROM bindings \
+             ORDER BY agent_id ASC LIMIT 1",
+            [],
+            |r| {
+                Ok(Binding {
+                    agent_id: r.get(0)?,
+                    channel: r.get(1)?,
+                    conversation_id: r.get(2)?,
+                })
+            },
+        )
+        .optional()?;
+    Ok(row)
+}
+
+/// List every binding row, ordered by `agent_id`.
+pub fn list_all(conn: &Connection) -> Result<Vec<Binding>, BindingError> {
+    let mut stmt = conn
+        .prepare("SELECT agent_id, channel, conversation_id FROM bindings ORDER BY agent_id ASC")?;
+    let rows: Vec<Binding> = stmt
+        .query_map([], |r| {
+            Ok(Binding {
+                agent_id: r.get(0)?,
+                channel: r.get(1)?,
+                conversation_id: r.get(2)?,
+            })
+        })?
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(rows)
+}
+
+/// Remove a binding. Idempotent.
+pub fn remove(conn: &Connection, agent_id: &str) -> Result<(), BindingError> {
+    conn.execute(
+        "DELETE FROM bindings WHERE agent_id = ?1",
+        params![agent_id],
+    )?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::schema::AGGREGATOR_MIGRATIONS;
+
+    fn open_migrated() -> Connection {
+        let mut conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE _migrations (idx INTEGER PRIMARY KEY, applied_at TEXT NOT NULL DEFAULT (datetime('now')))",
+        )
+        .unwrap();
+        let tx = conn.transaction().unwrap();
+        for (idx, sql) in AGGREGATOR_MIGRATIONS.iter().enumerate() {
+            tx.execute_batch(sql).unwrap();
+            tx.execute(
+                "INSERT INTO _migrations (idx) VALUES (?1)",
+                params![idx as i64],
+            )
+            .unwrap();
+        }
+        tx.commit().unwrap();
+        conn
+    }
+
+    fn b(agent: &str, ch: &str, cid: &str) -> Binding {
+        Binding {
+            agent_id: agent.into(),
+            channel: ch.into(),
+            conversation_id: cid.into(),
+        }
+    }
+
+    #[test]
+    fn record_and_load_roundtrip() {
+        let conn = open_migrated();
+        record(&conn, &b("default", "signal", "+15551234567")).unwrap();
+        let got = load(&conn, "default").unwrap().unwrap();
+        assert_eq!(got, b("default", "signal", "+15551234567"));
+    }
+
+    #[test]
+    fn record_replaces_on_duplicate_agent() {
+        let conn = open_migrated();
+        record(&conn, &b("default", "signal", "+15551111111")).unwrap();
+        record(&conn, &b("default", "telegram", "12345")).unwrap();
+        let got = load(&conn, "default").unwrap().unwrap();
+        assert_eq!(got, b("default", "telegram", "12345"));
+    }
+
+    #[test]
+    fn load_first_returns_none_when_empty() {
+        let conn = open_migrated();
+        assert!(load_first(&conn).unwrap().is_none());
+    }
+
+    #[test]
+    fn load_first_returns_lowest_agent_id() {
+        let conn = open_migrated();
+        record(&conn, &b("zeta", "signal", "+1")).unwrap();
+        record(&conn, &b("alpha", "slack", "C0")).unwrap();
+        let got = load_first(&conn).unwrap().unwrap();
+        assert_eq!(got.agent_id, "alpha");
+    }
+
+    #[test]
+    fn remove_deletes_binding() {
+        let conn = open_migrated();
+        record(&conn, &b("default", "signal", "+15551234567")).unwrap();
+        remove(&conn, "default").unwrap();
+        assert!(load(&conn, "default").unwrap().is_none());
+    }
+
+    #[test]
+    fn list_all_orders_by_agent_id() {
+        let conn = open_migrated();
+        record(&conn, &b("zeta", "signal", "+1")).unwrap();
+        record(&conn, &b("alpha", "slack", "C0")).unwrap();
+        record(&conn, &b("mid", "telegram", "999")).unwrap();
+        let rows = list_all(&conn).unwrap();
+        assert_eq!(rows.len(), 3);
+        assert_eq!(rows[0].agent_id, "alpha");
+        assert_eq!(rows[1].agent_id, "mid");
+        assert_eq!(rows[2].agent_id, "zeta");
+    }
+}

--- a/crates/zirkel/src/digest.rs
+++ b/crates/zirkel/src/digest.rs
@@ -1,0 +1,548 @@
+//! Digest renderer for the daily push.
+//!
+//! Reads candidate + theme rows for a run, groups them, and produces
+//! a numbered text body and the matching ordered candidate-id list.
+//! The renderer does not touch the database for writes — `digest_log`
+//! is the persistence side, called by the wiring after the renderer
+//! produces its output.
+//!
+//! ## Single-section rule
+//!
+//! HDBSCAN's noise / low-density behaviour means a run can land
+//! entirely in one bucket — every item ungrouped, or every item in a
+//! single named theme. Rendering a lonely `— Ungrouped (8) —` header
+//! over the only section is sad and misleading; the body reads
+//! cleaner as a flat numbered list with no header at all. The rule:
+//! when the digest collapses to one section, drop the section
+//! header. ≥2 sections always render headers, including the
+//! ungrouped section if it coexists with named themes.
+
+use rusqlite::{Connection, params};
+
+#[derive(Debug, thiserror::Error)]
+pub enum DigestError {
+    #[error("sqlite: {0}")]
+    Sqlite(#[from] rusqlite::Error),
+    #[error("run {run_id} has no candidates to render")]
+    EmptyRun { run_id: String },
+}
+
+#[derive(Debug, Clone)]
+pub struct DigestRow {
+    pub candidate_id: i64,
+    pub title: String,
+    pub url: String,
+    pub source_name: String,
+    pub llm_relevance_score: Option<u32>,
+    pub llm_why_surfaced: Option<String>,
+    pub cluster_id: Option<i64>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ThemeRow {
+    pub id: i64,
+    pub name: String,
+    pub member_count: u32,
+}
+
+#[derive(Debug, Clone)]
+pub struct RenderOptions {
+    /// Cap on rendered items. Items past this cap are dropped from
+    /// the output text and from `ordered_candidate_ids`. The
+    /// operator can re-query the database for the full run.
+    pub max_items: usize,
+    /// One-line title for the digest (e.g. `"Daily digest"`).
+    pub title: String,
+    /// Optional date string appended after the title with `" — "`.
+    pub date: Option<String>,
+}
+
+impl Default for RenderOptions {
+    fn default() -> Self {
+        Self {
+            max_items: 20,
+            title: "Daily digest".into(),
+            date: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct RenderedDigest {
+    pub text: String,
+    /// Candidate ids in the 1-indexed order they appear in `text`.
+    /// Goes to `digest_log::record_sent` so the keep/skip
+    /// interceptor maps the operator's reply back to candidates.
+    pub ordered_candidate_ids: Vec<i64>,
+}
+
+/// Read every candidate in the run and the run's theme rows.
+pub fn load_run(
+    conn: &Connection,
+    run_id: &str,
+) -> Result<(Vec<DigestRow>, Vec<ThemeRow>), DigestError> {
+    let mut stmt = conn.prepare(
+        "SELECT id, title, url, source_name, llm_relevance_score, llm_why_surfaced, cluster_id \
+         FROM candidates \
+         WHERE run_id = ?1 \
+         ORDER BY \
+            llm_relevance_score IS NULL ASC, \
+            llm_relevance_score DESC, \
+            id ASC",
+    )?;
+    let rows: Vec<DigestRow> = stmt
+        .query_map(params![run_id], |r| {
+            Ok(DigestRow {
+                candidate_id: r.get(0)?,
+                title: r.get(1)?,
+                url: r.get(2)?,
+                source_name: r.get(3)?,
+                llm_relevance_score: r
+                    .get::<_, Option<f64>>(4)?
+                    .map(|f| f.round().clamp(0.0, 1000.0) as u32),
+                llm_why_surfaced: r.get(5)?,
+                cluster_id: r.get(6)?,
+            })
+        })?
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let mut tstmt = conn.prepare(
+        "SELECT id, name, member_count FROM themes WHERE run_id = ?1 ORDER BY member_count DESC, id ASC",
+    )?;
+    let themes: Vec<ThemeRow> = tstmt
+        .query_map(params![run_id], |r| {
+            Ok(ThemeRow {
+                id: r.get(0)?,
+                name: r.get(1)?,
+                member_count: r.get::<_, i64>(2)? as u32,
+            })
+        })?
+        .collect::<Result<Vec<_>, _>>()?;
+
+    Ok((rows, themes))
+}
+
+/// Render a digest from the loaded rows.
+pub fn render(
+    rows: &[DigestRow],
+    themes: &[ThemeRow],
+    opts: &RenderOptions,
+) -> Result<RenderedDigest, DigestError> {
+    if rows.is_empty() {
+        return Err(DigestError::EmptyRun {
+            run_id: String::new(),
+        });
+    }
+
+    // Cap before grouping so the rendered text and the recorded
+    // ordered ids match exactly.
+    let capped: Vec<&DigestRow> = rows.iter().take(opts.max_items).collect();
+
+    // Theme metadata by id.
+    let theme_by_id: std::collections::HashMap<i64, &ThemeRow> =
+        themes.iter().map(|t| (t.id, t)).collect();
+
+    // Group rows by cluster_id (None = ungrouped). Stable order
+    // within a group is the row order we received (already
+    // relevance-sorted by load_run).
+    let mut groups: std::collections::HashMap<Option<i64>, Vec<&DigestRow>> =
+        std::collections::HashMap::new();
+    for r in &capped {
+        groups.entry(r.cluster_id).or_default().push(r);
+    }
+
+    // Order groups: named themes first (by member_count DESC, then id),
+    // ungrouped at the end.
+    let mut named: Vec<i64> = groups.keys().filter_map(|k| *k).collect();
+    named.sort_by_key(|id| {
+        let t = theme_by_id.get(id);
+        // Sort key: -member_count then id; clusters with no theme
+        // row land below named themes but above the ungrouped bucket.
+        (
+            t.map(|t| -(t.member_count as i64)).unwrap_or(0),
+            t.is_none(),
+            *id,
+        )
+    });
+
+    // Total ordered list of (header_label_or_none, rows).
+    let mut sections: Vec<(Option<String>, Vec<&DigestRow>)> = Vec::new();
+    for cid in &named {
+        let label = theme_by_id
+            .get(cid)
+            .map(|t| t.name.clone())
+            .unwrap_or_else(|| format!("Cluster {cid}"));
+        if let Some(rs) = groups.remove(&Some(*cid)) {
+            sections.push((Some(label), rs));
+        }
+    }
+    if let Some(ungrouped) = groups.remove(&None) {
+        sections.push((Some("Ungrouped".into()), ungrouped));
+    }
+
+    // Single-section rule: drop the lone header.
+    let drop_headers = sections.len() == 1;
+
+    // Build text + ordered_candidate_ids in lockstep.
+    let mut text = String::new();
+    text.push_str(&opts.title);
+    if let Some(date) = opts.date.as_ref() {
+        text.push_str(" — ");
+        text.push_str(date);
+    }
+    text.push('\n');
+
+    let mut ordered: Vec<i64> = Vec::with_capacity(capped.len());
+    let mut idx: u32 = 1;
+    for (header, rs) in &sections {
+        if !drop_headers {
+            if let Some(h) = header {
+                text.push('\n');
+                text.push_str("— ");
+                text.push_str(h);
+                text.push_str(&format!(" ({}) —\n", rs.len()));
+            }
+        } else {
+            text.push('\n');
+        }
+        for r in rs {
+            text.push_str(&format!("{idx}. {}\n", r.title));
+            text.push_str(&format!("   {}", r.source_name));
+            if let Some(why) = &r.llm_why_surfaced {
+                if !why.is_empty() {
+                    text.push_str(" — ");
+                    text.push_str(why);
+                }
+            }
+            text.push('\n');
+            text.push_str(&format!("   {}\n", r.url));
+            ordered.push(r.candidate_id);
+            idx += 1;
+        }
+    }
+
+    text.push('\n');
+    text.push_str("Reply: keep 1,3,5 / skip 2 / keep all / skip all\n");
+
+    Ok(RenderedDigest {
+        text,
+        ordered_candidate_ids: ordered,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::schema::AGGREGATOR_MIGRATIONS;
+
+    fn open_migrated() -> Connection {
+        let mut conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE _migrations (idx INTEGER PRIMARY KEY, applied_at TEXT NOT NULL DEFAULT (datetime('now')))",
+        )
+        .unwrap();
+        let tx = conn.transaction().unwrap();
+        for (idx, sql) in AGGREGATOR_MIGRATIONS.iter().enumerate() {
+            tx.execute_batch(sql).unwrap();
+            tx.execute(
+                "INSERT INTO _migrations (idx) VALUES (?1)",
+                params![idx as i64],
+            )
+            .unwrap();
+        }
+        tx.commit().unwrap();
+        conn
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn insert_candidate(
+        conn: &Connection,
+        run_id: &str,
+        title: &str,
+        url: &str,
+        source: &str,
+        llm_score: Option<f64>,
+        why: Option<&str>,
+        cluster_id: Option<i64>,
+    ) -> i64 {
+        conn.execute(
+            "INSERT INTO candidates (source_name, url, body, run_id, title, llm_relevance_score, \
+             llm_why_surfaced, cluster_id) \
+             VALUES (?1, ?2, '', ?3, ?4, ?5, ?6, ?7)",
+            params![source, url, run_id, title, llm_score, why, cluster_id],
+        )
+        .unwrap();
+        conn.last_insert_rowid()
+    }
+
+    fn insert_theme(conn: &Connection, run_id: &str, name: &str, member_count: i64) -> i64 {
+        conn.execute(
+            "INSERT INTO themes (run_id, name, member_count) VALUES (?1, ?2, ?3)",
+            params![run_id, name, member_count],
+        )
+        .unwrap();
+        conn.last_insert_rowid()
+    }
+
+    #[test]
+    fn empty_run_errors() {
+        let r = render(&[], &[], &RenderOptions::default());
+        assert!(matches!(r, Err(DigestError::EmptyRun { .. })));
+    }
+
+    #[test]
+    fn single_section_drops_header_when_all_ungrouped() {
+        let conn = open_migrated();
+        insert_candidate(
+            &conn,
+            "run-1",
+            "Item A",
+            "https://example.com/a",
+            "src-a",
+            Some(80.0),
+            Some("matches your interest in privacy"),
+            None,
+        );
+        insert_candidate(
+            &conn,
+            "run-1",
+            "Item B",
+            "https://example.com/b",
+            "src-b",
+            Some(60.0),
+            None,
+            None,
+        );
+        let (rows, themes) = load_run(&conn, "run-1").unwrap();
+        let out = render(&rows, &themes, &RenderOptions::default()).unwrap();
+        // Single-section rule: no "— Ungrouped (2) —" header.
+        assert!(
+            !out.text.contains("Ungrouped"),
+            "should not render section header for the only section: {}",
+            out.text
+        );
+        assert!(out.text.contains("1. Item A"));
+        assert!(out.text.contains("2. Item B"));
+        assert!(out.text.contains("matches your interest in privacy"));
+        assert_eq!(out.ordered_candidate_ids.len(), 2);
+    }
+
+    #[test]
+    fn single_section_drops_header_when_all_in_one_named_theme() {
+        let conn = open_migrated();
+        let theme_id = insert_theme(&conn, "run-1", "Adtech consent", 3);
+        for n in 0..3 {
+            insert_candidate(
+                &conn,
+                "run-1",
+                &format!("Item {n}"),
+                &format!("https://example.com/{n}"),
+                "src",
+                Some(80.0 - n as f64),
+                None,
+                Some(theme_id),
+            );
+        }
+        let (rows, themes) = load_run(&conn, "run-1").unwrap();
+        let out = render(&rows, &themes, &RenderOptions::default()).unwrap();
+        assert!(
+            !out.text.contains("Adtech consent ("),
+            "should not render lone theme header: {}",
+            out.text
+        );
+        assert!(out.text.contains("1. Item 0"));
+        assert!(out.text.contains("3. Item 2"));
+    }
+
+    #[test]
+    fn multi_section_renders_headers_with_member_counts() {
+        let conn = open_migrated();
+        let big = insert_theme(&conn, "run-1", "Privacy enforcement", 3);
+        let small = insert_theme(&conn, "run-1", "Cross-border transfers", 2);
+        for n in 0..3 {
+            insert_candidate(
+                &conn,
+                "run-1",
+                &format!("PE {n}"),
+                &format!("https://pe/{n}"),
+                "src",
+                Some(80.0),
+                None,
+                Some(big),
+            );
+        }
+        for n in 0..2 {
+            insert_candidate(
+                &conn,
+                "run-1",
+                &format!("CB {n}"),
+                &format!("https://cb/{n}"),
+                "src",
+                Some(70.0),
+                None,
+                Some(small),
+            );
+        }
+        // Ungrouped tail.
+        insert_candidate(
+            &conn,
+            "run-1",
+            "Loose",
+            "https://x/y",
+            "src",
+            Some(50.0),
+            None,
+            None,
+        );
+        let (rows, themes) = load_run(&conn, "run-1").unwrap();
+        let out = render(&rows, &themes, &RenderOptions::default()).unwrap();
+        assert!(out.text.contains("— Privacy enforcement (3) —"));
+        assert!(out.text.contains("— Cross-border transfers (2) —"));
+        assert!(out.text.contains("— Ungrouped (1) —"));
+        // Big theme appears before small theme (by member_count).
+        let big_pos = out.text.find("Privacy enforcement").unwrap();
+        let small_pos = out.text.find("Cross-border").unwrap();
+        let un_pos = out.text.find("Ungrouped").unwrap();
+        assert!(big_pos < small_pos);
+        assert!(small_pos < un_pos);
+        // 6 items total, 1-indexed across the whole digest.
+        assert!(out.text.contains("1. PE 0"));
+        assert!(out.text.contains("6. Loose"));
+        assert_eq!(out.ordered_candidate_ids.len(), 6);
+    }
+
+    #[test]
+    fn cap_drops_low_relevance_items() {
+        let conn = open_migrated();
+        for n in 0..5 {
+            insert_candidate(
+                &conn,
+                "run-1",
+                &format!("Item {n}"),
+                &format!("https://x/{n}"),
+                "src",
+                // 90, 80, 70, 60, 50
+                Some(90.0 - 10.0 * n as f64),
+                None,
+                None,
+            );
+        }
+        let (rows, themes) = load_run(&conn, "run-1").unwrap();
+        let opts = RenderOptions {
+            max_items: 3,
+            ..RenderOptions::default()
+        };
+        let out = render(&rows, &themes, &opts).unwrap();
+        assert!(out.text.contains("1. Item 0"));
+        assert!(out.text.contains("3. Item 2"));
+        assert!(!out.text.contains("Item 3"));
+        assert_eq!(out.ordered_candidate_ids.len(), 3);
+    }
+
+    #[test]
+    fn ordered_candidate_ids_match_rendered_indices() {
+        let conn = open_migrated();
+        let id_a = insert_candidate(
+            &conn,
+            "run-1",
+            "A",
+            "https://a",
+            "s",
+            Some(90.0),
+            None,
+            None,
+        );
+        let id_b = insert_candidate(
+            &conn,
+            "run-1",
+            "B",
+            "https://b",
+            "s",
+            Some(80.0),
+            None,
+            None,
+        );
+        let id_c = insert_candidate(
+            &conn,
+            "run-1",
+            "C",
+            "https://c",
+            "s",
+            Some(70.0),
+            None,
+            None,
+        );
+        let (rows, themes) = load_run(&conn, "run-1").unwrap();
+        let out = render(&rows, &themes, &RenderOptions::default()).unwrap();
+        assert_eq!(out.ordered_candidate_ids, vec![id_a, id_b, id_c]);
+    }
+
+    #[test]
+    fn nulls_sort_after_scored_items() {
+        let conn = open_migrated();
+        let unscored = insert_candidate(
+            &conn,
+            "run-1",
+            "Unscored",
+            "https://u",
+            "s",
+            None,
+            None,
+            None,
+        );
+        let scored = insert_candidate(
+            &conn,
+            "run-1",
+            "Scored",
+            "https://s",
+            "s",
+            Some(70.0),
+            None,
+            None,
+        );
+        let (rows, themes) = load_run(&conn, "run-1").unwrap();
+        let out = render(&rows, &themes, &RenderOptions::default()).unwrap();
+        assert_eq!(out.ordered_candidate_ids, vec![scored, unscored]);
+    }
+
+    #[test]
+    fn footer_includes_reply_help() {
+        let conn = open_migrated();
+        insert_candidate(
+            &conn,
+            "run-1",
+            "X",
+            "https://x",
+            "s",
+            Some(70.0),
+            None,
+            None,
+        );
+        let (rows, themes) = load_run(&conn, "run-1").unwrap();
+        let out = render(&rows, &themes, &RenderOptions::default()).unwrap();
+        assert!(out.text.contains("keep 1,3,5"));
+        assert!(out.text.contains("skip all"));
+    }
+
+    #[test]
+    fn date_appears_in_title_when_provided() {
+        let conn = open_migrated();
+        insert_candidate(
+            &conn,
+            "run-1",
+            "X",
+            "https://x",
+            "s",
+            Some(70.0),
+            None,
+            None,
+        );
+        let (rows, themes) = load_run(&conn, "run-1").unwrap();
+        let opts = RenderOptions {
+            date: Some("2026-04-29".into()),
+            ..RenderOptions::default()
+        };
+        let out = render(&rows, &themes, &opts).unwrap();
+        assert!(out.text.starts_with("Daily digest — 2026-04-29"));
+    }
+}

--- a/crates/zirkel/src/digest_log.rs
+++ b/crates/zirkel/src/digest_log.rs
@@ -1,0 +1,257 @@
+//! Digest persistence — what was sent, in what order, with what
+//! resolution.
+//!
+//! The digest renderer (piece 4) calls [`record_sent`] when it pushes
+//! a digest to the operator's channel; the keep/skip interceptor
+//! (piece 3) calls [`most_recent_unresolved`] and [`resolve`] when
+//! processing the operator's reply.
+//!
+//! All operations are scoped by `agent_id`. Today's bind keeps a
+//! single zirkel-bound conversation per agent so the agent scope is
+//! sufficient discrimination; widening to (agent_id, channel,
+//! conversation_id) is a future migration if multi-conversation
+//! becomes a real case.
+
+use rusqlite::{Connection, OptionalExtension, params};
+
+#[derive(Debug, thiserror::Error)]
+pub enum DigestLogError {
+    #[error("sqlite: {0}")]
+    Sqlite(#[from] rusqlite::Error),
+    #[error("digest_id {0} has no items")]
+    EmptyDigest(i64),
+}
+
+/// One persisted digest with the items the operator was shown.
+#[derive(Debug, Clone)]
+pub struct DigestRecord {
+    pub id: i64,
+    pub run_id: String,
+    pub agent_id: String,
+    pub items: Vec<DigestItem>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DigestItem {
+    /// 1-indexed position the operator sees in the rendered digest.
+    pub idx: u32,
+    pub candidate_id: i64,
+    /// `None` until the digest is resolved. After resolution one of
+    /// `"kept"` or `"skipped"`.
+    pub decision: Option<String>,
+}
+
+/// Decision applied by the keep/skip resolver.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Decision {
+    Kept,
+    Skipped,
+}
+
+impl Decision {
+    pub fn as_db_str(self) -> &'static str {
+        match self {
+            Decision::Kept => "kept",
+            Decision::Skipped => "skipped",
+        }
+    }
+}
+
+/// Insert a new digest with the given 1-indexed candidate list. The
+/// caller is responsible for the candidate-ordering decision; the
+/// 1-indexed positions in `candidate_ids` (vec position + 1) are
+/// what the operator will see and refer to in their reply.
+pub fn record_sent(
+    conn: &mut Connection,
+    run_id: &str,
+    agent_id: &str,
+    candidate_ids: &[i64],
+) -> Result<i64, DigestLogError> {
+    let tx = conn.transaction()?;
+    tx.execute(
+        "INSERT INTO digests (run_id, agent_id) VALUES (?1, ?2)",
+        params![run_id, agent_id],
+    )?;
+    let digest_id = tx.last_insert_rowid();
+    {
+        let mut stmt = tx.prepare(
+            "INSERT INTO digest_items (digest_id, idx, candidate_id) VALUES (?1, ?2, ?3)",
+        )?;
+        for (i, candidate_id) in candidate_ids.iter().enumerate() {
+            let idx = (i as i64) + 1;
+            stmt.execute(params![digest_id, idx, candidate_id])?;
+        }
+    }
+    tx.commit()?;
+    Ok(digest_id)
+}
+
+/// The most recent digest for `agent_id` whose `resolved_at` is
+/// still NULL. `None` if every previous digest has been resolved
+/// or no digest has been sent.
+pub fn most_recent_unresolved(
+    conn: &Connection,
+    agent_id: &str,
+) -> Result<Option<DigestRecord>, DigestLogError> {
+    let row = conn
+        .query_row(
+            "SELECT id, run_id FROM digests \
+             WHERE agent_id = ?1 AND resolved_at IS NULL \
+             ORDER BY sent_at DESC, id DESC LIMIT 1",
+            params![agent_id],
+            |row| Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?)),
+        )
+        .optional()?;
+    let Some((id, run_id)) = row else {
+        return Ok(None);
+    };
+
+    let mut stmt = conn.prepare(
+        "SELECT idx, candidate_id, decision FROM digest_items \
+         WHERE digest_id = ?1 ORDER BY idx ASC",
+    )?;
+    let items: Vec<DigestItem> = stmt
+        .query_map(params![id], |row| {
+            Ok(DigestItem {
+                idx: row.get::<_, i64>(0)? as u32,
+                candidate_id: row.get(1)?,
+                decision: row.get::<_, Option<String>>(2)?,
+            })
+        })?
+        .collect::<Result<Vec<_>, _>>()?;
+
+    if items.is_empty() {
+        return Err(DigestLogError::EmptyDigest(id));
+    }
+
+    Ok(Some(DigestRecord {
+        id,
+        run_id,
+        agent_id: agent_id.to_string(),
+        items,
+    }))
+}
+
+/// Apply a decision per-item and mark the digest resolved. Items not
+/// listed in `decisions` keep their existing decision (typically
+/// `NULL` — the resolver should pass a decision for every item to
+/// avoid leaving a partially-resolved digest).
+pub fn resolve(
+    conn: &mut Connection,
+    digest_id: i64,
+    decisions: &[(u32, Decision)],
+) -> Result<(), DigestLogError> {
+    let tx = conn.transaction()?;
+    {
+        let mut stmt =
+            tx.prepare("UPDATE digest_items SET decision = ?1 WHERE digest_id = ?2 AND idx = ?3")?;
+        for (idx, decision) in decisions {
+            stmt.execute(params![decision.as_db_str(), digest_id, *idx as i64])?;
+        }
+    }
+    tx.execute(
+        "UPDATE digests SET resolved_at = datetime('now') WHERE id = ?1",
+        params![digest_id],
+    )?;
+    tx.commit()?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::schema::AGGREGATOR_MIGRATIONS;
+
+    fn open_migrated() -> Connection {
+        let mut conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE _migrations (idx INTEGER PRIMARY KEY, applied_at TEXT NOT NULL DEFAULT (datetime('now')))",
+        ).unwrap();
+        let tx = conn.transaction().unwrap();
+        for (idx, sql) in AGGREGATOR_MIGRATIONS.iter().enumerate() {
+            tx.execute_batch(sql).unwrap();
+            tx.execute(
+                "INSERT INTO _migrations (idx) VALUES (?1)",
+                params![idx as i64],
+            )
+            .unwrap();
+        }
+        tx.commit().unwrap();
+        conn
+    }
+
+    #[test]
+    fn record_sent_returns_id_and_writes_items() {
+        let mut conn = open_migrated();
+        let id = record_sent(&mut conn, "run-1", "default", &[10, 11, 12]).unwrap();
+        assert!(id > 0);
+        let rec = most_recent_unresolved(&conn, "default").unwrap().unwrap();
+        assert_eq!(rec.id, id);
+        assert_eq!(rec.run_id, "run-1");
+        assert_eq!(rec.items.len(), 3);
+        assert_eq!(rec.items[0].idx, 1);
+        assert_eq!(rec.items[0].candidate_id, 10);
+        assert_eq!(rec.items[2].idx, 3);
+        assert_eq!(rec.items[2].candidate_id, 12);
+        for it in rec.items {
+            assert!(it.decision.is_none());
+        }
+    }
+
+    #[test]
+    fn most_recent_unresolved_returns_none_when_no_digest() {
+        let conn = open_migrated();
+        assert!(most_recent_unresolved(&conn, "default").unwrap().is_none());
+    }
+
+    #[test]
+    fn most_recent_unresolved_skips_resolved_rows() {
+        let mut conn = open_migrated();
+        let first = record_sent(&mut conn, "run-1", "default", &[10]).unwrap();
+        resolve(&mut conn, first, &[(1, Decision::Kept)]).unwrap();
+        let second = record_sent(&mut conn, "run-2", "default", &[20, 21]).unwrap();
+        let rec = most_recent_unresolved(&conn, "default").unwrap().unwrap();
+        assert_eq!(rec.id, second);
+        assert_eq!(rec.run_id, "run-2");
+    }
+
+    #[test]
+    fn most_recent_unresolved_filters_by_agent() {
+        let mut conn = open_migrated();
+        record_sent(&mut conn, "run-1", "agent-a", &[10]).unwrap();
+        let rec = most_recent_unresolved(&conn, "agent-b").unwrap();
+        assert!(rec.is_none());
+    }
+
+    #[test]
+    fn resolve_writes_decisions_and_marks_resolved() {
+        let mut conn = open_migrated();
+        let id = record_sent(&mut conn, "run-1", "default", &[10, 11, 12]).unwrap();
+        resolve(
+            &mut conn,
+            id,
+            &[
+                (1, Decision::Kept),
+                (2, Decision::Skipped),
+                (3, Decision::Kept),
+            ],
+        )
+        .unwrap();
+        // Now the digest is resolved → most_recent_unresolved is None.
+        assert!(most_recent_unresolved(&conn, "default").unwrap().is_none());
+        // Verify the per-item decisions were stored.
+        let mut stmt = conn
+            .prepare("SELECT idx, decision FROM digest_items WHERE digest_id = ?1 ORDER BY idx")
+            .unwrap();
+        let rows: Vec<(i64, Option<String>)> = stmt
+            .query_map(params![id], |r| {
+                Ok((r.get::<_, i64>(0)?, r.get::<_, Option<String>>(1)?))
+            })
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        assert_eq!(rows[0], (1, Some("kept".to_string())));
+        assert_eq!(rows[1], (2, Some("skipped".to_string())));
+        assert_eq!(rows[2], (3, Some("kept".to_string())));
+    }
+}

--- a/crates/zirkel/src/keep_skip.rs
+++ b/crates/zirkel/src/keep_skip.rs
@@ -1,0 +1,218 @@
+//! Reply-parser for the daily-digest keep/skip surface.
+//!
+//! The lawyer's reply on Signal is one short message that resolves
+//! the digest in a single shot. Recognised forms:
+//!
+//! - `keep all`      — every item in the digest is kept
+//! - `skip all`      — every item is skipped
+//! - `keep N`        — that one item is kept, every other is skipped
+//! - `skip N`        — that one item is skipped, every other is kept
+//! - `keep N,M,P`    — listed items kept, rest skipped
+//! - `skip N,M,P`    — listed items skipped, rest kept
+//! - `keep N M P`    — whitespace-separated form, equivalent
+//! - `keep 3, 5, 7`  — whitespace inside lists is tolerated
+//!
+//! Numbers are 1-indexed, scoped to the most recently sent digest
+//! for the receiving agent. Anything that isn't a clean keep/skip
+//! command — including a number out of range — yields `None` from
+//! [`parse`]; the orchestrator decides whether to surface "out of
+//! range" as a Reject or to ignore. `parse` is shape-only.
+//!
+//! ## Strict, not fuzzy
+//!
+//! Like the slash parser, the surface is the contract. We don't
+//! match `"please keep item 3"` or `"keep #3"`. The Signal user
+//! sees the exact syntax in the digest footer; anything outside
+//! that shape is a free-text reply and falls through.
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum KeepSkipCmd {
+    Keep(KeepSkipTargets),
+    Skip(KeepSkipTargets),
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum KeepSkipTargets {
+    All,
+    /// 1-indexed positions, in caller-provided order. May contain
+    /// duplicates — the resolver dedupes.
+    Indices(Vec<u32>),
+}
+
+/// Parse a user reply for a keep/skip command. `None` for anything
+/// that isn't a clean command shape.
+pub fn parse(message: &str) -> Option<KeepSkipCmd> {
+    let trimmed = message.trim();
+    let lower = trimmed.to_ascii_lowercase();
+    let (verb, rest) = if let Some(r) = lower.strip_prefix("keep") {
+        (Verb::Keep, r)
+    } else if let Some(r) = lower.strip_prefix("skip") {
+        (Verb::Skip, r)
+    } else {
+        return None;
+    };
+    // Verb must be followed by whitespace (or end of message — bare
+    // `keep` is not a command).
+    if !rest.starts_with(|c: char| c.is_whitespace()) {
+        return None;
+    }
+    let arg = rest.trim();
+    if arg.is_empty() {
+        return None;
+    }
+    if arg == "all" {
+        return Some(verb.with(KeepSkipTargets::All));
+    }
+    let indices = parse_indices(arg)?;
+    if indices.is_empty() {
+        return None;
+    }
+    Some(verb.with(KeepSkipTargets::Indices(indices)))
+}
+
+#[derive(Copy, Clone)]
+enum Verb {
+    Keep,
+    Skip,
+}
+
+impl Verb {
+    fn with(self, t: KeepSkipTargets) -> KeepSkipCmd {
+        match self {
+            Verb::Keep => KeepSkipCmd::Keep(t),
+            Verb::Skip => KeepSkipCmd::Skip(t),
+        }
+    }
+}
+
+/// Parse a numeric list — comma- or whitespace-separated 1-indexed
+/// positive integers. Returns `None` on any non-numeric token or
+/// zero / overflow / negative.
+fn parse_indices(s: &str) -> Option<Vec<u32>> {
+    let mut out = Vec::new();
+    for tok in s.split(|c: char| c == ',' || c.is_whitespace()) {
+        if tok.is_empty() {
+            continue;
+        }
+        let n: u32 = tok.parse().ok()?;
+        if n == 0 {
+            return None;
+        }
+        out.push(n);
+    }
+    Some(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn keep_indices(v: &[u32]) -> KeepSkipCmd {
+        KeepSkipCmd::Keep(KeepSkipTargets::Indices(v.to_vec()))
+    }
+    fn skip_indices(v: &[u32]) -> KeepSkipCmd {
+        KeepSkipCmd::Skip(KeepSkipTargets::Indices(v.to_vec()))
+    }
+
+    #[test]
+    fn keep_all_parses() {
+        assert_eq!(
+            parse("keep all"),
+            Some(KeepSkipCmd::Keep(KeepSkipTargets::All))
+        );
+    }
+
+    #[test]
+    fn skip_all_parses() {
+        assert_eq!(
+            parse("skip all"),
+            Some(KeepSkipCmd::Skip(KeepSkipTargets::All))
+        );
+    }
+
+    #[test]
+    fn keep_single_index() {
+        assert_eq!(parse("keep 3"), Some(keep_indices(&[3])));
+    }
+
+    #[test]
+    fn skip_single_index() {
+        assert_eq!(parse("skip 4"), Some(skip_indices(&[4])));
+    }
+
+    #[test]
+    fn comma_separated_list() {
+        assert_eq!(parse("keep 3,5,7"), Some(keep_indices(&[3, 5, 7])));
+    }
+
+    #[test]
+    fn whitespace_separated_list() {
+        assert_eq!(parse("keep 3 5 7"), Some(keep_indices(&[3, 5, 7])));
+    }
+
+    #[test]
+    fn mixed_separators() {
+        assert_eq!(parse("keep 3, 5,7  9"), Some(keep_indices(&[3, 5, 7, 9])));
+    }
+
+    #[test]
+    fn case_insensitive_verb() {
+        assert_eq!(parse("KEEP 1"), Some(keep_indices(&[1])));
+        assert_eq!(
+            parse("Skip All"),
+            Some(KeepSkipCmd::Skip(KeepSkipTargets::All))
+        );
+    }
+
+    #[test]
+    fn leading_and_trailing_whitespace_tolerated() {
+        assert_eq!(parse("  keep 3  "), Some(keep_indices(&[3])));
+    }
+
+    #[test]
+    fn bare_verb_is_not_a_command() {
+        assert_eq!(parse("keep"), None);
+        assert_eq!(parse("skip"), None);
+        assert_eq!(parse("keep "), None);
+    }
+
+    #[test]
+    fn zero_index_rejected() {
+        assert_eq!(parse("keep 0"), None);
+        assert_eq!(parse("keep 0,1,2"), None);
+    }
+
+    #[test]
+    fn non_numeric_token_rejected() {
+        assert_eq!(parse("keep 3,a,5"), None);
+        assert_eq!(parse("keep three"), None);
+    }
+
+    #[test]
+    fn negative_rejected() {
+        assert_eq!(parse("keep -3"), None);
+    }
+
+    #[test]
+    fn unrelated_message_returns_none() {
+        assert_eq!(parse("thanks for the digest"), None);
+        assert_eq!(parse("/help"), None);
+        assert_eq!(parse(""), None);
+    }
+
+    #[test]
+    fn verb_only_at_start_no_substring_match() {
+        // "keepsake" must not be parsed as "keep sake".
+        assert_eq!(parse("keepsake"), None);
+        // "keep1" likewise — needs whitespace after the verb.
+        assert_eq!(parse("keep1"), None);
+    }
+
+    #[test]
+    fn embedded_keep_in_freeform_reply_is_not_a_command() {
+        // Strictness: only commands at message start. The user's
+        // reply "I'd like to keep 3 of these" must not resolve
+        // the digest.
+        assert_eq!(parse("I'd like to keep 3 of these"), None);
+    }
+}

--- a/crates/zirkel/src/keep_skip_interceptor.rs
+++ b/crates/zirkel/src/keep_skip_interceptor.rs
@@ -1,0 +1,501 @@
+//! Inbound interceptor: parses keep/skip replies on the agent
+//! receiving the digest, resolves the most recent unresolved digest
+//! for that agent, and short-circuits the LLM for this turn.
+//!
+//! Registered on the agent that's bound to the operator's digest
+//! channel (today: a single conversation per zirkel binding — see
+//! piece 5). Free-text replies that aren't keep/skip commands fall
+//! through to the LLM as normal.
+
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+use rusqlite::{Connection, params};
+use sha2::{Digest, Sha256};
+
+use wirken_agent::inbound_interceptor::{InboundInterceptor, InterceptResult, InterceptorContext};
+use wirken_audit::{HashHex, SessionEvent};
+
+use crate::digest_log::{Decision, DigestLogError, DigestRecord, most_recent_unresolved, resolve};
+use crate::keep_skip::{KeepSkipCmd, KeepSkipTargets, parse};
+
+/// Per-instance keep/skip handler. Holds an open SQLite handle to
+/// zirkel's per-skill DB; intercept calls take a brief sync mutex
+/// and don't await across SQL.
+pub struct KeepSkipInterceptor {
+    db_path: PathBuf,
+    conn: Mutex<Connection>,
+}
+
+impl KeepSkipInterceptor {
+    /// Open the zirkel aggregator DB. Migrations are the
+    /// orchestrator's responsibility — `open` does not run them.
+    pub fn open(db_path: &Path) -> rusqlite::Result<Self> {
+        let conn = Connection::open(db_path)?;
+        Ok(Self {
+            db_path: db_path.to_path_buf(),
+            conn: Mutex::new(conn),
+        })
+    }
+
+    pub fn db_path(&self) -> &Path {
+        &self.db_path
+    }
+}
+
+impl InboundInterceptor for KeepSkipInterceptor {
+    fn name(&self) -> &'static str {
+        "keep-skip"
+    }
+
+    fn intercept(&self, message: &str, ctx: &InterceptorContext<'_>) -> InterceptResult {
+        let Some(cmd) = parse(message) else {
+            return InterceptResult::Pass;
+        };
+        let mut guard = self.conn.lock().unwrap();
+        // The conn is held inside a Mutex; we need a &mut Connection
+        // for transactions inside resolve(). Take the lock for the
+        // duration of the SQL.
+        match handle(&mut guard, ctx.agent_id, cmd) {
+            Ok(outcome) => InterceptResult::Handle {
+                reply: outcome.reply,
+                audit_events: outcome.events,
+            },
+            Err(HandleError::NoActiveDigest) => InterceptResult::Handle {
+                reply: "No digest awaiting reply. The next daily digest will arrive on schedule."
+                    .to_string(),
+                audit_events: vec![],
+            },
+            Err(HandleError::IndexOutOfRange { idx, total }) => InterceptResult::Handle {
+                reply: format!(
+                    "Index {idx} is out of range — the most recent digest has {total} item{}.",
+                    if total == 1 { "" } else { "s" }
+                ),
+                audit_events: vec![],
+            },
+            Err(HandleError::Sqlite(e)) => {
+                tracing::error!("keep-skip: sqlite error: {e}");
+                InterceptResult::Handle {
+                    reply: format!("Could not record decision: {e}"),
+                    audit_events: vec![],
+                }
+            }
+        }
+    }
+}
+
+struct Outcome {
+    reply: String,
+    events: Vec<SessionEvent>,
+}
+
+#[derive(Debug, thiserror::Error)]
+enum HandleError {
+    #[error("no active digest")]
+    NoActiveDigest,
+    #[error("index {idx} out of range (digest has {total} items)")]
+    IndexOutOfRange { idx: u32, total: u32 },
+    #[error("sqlite: {0}")]
+    Sqlite(#[from] DigestLogError),
+}
+
+fn handle(conn: &mut Connection, agent_id: &str, cmd: KeepSkipCmd) -> Result<Outcome, HandleError> {
+    let digest = match most_recent_unresolved(conn, agent_id)? {
+        Some(d) => d,
+        None => return Err(HandleError::NoActiveDigest),
+    };
+    let total = digest.items.len() as u32;
+
+    // Validate listed indices before any write.
+    let listed = listed_indices(&cmd);
+    if let Some(out_of_range) = listed.iter().copied().find(|i| *i == 0 || *i > total) {
+        return Err(HandleError::IndexOutOfRange {
+            idx: out_of_range,
+            total,
+        });
+    }
+
+    // Materialise the per-item decision for every position in the
+    // digest, then apply.
+    let decisions = expand_decisions(&cmd, total);
+    let listed_unique = unique_listed(&cmd);
+
+    // Map idx → candidate_id once for the audit-event pass.
+    let idx_to_candidate: std::collections::HashMap<u32, i64> = digest
+        .items
+        .iter()
+        .map(|it| (it.idx, it.candidate_id))
+        .collect();
+
+    resolve(conn, digest.id, &decisions)?;
+
+    let events = build_session_events(conn, &digest, &decisions, &idx_to_candidate)?;
+    let reply = format_reply(&cmd, total, &listed_unique, &decisions);
+    Ok(Outcome { reply, events })
+}
+
+/// Indices the user named explicitly (as opposed to `all`). Empty
+/// for `keep all` / `skip all`.
+fn listed_indices(cmd: &KeepSkipCmd) -> Vec<u32> {
+    match cmd {
+        KeepSkipCmd::Keep(KeepSkipTargets::Indices(v))
+        | KeepSkipCmd::Skip(KeepSkipTargets::Indices(v)) => v.clone(),
+        _ => vec![],
+    }
+}
+
+/// De-duplicated, sorted version of `listed_indices`.
+fn unique_listed(cmd: &KeepSkipCmd) -> Vec<u32> {
+    let mut v = listed_indices(cmd);
+    v.sort_unstable();
+    v.dedup();
+    v
+}
+
+/// Materialise a decision for every position 1..=total based on the
+/// command. `keep N,M` means N+M kept and the rest skipped; `skip
+/// N,M` means N+M skipped and the rest kept; `keep all` / `skip all`
+/// is blanket.
+fn expand_decisions(cmd: &KeepSkipCmd, total: u32) -> Vec<(u32, Decision)> {
+    match cmd {
+        KeepSkipCmd::Keep(KeepSkipTargets::All) => {
+            (1..=total).map(|i| (i, Decision::Kept)).collect()
+        }
+        KeepSkipCmd::Skip(KeepSkipTargets::All) => {
+            (1..=total).map(|i| (i, Decision::Skipped)).collect()
+        }
+        KeepSkipCmd::Keep(KeepSkipTargets::Indices(v)) => {
+            let kept: std::collections::HashSet<u32> = v.iter().copied().collect();
+            (1..=total)
+                .map(|i| {
+                    if kept.contains(&i) {
+                        (i, Decision::Kept)
+                    } else {
+                        (i, Decision::Skipped)
+                    }
+                })
+                .collect()
+        }
+        KeepSkipCmd::Skip(KeepSkipTargets::Indices(v)) => {
+            let skipped: std::collections::HashSet<u32> = v.iter().copied().collect();
+            (1..=total)
+                .map(|i| {
+                    if skipped.contains(&i) {
+                        (i, Decision::Skipped)
+                    } else {
+                        (i, Decision::Kept)
+                    }
+                })
+                .collect()
+        }
+    }
+}
+
+fn build_session_events(
+    conn: &Connection,
+    digest: &DigestRecord,
+    decisions: &[(u32, Decision)],
+    idx_to_candidate: &std::collections::HashMap<u32, i64>,
+) -> Result<Vec<SessionEvent>, HandleError> {
+    let mut events = Vec::with_capacity(decisions.len());
+    for (idx, decision) in decisions {
+        let candidate_id = match idx_to_candidate.get(idx) {
+            Some(c) => *c,
+            None => continue,
+        };
+        match decision {
+            Decision::Kept => events.push(SessionEvent::CandidateKept {
+                run_id: digest.run_id.clone(),
+                candidate_id,
+                via: "signal-keep".into(),
+            }),
+            Decision::Skipped => {
+                let (url, source_name) = read_candidate_url(conn, candidate_id)?;
+                events.push(SessionEvent::CandidateSkipped {
+                    run_id: digest.run_id.clone(),
+                    url_hash: HashHex(hash_hex(url.as_bytes())),
+                    source: source_name,
+                    reason: "user_skipped".into(),
+                });
+            }
+        }
+    }
+    Ok(events)
+}
+
+fn read_candidate_url(
+    conn: &Connection,
+    candidate_id: i64,
+) -> Result<(String, String), HandleError> {
+    let row = conn.query_row(
+        "SELECT url, source_name FROM candidates WHERE id = ?1",
+        params![candidate_id],
+        |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)),
+    );
+    match row {
+        Ok(t) => Ok(t),
+        Err(rusqlite::Error::QueryReturnedNoRows) => Ok((String::new(), String::new())),
+        Err(e) => Err(HandleError::Sqlite(DigestLogError::Sqlite(e))),
+    }
+}
+
+fn hash_hex(bytes: &[u8]) -> String {
+    let digest = Sha256::digest(bytes);
+    let mut s = String::with_capacity(64);
+    for byte in digest {
+        use std::fmt::Write;
+        write!(&mut s, "{byte:02x}").unwrap();
+    }
+    s
+}
+
+fn format_reply(
+    cmd: &KeepSkipCmd,
+    total: u32,
+    listed_unique: &[u32],
+    decisions: &[(u32, Decision)],
+) -> String {
+    let kept_count = decisions
+        .iter()
+        .filter(|(_, d)| matches!(d, Decision::Kept))
+        .count();
+    let skipped_count = decisions.len() - kept_count;
+    match cmd {
+        KeepSkipCmd::Keep(KeepSkipTargets::All) => {
+            format!("✓ kept all {total}")
+        }
+        KeepSkipCmd::Skip(KeepSkipTargets::All) => {
+            format!("✓ skipped all {total}")
+        }
+        KeepSkipCmd::Keep(KeepSkipTargets::Indices(_)) => {
+            format!(
+                "✓ kept {} ({} skipped)",
+                format_idx_list(listed_unique),
+                skipped_count
+            )
+        }
+        KeepSkipCmd::Skip(KeepSkipTargets::Indices(_)) => {
+            format!(
+                "✓ skipped {} ({} kept)",
+                format_idx_list(listed_unique),
+                kept_count
+            )
+        }
+    }
+}
+
+fn format_idx_list(v: &[u32]) -> String {
+    v.iter()
+        .map(|n| n.to_string())
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::digest_log::record_sent;
+    use crate::schema::AGGREGATOR_MIGRATIONS;
+    use tempfile::TempDir;
+    use wirken_agent::skill::Skill;
+
+    fn open_migrated_with_seed(db_path: &Path, seed_candidates: &[(&str, &str)]) {
+        let mut conn = Connection::open(db_path).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE _migrations (idx INTEGER PRIMARY KEY, applied_at TEXT NOT NULL DEFAULT (datetime('now')))",
+        )
+        .unwrap();
+        let tx = conn.transaction().unwrap();
+        for (idx, sql) in AGGREGATOR_MIGRATIONS.iter().enumerate() {
+            tx.execute_batch(sql).unwrap();
+            tx.execute(
+                "INSERT INTO _migrations (idx) VALUES (?1)",
+                params![idx as i64],
+            )
+            .unwrap();
+        }
+        // Seed candidate rows so CandidateSkipped events can read
+        // url + source_name.
+        for (url, source) in seed_candidates {
+            tx.execute(
+                "INSERT INTO candidates (source_name, url, body, run_id, title) \
+                 VALUES (?1, ?2, '', 'run-1', 'title')",
+                params![source, url],
+            )
+            .unwrap();
+        }
+        tx.commit().unwrap();
+    }
+
+    fn ctx<'a>(agent_id: &'a str, skills: &'a [Skill]) -> InterceptorContext<'a> {
+        InterceptorContext { agent_id, skills }
+    }
+
+    fn make_three_item_digest(db_path: &Path) -> i64 {
+        open_migrated_with_seed(
+            db_path,
+            &[
+                ("https://a.example/1", "src-a"),
+                ("https://a.example/2", "src-a"),
+                ("https://b.example/3", "src-b"),
+            ],
+        );
+        let mut conn = Connection::open(db_path).unwrap();
+        record_sent(&mut conn, "run-1", "default", &[1, 2, 3]).unwrap()
+    }
+
+    #[test]
+    fn pass_through_for_unrelated_message() {
+        let dir = TempDir::new().unwrap();
+        let db = dir.path().join("agg.db");
+        make_three_item_digest(&db);
+        let interceptor = KeepSkipInterceptor::open(&db).unwrap();
+        let r = interceptor.intercept("hi there", &ctx("default", &[]));
+        assert!(matches!(r, InterceptResult::Pass));
+    }
+
+    #[test]
+    fn keep_indices_resolves_digest_and_emits_events() {
+        let dir = TempDir::new().unwrap();
+        let db = dir.path().join("agg.db");
+        let _digest_id = make_three_item_digest(&db);
+        let interceptor = KeepSkipInterceptor::open(&db).unwrap();
+        let r = interceptor.intercept("keep 1,3", &ctx("default", &[]));
+        match r {
+            InterceptResult::Handle {
+                reply,
+                audit_events,
+            } => {
+                assert!(reply.starts_with("✓ kept"), "reply was: {reply}");
+                assert_eq!(audit_events.len(), 3);
+                let kept = audit_events
+                    .iter()
+                    .filter(|e| matches!(e, SessionEvent::CandidateKept { .. }))
+                    .count();
+                let skipped = audit_events
+                    .iter()
+                    .filter(|e| matches!(e, SessionEvent::CandidateSkipped { .. }))
+                    .count();
+                assert_eq!(kept, 2);
+                assert_eq!(skipped, 1);
+            }
+            other => panic!("expected Handle, got {other:?}"),
+        }
+        // Subsequent reply gets "no active digest" — proves resolved.
+        let r2 = interceptor.intercept("keep 1", &ctx("default", &[]));
+        match r2 {
+            InterceptResult::Handle { reply, .. } => {
+                assert!(reply.starts_with("No digest"), "reply was: {reply}");
+            }
+            other => panic!("expected Handle, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn skip_all_marks_all_skipped() {
+        let dir = TempDir::new().unwrap();
+        let db = dir.path().join("agg.db");
+        make_three_item_digest(&db);
+        let interceptor = KeepSkipInterceptor::open(&db).unwrap();
+        let r = interceptor.intercept("skip all", &ctx("default", &[]));
+        match r {
+            InterceptResult::Handle {
+                reply,
+                audit_events,
+            } => {
+                assert_eq!(reply, "✓ skipped all 3");
+                assert_eq!(audit_events.len(), 3);
+                assert!(
+                    audit_events
+                        .iter()
+                        .all(|e| matches!(e, SessionEvent::CandidateSkipped { .. }))
+                );
+            }
+            other => panic!("expected Handle, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn keep_all_marks_all_kept() {
+        let dir = TempDir::new().unwrap();
+        let db = dir.path().join("agg.db");
+        make_three_item_digest(&db);
+        let interceptor = KeepSkipInterceptor::open(&db).unwrap();
+        let r = interceptor.intercept("keep all", &ctx("default", &[]));
+        match r {
+            InterceptResult::Handle {
+                reply,
+                audit_events,
+            } => {
+                assert_eq!(reply, "✓ kept all 3");
+                assert!(
+                    audit_events
+                        .iter()
+                        .all(|e| matches!(e, SessionEvent::CandidateKept { .. }))
+                );
+            }
+            other => panic!("expected Handle, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn out_of_range_index_surfaces_helpful_reply() {
+        let dir = TempDir::new().unwrap();
+        let db = dir.path().join("agg.db");
+        make_three_item_digest(&db);
+        let interceptor = KeepSkipInterceptor::open(&db).unwrap();
+        let r = interceptor.intercept("keep 99", &ctx("default", &[]));
+        match r {
+            InterceptResult::Handle { reply, .. } => {
+                assert!(reply.contains("99"), "reply was: {reply}");
+                assert!(reply.contains("3"), "reply was: {reply}");
+            }
+            other => panic!("expected Handle, got {other:?}"),
+        }
+        // The digest should NOT be resolved on out-of-range error.
+        let mut conn = Connection::open(&db).unwrap();
+        assert!(most_recent_unresolved(&conn, "default").unwrap().is_some());
+        // Hush unused-must-use warnings on our reborrow.
+        let _ = &mut conn;
+    }
+
+    #[test]
+    fn no_active_digest_yields_friendly_reply() {
+        let dir = TempDir::new().unwrap();
+        let db = dir.path().join("agg.db");
+        // Migrations only — no digest sent.
+        open_migrated_with_seed(&db, &[]);
+        let interceptor = KeepSkipInterceptor::open(&db).unwrap();
+        let r = interceptor.intercept("keep 1", &ctx("default", &[]));
+        match r {
+            InterceptResult::Handle { reply, .. } => {
+                assert!(reply.starts_with("No digest"), "reply was: {reply}");
+            }
+            other => panic!("expected Handle, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn agent_id_scopes_lookup() {
+        let dir = TempDir::new().unwrap();
+        let db = dir.path().join("agg.db");
+        // A digest exists for agent "alpha", but the interceptor is
+        // serving agent "beta" — beta should see "no active digest."
+        open_migrated_with_seed(&db, &[("https://x", "src-x")]);
+        let mut conn = Connection::open(&db).unwrap();
+        record_sent(&mut conn, "run-1", "alpha", &[1]).unwrap();
+        drop(conn);
+
+        let interceptor = KeepSkipInterceptor::open(&db).unwrap();
+        let r = interceptor.intercept("keep 1", &ctx("beta", &[]));
+        match r {
+            InterceptResult::Handle { reply, .. } => {
+                assert!(reply.starts_with("No digest"), "reply was: {reply}");
+            }
+            other => panic!("expected Handle, got {other:?}"),
+        }
+        // Alpha still has its digest pending.
+        let conn = Connection::open(&db).unwrap();
+        assert!(most_recent_unresolved(&conn, "alpha").unwrap().is_some());
+    }
+}

--- a/crates/zirkel/src/lib.rs
+++ b/crates/zirkel/src/lib.rs
@@ -13,12 +13,18 @@
 //! No LLM call (relevance scoring is Scope C). No clustering, no theme
 //! naming, no digest push.
 
+pub mod binding;
 pub mod cluster;
+pub mod digest;
+pub mod digest_log;
 pub mod embedding;
 pub mod fetcher;
 pub mod interests;
+pub mod keep_skip;
+pub mod keep_skip_interceptor;
 pub mod llm_score;
 pub mod orchestrator;
+pub mod push_client;
 pub mod schema;
 pub mod score;
 pub mod synthetic_tool;

--- a/crates/zirkel/src/push_client.rs
+++ b/crates/zirkel/src/push_client.rs
@@ -1,0 +1,201 @@
+//! Client for the orchestrator → gateway push socket.
+//!
+//! Connects to `<data_dir>/sockets/orchestrator.sock` (the same path
+//! the running gateway daemon binds in `wirken run`), sends one
+//! line-delimited JSON [`OrchestratorPushRequest`], reads one
+//! [`OrchestratorPushResponse`], and disconnects.
+//!
+//! See `crates/ipc/src/orchestrator.rs` for the wire types and the
+//! "this is not an adapter" trust posture; see
+//! `crates/cli/src/commands/run.rs` for the server side.
+
+use std::path::Path;
+
+use thiserror::Error;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::UnixStream;
+
+use wirken_ipc::orchestrator::{OrchestratorPushRequest, OrchestratorPushResponse};
+
+#[derive(Debug, Error)]
+pub enum PushError {
+    #[error("connect to {path}: {source}")]
+    Connect {
+        path: String,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("io: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("json: {0}")]
+    Json(#[from] serde_json::Error),
+    #[error("gateway returned no response (connection closed before reply)")]
+    NoResponse,
+    #[error("gateway rejected push: {0}")]
+    Rejected(String),
+}
+
+/// Push one outbound message to the running gateway.
+///
+/// On success the gateway has handed the frame to the live adapter
+/// writer for `channel`; the adapter is responsible for the actual
+/// delivery to the third-party platform. A successful return here
+/// therefore means "queued for the adapter," not "delivered to the
+/// recipient."
+pub async fn push(
+    socket_path: &Path,
+    channel: &str,
+    conversation_id: &str,
+    text: &str,
+) -> Result<(), PushError> {
+    push_with_reply_to(socket_path, channel, conversation_id, text, "").await
+}
+
+/// Same as [`push`] but lets the caller set `reply_to_id` (Slack
+/// thread root, Telegram reply target, etc.). Empty string means
+/// "no thread."
+pub async fn push_with_reply_to(
+    socket_path: &Path,
+    channel: &str,
+    conversation_id: &str,
+    text: &str,
+    reply_to_id: &str,
+) -> Result<(), PushError> {
+    let stream = UnixStream::connect(socket_path)
+        .await
+        .map_err(|e| PushError::Connect {
+            path: socket_path.display().to_string(),
+            source: e,
+        })?;
+    let (reader, mut writer) = stream.into_split();
+
+    let req = OrchestratorPushRequest {
+        channel: channel.to_string(),
+        conversation_id: conversation_id.to_string(),
+        text: text.to_string(),
+        reply_to_id: reply_to_id.to_string(),
+    };
+    let mut line = serde_json::to_string(&req)?;
+    line.push('\n');
+    writer.write_all(line.as_bytes()).await?;
+    // Half-close so the server's `read_line` returns rather than
+    // blocking; we still hold the read half.
+    writer.shutdown().await.ok();
+
+    let mut br = BufReader::new(reader);
+    let mut resp_line = String::new();
+    let n = br.read_line(&mut resp_line).await?;
+    if n == 0 {
+        return Err(PushError::NoResponse);
+    }
+    let resp: OrchestratorPushResponse = serde_json::from_str(resp_line.trim_end())?;
+    if resp.ok {
+        Ok(())
+    } else {
+        Err(PushError::Rejected(
+            resp.error.unwrap_or_else(|| "(no message)".into()),
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+    use tokio::net::UnixListener;
+
+    /// Spin up a fake server on a temp socket that reads one JSON
+    /// line and writes back a fixed response.
+    async fn spawn_fake_server(
+        socket_path: std::path::PathBuf,
+        response: OrchestratorPushResponse,
+    ) -> tokio::task::JoinHandle<Option<OrchestratorPushRequest>> {
+        let listener = UnixListener::bind(&socket_path).expect("bind fake server");
+        tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.ok()?;
+            let (reader, mut writer) = stream.into_split();
+            let mut br = BufReader::new(reader);
+            let mut line = String::new();
+            br.read_line(&mut line).await.ok()?;
+            let req: OrchestratorPushRequest = serde_json::from_str(line.trim_end()).ok()?;
+            let mut out = serde_json::to_string(&response).unwrap();
+            out.push('\n');
+            writer.write_all(out.as_bytes()).await.ok()?;
+            writer.shutdown().await.ok();
+            Some(req)
+        })
+    }
+
+    #[tokio::test]
+    async fn push_sends_request_and_parses_ok_response() {
+        let dir = TempDir::new().unwrap();
+        let sock = dir.path().join("orch.sock");
+        let server = spawn_fake_server(
+            sock.clone(),
+            OrchestratorPushResponse {
+                ok: true,
+                error: None,
+            },
+        )
+        .await;
+
+        push(&sock, "signal", "+15551234567", "hi").await.unwrap();
+        let req = server.await.unwrap().expect("server received request");
+        assert_eq!(req.channel, "signal");
+        assert_eq!(req.conversation_id, "+15551234567");
+        assert_eq!(req.text, "hi");
+        assert_eq!(req.reply_to_id, "");
+    }
+
+    #[tokio::test]
+    async fn push_surfaces_rejected_response() {
+        let dir = TempDir::new().unwrap();
+        let sock = dir.path().join("orch.sock");
+        let _server = spawn_fake_server(
+            sock.clone(),
+            OrchestratorPushResponse {
+                ok: false,
+                error: Some("no adapter connected on channel 'signal'".into()),
+            },
+        )
+        .await;
+
+        let err = push(&sock, "signal", "+15551234567", "hi")
+            .await
+            .unwrap_err();
+        match err {
+            PushError::Rejected(msg) => {
+                assert!(msg.contains("no adapter connected"));
+            }
+            other => panic!("expected Rejected, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn push_with_reply_to_propagates() {
+        let dir = TempDir::new().unwrap();
+        let sock = dir.path().join("orch.sock");
+        let server = spawn_fake_server(
+            sock.clone(),
+            OrchestratorPushResponse {
+                ok: true,
+                error: None,
+            },
+        )
+        .await;
+
+        push_with_reply_to(&sock, "slack", "C123", "hello", "1234.5678")
+            .await
+            .unwrap();
+        let req = server.await.unwrap().unwrap();
+        assert_eq!(req.reply_to_id, "1234.5678");
+    }
+
+    #[tokio::test]
+    async fn missing_socket_returns_connect_error() {
+        let dir = TempDir::new().unwrap();
+        let sock = dir.path().join("does-not-exist.sock");
+        let err = push(&sock, "signal", "+1", "hi").await.unwrap_err();
+        assert!(matches!(err, PushError::Connect { .. }));
+    }
+}

--- a/crates/zirkel/src/schema.rs
+++ b/crates/zirkel/src/schema.rs
@@ -93,4 +93,45 @@ pub const AGGREGATOR_MIGRATIONS: &[&str] = &[
     )",
     "CREATE INDEX idx_themes_run ON themes(run_id)",
     "CREATE INDEX idx_candidates_cluster ON candidates(cluster_id)",
+    // 7 — C-Signal: per-digest record + per-item position. The
+    // digest renderer (piece 4) writes one `digests` row when it
+    // pushes to the operator's channel, plus one `digest_items` row
+    // per included candidate at the same 1-indexed position the
+    // operator sees in the rendered text. The keep/skip interceptor
+    // (piece 3) resolves a digest by looking up the most recent
+    // unresolved row for the agent and updating each item's
+    // `decision`.
+    //
+    // `agent_id` rather than `(channel, conversation_id)` because
+    // the agent_id is what the InboundInterceptor context already
+    // carries; today's bind keeps a single zirkel-bound conversation
+    // per agent, so the agent scope is sufficient discrimination.
+    "CREATE TABLE digests ( \
+        id            INTEGER PRIMARY KEY AUTOINCREMENT, \
+        run_id        TEXT NOT NULL, \
+        agent_id      TEXT NOT NULL, \
+        sent_at       TEXT NOT NULL DEFAULT (datetime('now')), \
+        resolved_at   TEXT \
+    )",
+    "CREATE INDEX idx_digests_lookup ON digests(agent_id, resolved_at, sent_at)",
+    "CREATE TABLE digest_items ( \
+        digest_id     INTEGER NOT NULL, \
+        idx           INTEGER NOT NULL, \
+        candidate_id  INTEGER NOT NULL, \
+        decision      TEXT, \
+        PRIMARY KEY (digest_id, idx), \
+        FOREIGN KEY (digest_id) REFERENCES digests(id) \
+    )",
+    "CREATE INDEX idx_digest_items_candidate ON digest_items(candidate_id)",
+    // 8 — C-Signal bindings. `wirken zirkel bind` writes one row;
+    // `wirken zirkel run`'s push step reads it. Keyed by `agent_id`
+    // because multi-zirkel is not in scope today (one bound
+    // conversation per agent is the contract); the CLI enforces
+    // idempotency / --force semantics on top.
+    "CREATE TABLE bindings ( \
+        agent_id         TEXT PRIMARY KEY, \
+        channel          TEXT NOT NULL, \
+        conversation_id  TEXT NOT NULL, \
+        bound_at         TEXT NOT NULL DEFAULT (datetime('now')) \
+    )",
 ];

--- a/crates/zirkel/tests/e2e_digest_keepskip.rs
+++ b/crates/zirkel/tests/e2e_digest_keepskip.rs
@@ -1,0 +1,373 @@
+//! End-to-end test for the C-Signal slice: render → push → record →
+//! keep/skip round-trip.
+//!
+//! What this covers (and why):
+//!
+//! - The renderer numbers candidates 1..N in a specific order. The
+//!   operator's reply against those numbers must map back to the
+//!   *same* candidate ids; the contract that holds this together is
+//!   `digest::render` → `digest_log::record_sent` (same ordered ids)
+//!   → `digest_log::most_recent_unresolved` (preserves order) →
+//!   `KeepSkipInterceptor` (1-indexed lookup against that order).
+//!
+//! - The push request the gateway receives carries the rendered text
+//!   for the bound channel + conversation. The push_client unit tests
+//!   exercise the wire format against a fake server; this test
+//!   exercises that the *digest* output reaches the wire correctly.
+//!
+//! - A subsequent keep/skip command resolves the most recent
+//!   unresolved digest exactly once. Replying again surfaces "no
+//!   digest awaiting reply."
+//!
+//! What this does NOT cover:
+//!
+//! - The orchestrator pipeline (fetch / screen / LLM / cluster /
+//!   theme-name). Those have their own end-to-end tests in
+//!   `orchestrator::tests`. We seed candidate rows directly so this
+//!   test runs without an HTTP transport, an Ollama instance, or a
+//!   network.
+//!
+//! - The gateway → adapter forwarding inside `wirken run`. Covered by
+//!   `OutboundDispatcher` tests + `push_client` loopback tests.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use rusqlite::{Connection, params};
+use tempfile::TempDir;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::UnixListener;
+use tokio::sync::Mutex;
+
+use wirken_agent::inbound_interceptor::{InboundInterceptor, InterceptResult, InterceptorContext};
+use wirken_audit::SessionEvent;
+use wirken_ipc::orchestrator::{OrchestratorPushRequest, OrchestratorPushResponse};
+use wirken_zirkel::binding::{Binding, record as record_binding};
+use wirken_zirkel::digest::{RenderOptions, load_run, render};
+use wirken_zirkel::digest_log::{Decision, most_recent_unresolved, record_sent};
+use wirken_zirkel::keep_skip_interceptor::KeepSkipInterceptor;
+use wirken_zirkel::push_client::push;
+use wirken_zirkel::schema::AGGREGATOR_MIGRATIONS;
+
+/// Spin up a fake "gateway" that accepts one push, captures it, and
+/// replies with `{ ok: true }`. Returns a join handle that yields the
+/// received request.
+fn spawn_fake_gateway(
+    socket_path: std::path::PathBuf,
+    captured: Arc<Mutex<Option<OrchestratorPushRequest>>>,
+) -> tokio::task::JoinHandle<()> {
+    let listener = UnixListener::bind(&socket_path).expect("bind fake gateway socket");
+    tokio::spawn(async move {
+        let (stream, _) = match listener.accept().await {
+            Ok(s) => s,
+            Err(_) => return,
+        };
+        let (reader, mut writer) = stream.into_split();
+        let mut br = BufReader::new(reader);
+        let mut line = String::new();
+        if br.read_line(&mut line).await.is_err() {
+            return;
+        }
+        if let Ok(req) = serde_json::from_str::<OrchestratorPushRequest>(line.trim_end()) {
+            *captured.lock().await = Some(req);
+        }
+        let resp = OrchestratorPushResponse {
+            ok: true,
+            error: None,
+        };
+        let mut out = serde_json::to_string(&resp).unwrap();
+        out.push('\n');
+        let _ = writer.write_all(out.as_bytes()).await;
+        let _ = writer.shutdown().await;
+    })
+}
+
+fn migrate(conn: &mut Connection) {
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS _migrations (idx INTEGER PRIMARY KEY, applied_at TEXT NOT NULL DEFAULT (datetime('now')))",
+    ).unwrap();
+    let tx = conn.transaction().unwrap();
+    for (idx, sql) in AGGREGATOR_MIGRATIONS.iter().enumerate() {
+        tx.execute_batch(sql).unwrap();
+        tx.execute(
+            "INSERT OR IGNORE INTO _migrations (idx) VALUES (?1)",
+            params![idx as i64],
+        )
+        .unwrap();
+    }
+    tx.commit().unwrap();
+}
+
+#[allow(clippy::too_many_arguments)]
+fn seed_candidate(
+    conn: &Connection,
+    run_id: &str,
+    title: &str,
+    url: &str,
+    source: &str,
+    score: f64,
+    why: &str,
+    cluster_id: Option<i64>,
+) -> i64 {
+    conn.execute(
+        "INSERT INTO candidates (source_name, url, body, run_id, title, llm_relevance_score, \
+         llm_why_surfaced, cluster_id) \
+         VALUES (?1, ?2, '', ?3, ?4, ?5, ?6, ?7)",
+        params![source, url, run_id, title, score, why, cluster_id],
+    )
+    .unwrap();
+    conn.last_insert_rowid()
+}
+
+fn seed_theme(conn: &Connection, run_id: &str, name: &str, members: i64) -> i64 {
+    conn.execute(
+        "INSERT INTO themes (run_id, name, member_count) VALUES (?1, ?2, ?3)",
+        params![run_id, name, members],
+    )
+    .unwrap();
+    conn.last_insert_rowid()
+}
+
+fn ctx_for<'a>(agent_id: &'a str) -> InterceptorContext<'a> {
+    InterceptorContext {
+        agent_id,
+        skills: &[],
+    }
+}
+
+fn open_zirkel_db(path: &Path) -> Connection {
+    let mut conn = Connection::open(path).expect("open db");
+    migrate(&mut conn);
+    conn
+}
+
+#[tokio::test]
+async fn render_push_record_keepskip_round_trip() {
+    let tmp = TempDir::new().unwrap();
+    let db_path = tmp.path().join("aggregator.db");
+    let socket_path = tmp.path().join("orchestrator.sock");
+
+    // ---------- Seed: two-theme run with five candidates -------------
+    let conn = open_zirkel_db(&db_path);
+    let run_id = "run-e2e-1";
+    let theme_pe = seed_theme(&conn, run_id, "Privacy enforcement", 3);
+    let theme_cb = seed_theme(&conn, run_id, "Cross-border transfers", 2);
+
+    // PE: 3 items, scored 90/85/80
+    let pe1 = seed_candidate(
+        &conn,
+        run_id,
+        "EU AG opinion on adtech consent",
+        "https://example.com/pe/1",
+        "privacy-news",
+        90.0,
+        "directly responsive to consent-banner interest",
+        Some(theme_pe),
+    );
+    let pe2 = seed_candidate(
+        &conn,
+        run_id,
+        "DPA fines retailer 2M",
+        "https://example.com/pe/2",
+        "privacy-news",
+        85.0,
+        "high-profile enforcement against tracking",
+        Some(theme_pe),
+    );
+    let pe3 = seed_candidate(
+        &conn,
+        run_id,
+        "ICO updates cookie guidance",
+        "https://example.com/pe/3",
+        "ico-blog",
+        80.0,
+        "regulator guidance pointer",
+        Some(theme_pe),
+    );
+    // CB: 2 items, scored 70/65
+    let cb1 = seed_candidate(
+        &conn,
+        run_id,
+        "Adequacy decision review starts",
+        "https://example.com/cb/1",
+        "eur-lex",
+        70.0,
+        "covers your transfer-impact assessment topic",
+        Some(theme_cb),
+    );
+    let cb2 = seed_candidate(
+        &conn,
+        run_id,
+        "SCC guidance update Q2",
+        "https://example.com/cb/2",
+        "edpb-news",
+        65.0,
+        "follow-up to last quarter's SCC update",
+        Some(theme_cb),
+    );
+
+    // ---------- Bind for an "operator-default" agent -----------------
+    let bound_agent = "default";
+    record_binding(
+        &conn,
+        &Binding {
+            agent_id: bound_agent.into(),
+            channel: "signal".into(),
+            conversation_id: "+15551234567".into(),
+        },
+    )
+    .unwrap();
+    drop(conn);
+
+    // ---------- Render -----------------------------------------------
+    let conn = Connection::open(&db_path).unwrap();
+    let (rows, themes) = load_run(&conn, run_id).unwrap();
+    let opts = RenderOptions {
+        date: Some("2026-04-29".into()),
+        ..RenderOptions::default()
+    };
+    let rendered = render(&rows, &themes, &opts).unwrap();
+    drop(conn);
+
+    // Two themes → both headers present; numbering is 1..5 across
+    // the whole digest, biggest theme first.
+    assert!(rendered.text.contains("— Privacy enforcement (3) —"));
+    assert!(rendered.text.contains("— Cross-border transfers (2) —"));
+    assert!(rendered.text.contains("1. EU AG opinion on adtech consent"));
+    assert!(rendered.text.contains("4. Adequacy decision review starts"));
+    assert!(rendered.text.contains("5. SCC guidance update Q2"));
+    assert!(rendered.text.contains("Daily digest — 2026-04-29"));
+    assert_eq!(
+        rendered.ordered_candidate_ids,
+        vec![pe1, pe2, pe3, cb1, cb2]
+    );
+
+    // ---------- Push to fake gateway --------------------------------
+    let captured = Arc::new(Mutex::new(None));
+    let server = spawn_fake_gateway(socket_path.clone(), captured.clone());
+
+    push(&socket_path, "signal", "+15551234567", &rendered.text)
+        .await
+        .expect("push succeeds");
+    server.await.unwrap();
+
+    let req = captured
+        .lock()
+        .await
+        .clone()
+        .expect("server captured request");
+    assert_eq!(req.channel, "signal");
+    assert_eq!(req.conversation_id, "+15551234567");
+    assert_eq!(req.text, rendered.text);
+
+    // ---------- Record sent so keep/skip can resolve it -------------
+    let mut conn = Connection::open(&db_path).unwrap();
+    let digest_id = record_sent(
+        &mut conn,
+        run_id,
+        bound_agent,
+        &rendered.ordered_candidate_ids,
+    )
+    .unwrap();
+    drop(conn);
+
+    // ---------- Operator replies "keep 1,3" -------------------------
+    // Numbering is operator-visible: 1 = PE first item, 3 = PE third.
+    // Items 2, 4, 5 should land as skipped.
+    let interceptor = KeepSkipInterceptor::open(&db_path).expect("open interceptor");
+    let result = interceptor.intercept("keep 1,3", &ctx_for(bound_agent));
+
+    let (reply, events) = match result {
+        InterceptResult::Handle {
+            reply,
+            audit_events,
+        } => (reply, audit_events),
+        other => panic!("expected Handle, got {other:?}"),
+    };
+    assert!(reply.starts_with("✓ kept 1, 3"), "reply was: {reply}");
+    assert!(reply.contains("3 skipped"), "reply was: {reply}");
+    assert_eq!(events.len(), 5);
+
+    // ---------- Verify per-item decisions in DB ----------------------
+    let conn = Connection::open(&db_path).unwrap();
+    let decisions: Vec<(i64, Option<String>)> = {
+        let mut stmt = conn
+            .prepare("SELECT idx, decision FROM digest_items WHERE digest_id = ?1 ORDER BY idx")
+            .unwrap();
+        stmt.query_map(params![digest_id], |r| {
+            Ok((r.get::<_, i64>(0)?, r.get::<_, Option<String>>(1)?))
+        })
+        .unwrap()
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap()
+    };
+    assert_eq!(decisions[0], (1, Some(Decision::Kept.as_db_str().into())));
+    assert_eq!(
+        decisions[1],
+        (2, Some(Decision::Skipped.as_db_str().into()))
+    );
+    assert_eq!(decisions[2], (3, Some(Decision::Kept.as_db_str().into())));
+    assert_eq!(
+        decisions[3],
+        (4, Some(Decision::Skipped.as_db_str().into()))
+    );
+    assert_eq!(
+        decisions[4],
+        (5, Some(Decision::Skipped.as_db_str().into()))
+    );
+
+    // ---------- Verify session events match decisions ---------------
+    let kept_count = events
+        .iter()
+        .filter(|e| matches!(e, SessionEvent::CandidateKept { .. }))
+        .count();
+    let skipped_count = events
+        .iter()
+        .filter(|e| matches!(e, SessionEvent::CandidateSkipped { .. }))
+        .count();
+    assert_eq!(kept_count, 2);
+    assert_eq!(skipped_count, 3);
+
+    // The CandidateKept events should reference pe1 and pe3 by id.
+    let kept_ids: Vec<i64> = events
+        .iter()
+        .filter_map(|e| match e {
+            SessionEvent::CandidateKept { candidate_id, .. } => Some(*candidate_id),
+            _ => None,
+        })
+        .collect();
+    assert!(kept_ids.contains(&pe1));
+    assert!(kept_ids.contains(&pe3));
+
+    // ---------- Reply again: digest is resolved, no-op ---------------
+    let result_again = interceptor.intercept("keep 2", &ctx_for(bound_agent));
+    let reply_again = match result_again {
+        InterceptResult::Handle { reply, .. } => reply,
+        other => panic!("expected Handle, got {other:?}"),
+    };
+    assert!(
+        reply_again.starts_with("No digest awaiting reply"),
+        "reply was: {reply_again}"
+    );
+
+    // ---------- Out-of-range index doesn't resolve a fresh digest ---
+    // Send a new digest and verify "keep 99" leaves it pending.
+    let mut conn = Connection::open(&db_path).unwrap();
+    record_sent(&mut conn, run_id, bound_agent, &[pe1, pe2]).unwrap();
+    drop(conn);
+    let result_oor = interceptor.intercept("keep 99", &ctx_for(bound_agent));
+    match result_oor {
+        InterceptResult::Handle { reply, .. } => {
+            assert!(reply.contains("99"), "reply was: {reply}");
+            assert!(reply.contains("2 items"), "reply was: {reply}");
+        }
+        other => panic!("expected Handle, got {other:?}"),
+    }
+    let conn = Connection::open(&db_path).unwrap();
+    assert!(
+        most_recent_unresolved(&conn, bound_agent)
+            .unwrap()
+            .is_some(),
+        "out-of-range reply must leave the digest unresolved"
+    );
+}


### PR DESCRIPTION
## What this slice delivers

Lawyer-facing surface lands. After this PR, an operator can:

1. Run \`wirken zirkel bind --channel signal --conversation +1...\` to point the daily digest at their thread.
2. Have \`wirken zirkel run\` (cron-fired) fetch, score, cluster, render a numbered digest, and push it to the bound channel.
3. Reply \`keep 1,3\` / \`skip all\` / etc. on the platform, and have those decisions resolve the digest the operator was actually shown — same numbering, same items.

The integration test \`tests/e2e_digest_keepskip.rs\` walks that whole chain (render → push → record → keep/skip → verify per-item decisions in DB and emitted SessionEvents) without needing the orchestrator pipeline, an LLM, or a network.

## Invariants the wiring establishes

- **Digest numbering is the contract.** \`render\` produces \`(text, ordered_candidate_ids)\`; \`record_sent\` persists those ids at exactly the 1-indexed positions the text shows. The keep/skip interceptor's lookup is index → digest_items.idx → candidate_id. No rewriting of indices in flight, no race window where the operator could see one set of numbers and have their reply land against a different set.

- **Push first, record second.** A failed push must not leave a phantom digest_log entry — otherwise the keep/skip interceptor would later resolve a digest the operator never saw. The cron-fail-soft choice (gateway down → run still completes, prints status, doesn't abort) preserves the day's fetch work; the lawyer gets the digest tomorrow when the gateway is back.

- **Out-of-range index does not consume a digest.** \`keep 99\` against a 5-item digest returns a friendly out-of-range message and leaves \`resolved_at\` NULL. A typo can't silently waste the day's queue.

- **Same-target re-bind is a no-op; different-target re-bind needs \`--force\`.** No accidental rerouting of the digest by tab-completion on a wrong conversation id.

- **Orchestrator socket is local-only.** \`<data_dir>/sockets/orchestrator.sock\` is bound at 0600; the listener also runs an SO_PEERCRED check on every accept. The threat model is same-UID-same-machine — adapters cross trust boundaries, this doesn't (commented at the bind site).

## The Box→Arc refactor

Agent's \`interceptors\` field went from \`Vec<Box<dyn InboundInterceptor>>\` to \`Vec<Arc<dyn InboundInterceptor>>\`, plus a matching change to \`run_chain\` and 9 \`AgentStaticConfig\` construction sites. The diff size in agent-crate files is forced by sharing one keep/skip interceptor instance across per-conversation wakes — opening a fresh SQLite connection per wake would have been wrong (each wake creates a per-conversation Agent; the interceptor's database handle is process-scoped, not conversation-scoped). Pure refactor with no behavioral change; the 265-test agent crate is unchanged green.

## Live-rebind decision

\`wirken zirkel bind\` writes the row and warns if the daemon is up:

> Note: \`wirken run\` is currently up. Restart it for the new binding to take effect — the keep/skip interceptor is attached at agent startup.

Hot rebind would require a process-wide interceptor registry mutated via separate IPC — real code paying for a rare operation. Operators running \`bind\` are not at the keyboard for the wrong reason; restart-after-bind is fine. Decision captured in code comments at both ends (bind command's post-write block and run.rs's interceptor wire-up loop) so this doesn't get \"fixed\" later without intent.

## Test plan

- [ ] \`cargo fmt --check\` clean
- [ ] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [ ] \`cargo test --workspace\` clean (95 zirkel tests up from 75; e2e test passes)
- [ ] Manual: \`wirken zirkel bind --channel signal --conversation +1...\` then \`wirken zirkel status\` shows the binding
- [ ] Manual: re-bind with same target prints \"Already bound\"; with different target requires \`--force\`
- [ ] Manual: \`wirken zirkel run\` with binding pushes a digest to a configured Signal adapter (requires \`wirken run\` daemon up + \`signal-cli\` adapter)
- [ ] Manual: reply \`keep 1,3\` on Signal; observe \"✓ kept 1, 3\" reply and per-item decisions in audit log