### PR TITLE
zirkel scope c-librarian: sqlite_query tool with named queries; librarian skill

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6497,6 +6497,7 @@ dependencies = [
  "lru",
  "rand 0.10.1",
  "reqwest 0.13.2",
+ "rusqlite",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/crates/agent/Cargo.toml
+++ b/crates/agent/Cargo.toml
@@ -38,6 +38,11 @@ futures-util = "0.3"
 # through Dir methods that refuse paths escaping the workspace. Used
 # instead of hand-rolled canonicalize + symlink_metadata checks.
 cap-std = "3.4"
+# Read-only SQLite handle for the `sqlite_query` librarian tool. The
+# tool opens a per-call connection with `SQLITE_OPEN_READ_ONLY` so
+# writes are refused at the connection layer, not by string-pattern
+# checks on the SQL.
+rusqlite = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/agent/src/factory.rs
+++ b/crates/agent/src/factory.rs
@@ -154,6 +154,13 @@ pub struct AgentStaticConfig {
     ///
     /// [`InboundInterceptor`]: crate::inbound_interceptor::InboundInterceptor
     pub extra_interceptors: Vec<Arc<dyn crate::inbound_interceptor::InboundInterceptor>>,
+    /// Path to the zirkel aggregator SQLite database, configured for
+    /// agents that carry the librarian skill. The factory calls
+    /// [`crate::runtime::Agent::attach_zirkel_db`] on every waked
+    /// Agent when this is `Some`. None disables the `sqlite_query`
+    /// tool for the agent (the tool returns a clear error if invoked
+    /// without the path bound).
+    pub zirkel_db_path: Option<PathBuf>,
 }
 
 /// Cache mode resolved at factory construction time. Tests pass it
@@ -342,6 +349,9 @@ impl AgentFactory {
         agent.attach_subagent_ceilings(cfg.allowed_subagents.clone());
         for interceptor in &cfg.extra_interceptors {
             agent.attach_interceptor(interceptor.clone());
+        }
+        if let Some(path) = &cfg.zirkel_db_path {
+            agent.attach_zirkel_db(path.clone());
         }
 
         let arc = Arc::new(AsyncMutex::new(agent));

--- a/crates/agent/src/runtime.rs
+++ b/crates/agent/src/runtime.rs
@@ -463,6 +463,15 @@ impl Agent {
     /// tools and logs them on attach. Operators see this line on
     /// every `wirken run` and can review which names run
     /// unprivileged.
+    /// Configure the path the `sqlite_query` librarian tool opens.
+    /// Called by the factory at wake time when the agent's static
+    /// config names a zirkel-bound database. The librarian skill's
+    /// `tools.allow` list still gates whether the LLM can see the
+    /// tool; this method just tells the tool which file to open.
+    pub fn attach_zirkel_db(&mut self, path: std::path::PathBuf) {
+        self.tools.set_zirkel_db_path(path);
+    }
+
     pub fn attach_mcp(&mut self, client: Arc<tokio::sync::Mutex<McpProxyClient>>) {
         self.mcp = Some(client.clone());
         let agent_id = self.id.clone();

--- a/crates/agent/src/tests.rs
+++ b/crates/agent/src/tests.rs
@@ -1234,6 +1234,7 @@ mod wake {
                 allowed_subagents: Default::default(),
                 sandbox: Default::default(),
                 extra_interceptors: vec![],
+                zirkel_db_path: None,
             },
         );
         (AgentFactory::new(configs, log, None), tmp)
@@ -1570,6 +1571,7 @@ mod wake {
                 allowed_subagents: Default::default(),
                 sandbox: Default::default(),
                 extra_interceptors: vec![],
+                zirkel_db_path: None,
             },
         );
         let factory = AgentFactory::with_options(configs, log, None, None, CacheMode::Drop, 64);
@@ -1634,6 +1636,7 @@ mod subagent {
                 allowed_subagents: parent_ceilings,
                 sandbox: Default::default(),
                 extra_interceptors: vec![],
+                zirkel_db_path: None,
             },
         );
         configs.insert(
@@ -1651,6 +1654,7 @@ mod subagent {
                 allowed_subagents: BTreeMap::new(),
                 sandbox: Default::default(),
                 extra_interceptors: vec![],
+                zirkel_db_path: None,
             },
         );
         (AgentFactory::new(configs, log, None), tmp)
@@ -4603,6 +4607,7 @@ mod per_channel_llm_override {
                 allowed_subagents: Default::default(),
                 sandbox: Default::default(),
                 extra_interceptors: vec![],
+                zirkel_db_path: None,
             },
         );
         let factory = AgentFactory::with_options(configs, log, None, None, CacheMode::Drop, 4);
@@ -4741,6 +4746,7 @@ mod per_channel_llm_override {
                 allowed_subagents: Default::default(),
                 sandbox: Default::default(),
                 extra_interceptors: vec![],
+                zirkel_db_path: None,
             },
         );
         let factory =
@@ -4894,6 +4900,7 @@ mod org_tool_policy {
                 allowed_subagents: Default::default(),
                 sandbox: Default::default(),
                 extra_interceptors: vec![],
+                zirkel_db_path: None,
             },
         );
         let factory =
@@ -5020,5 +5027,627 @@ mod org_tool_policy {
             assert!(!r.output.contains("blocked by org policy"));
             assert!(!r.output.contains("not in the org allowed_tools list"));
         }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// C-Librarian piece 1: sqlite_query named-query tool
+// ---------------------------------------------------------------------------
+
+mod sqlite_query {
+    use std::path::PathBuf;
+
+    use rusqlite::params;
+    use tempfile::TempDir;
+
+    use crate::tool::{ToolConfig, ToolRegistry};
+
+    /// Build a zirkel-shaped fixture DB at `db_path` with two
+    /// resolved digests covering five kept items across two
+    /// runs and two themes. The schema mirrors what
+    /// `wirken_zirkel::schema::AGGREGATOR_MIGRATIONS` produces;
+    /// repeated here so the agent crate doesn't depend on zirkel
+    /// for its own tests.
+    fn seed_fixture_db(db_path: &std::path::Path) {
+        let conn = rusqlite::Connection::open(db_path).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE candidates ( \
+                id INTEGER PRIMARY KEY AUTOINCREMENT, \
+                source_name TEXT NOT NULL, \
+                url TEXT NOT NULL, \
+                fetched_at TEXT NOT NULL DEFAULT (datetime('now')), \
+                body TEXT NOT NULL, \
+                run_id TEXT NOT NULL DEFAULT '', \
+                title TEXT NOT NULL DEFAULT '', \
+                published_at TEXT, \
+                matched_keywords TEXT NOT NULL DEFAULT '[]', \
+                keyword_match_score INTEGER NOT NULL DEFAULT 0, \
+                llm_relevance_score REAL, \
+                llm_why_surfaced TEXT, \
+                cluster_id INTEGER, \
+                source_metadata TEXT NOT NULL DEFAULT '{}' \
+            ); \
+            CREATE TABLE themes ( \
+                id INTEGER PRIMARY KEY AUTOINCREMENT, \
+                run_id TEXT NOT NULL, \
+                name TEXT NOT NULL, \
+                member_count INTEGER NOT NULL, \
+                created_at TEXT NOT NULL DEFAULT (datetime('now')) \
+            ); \
+            CREATE TABLE digests ( \
+                id INTEGER PRIMARY KEY AUTOINCREMENT, \
+                run_id TEXT NOT NULL, \
+                agent_id TEXT NOT NULL, \
+                sent_at TEXT NOT NULL DEFAULT (datetime('now')), \
+                resolved_at TEXT \
+            ); \
+            CREATE TABLE digest_items ( \
+                digest_id INTEGER NOT NULL, \
+                idx INTEGER NOT NULL, \
+                candidate_id INTEGER NOT NULL, \
+                decision TEXT, \
+                PRIMARY KEY (digest_id, idx) \
+            );",
+        )
+        .unwrap();
+
+        // Two themes for run-1.
+        conn.execute(
+            "INSERT INTO themes (id, run_id, name, member_count) VALUES (1, 'run-1', 'Privacy enforcement', 3)",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO themes (id, run_id, name, member_count) VALUES (2, 'run-1', 'Cross-border transfers', 2)",
+            [],
+        )
+        .unwrap();
+
+        // Five candidates in run-1.
+        let candidates = [
+            (
+                1,
+                "ftc-press",
+                "https://x/1",
+                "FTC enforcement on adtech",
+                90.0,
+                "consent-banner topic",
+                1i64,
+            ),
+            (
+                2,
+                "ftc-press",
+                "https://x/2",
+                "DPA fines retailer",
+                85.0,
+                "tracking enforcement",
+                1,
+            ),
+            (
+                3,
+                "ico-blog",
+                "https://x/3",
+                "ICO updates cookie guidance",
+                80.0,
+                "regulator guidance",
+                1,
+            ),
+            (
+                4,
+                "eur-lex",
+                "https://x/4",
+                "Adequacy decision review starts",
+                70.0,
+                "transfer-impact assessment",
+                2,
+            ),
+            (
+                5,
+                "edpb-news",
+                "https://x/5",
+                "SCC guidance update",
+                65.0,
+                "follow-up to last quarter",
+                2,
+            ),
+        ];
+        for (id, source, url, title, score, why, cluster) in candidates {
+            conn.execute(
+                "INSERT INTO candidates (id, source_name, url, body, run_id, title, published_at, llm_relevance_score, llm_why_surfaced, cluster_id) \
+                 VALUES (?1, ?2, ?3, ?4, 'run-1', ?5, '2026-04-29', ?6, ?7, ?8)",
+                params![id, source, url, format!("body of {title}"), title, score, why, cluster],
+            )
+            .unwrap();
+        }
+
+        // One resolved digest for agent 'default' covering all 5 items.
+        // 3 kept (ids 1, 3, 4), 2 skipped (ids 2, 5).
+        conn.execute(
+            "INSERT INTO digests (id, run_id, agent_id, sent_at, resolved_at) \
+             VALUES (1, 'run-1', 'default', datetime('now', '-1 day'), datetime('now', '-1 day'))",
+            [],
+        )
+        .unwrap();
+        let decisions = [
+            (1, 1i64, 1i64, "kept"),
+            (1, 2, 2, "skipped"),
+            (1, 3, 3, "kept"),
+            (1, 4, 4, "kept"),
+            (1, 5, 5, "skipped"),
+        ];
+        for (digest_id, idx, candidate_id, decision) in decisions {
+            conn.execute(
+                "INSERT INTO digest_items (digest_id, idx, candidate_id, decision) VALUES (?1, ?2, ?3, ?4)",
+                params![digest_id, idx, candidate_id, decision],
+            )
+            .unwrap();
+        }
+    }
+
+    fn build_registry(db_path: PathBuf) -> ToolRegistry {
+        let tmp_workspace = TempDir::new().unwrap();
+        let mut reg =
+            ToolRegistry::new(tmp_workspace.path().to_path_buf(), ToolConfig::default()).unwrap();
+        reg.set_zirkel_db_path(db_path);
+        // Leak the workspace TempDir — tool tests don't read from
+        // workspace paths and we want the path to remain valid.
+        std::mem::forget(tmp_workspace);
+        reg
+    }
+
+    fn parse_rows(output: &str) -> serde_json::Value {
+        serde_json::from_str(output).expect("output is valid JSON")
+    }
+
+    #[tokio::test]
+    async fn unconfigured_path_returns_clear_error() {
+        let tmp_workspace = TempDir::new().unwrap();
+        let reg =
+            ToolRegistry::new(tmp_workspace.path().to_path_buf(), ToolConfig::default()).unwrap();
+        let r = reg
+            .execute("sqlite_query", r#"{"query":"kept_recent","params":{}}"#)
+            .await
+            .unwrap();
+        assert!(!r.success);
+        assert!(r.output.contains("not configured"));
+    }
+
+    #[tokio::test]
+    async fn unknown_query_name_errors() {
+        let tmp = TempDir::new().unwrap();
+        let db = tmp.path().join("agg.db");
+        seed_fixture_db(&db);
+        let reg = build_registry(db);
+        let r = reg
+            .execute(
+                "sqlite_query",
+                r#"{"query":"select_everything","params":{}}"#,
+            )
+            .await
+            .unwrap();
+        assert!(!r.success);
+        assert!(r.output.contains("unknown named query"));
+    }
+
+    #[tokio::test]
+    async fn kept_recent_returns_three_kept_rows() {
+        let tmp = TempDir::new().unwrap();
+        let db = tmp.path().join("agg.db");
+        seed_fixture_db(&db);
+        let reg = build_registry(db);
+        let r = reg
+            .execute(
+                "sqlite_query",
+                r#"{"query":"kept_recent","params":{"days":7}}"#,
+            )
+            .await
+            .unwrap();
+        assert!(r.success, "output: {}", r.output);
+        let parsed = parse_rows(&r.output);
+        assert_eq!(parsed["count"], 3);
+        let rows = parsed["rows"].as_array().unwrap();
+        assert_eq!(rows.len(), 3);
+        // Verbatim fields surfaced — the librarian skill body relies
+        // on these names without paraphrase.
+        let keys: Vec<&str> = rows[0]
+            .as_object()
+            .unwrap()
+            .keys()
+            .map(|s| s.as_str())
+            .collect();
+        for required in [
+            "title",
+            "source",
+            "url",
+            "date",
+            "kept_at",
+            "theme",
+            "why_surfaced",
+        ] {
+            assert!(keys.contains(&required), "missing key: {required}");
+        }
+    }
+
+    #[tokio::test]
+    async fn kept_by_keyword_matches_title_substring() {
+        let tmp = TempDir::new().unwrap();
+        let db = tmp.path().join("agg.db");
+        seed_fixture_db(&db);
+        let reg = build_registry(db);
+        let r = reg
+            .execute(
+                "sqlite_query",
+                r#"{"query":"kept_by_keyword","params":{"term":"adtech"}}"#,
+            )
+            .await
+            .unwrap();
+        let parsed = parse_rows(&r.output);
+        assert_eq!(parsed["count"], 1);
+        assert_eq!(parsed["rows"][0]["title"], "FTC enforcement on adtech");
+    }
+
+    #[tokio::test]
+    async fn kept_by_keyword_case_insensitive() {
+        let tmp = TempDir::new().unwrap();
+        let db = tmp.path().join("agg.db");
+        seed_fixture_db(&db);
+        let reg = build_registry(db);
+        let r = reg
+            .execute(
+                "sqlite_query",
+                r#"{"query":"kept_by_keyword","params":{"term":"ADTECH"}}"#,
+            )
+            .await
+            .unwrap();
+        let parsed = parse_rows(&r.output);
+        assert_eq!(parsed["count"], 1);
+    }
+
+    #[tokio::test]
+    async fn kept_by_theme_returns_only_kept_in_theme() {
+        let tmp = TempDir::new().unwrap();
+        let db = tmp.path().join("agg.db");
+        seed_fixture_db(&db);
+        let reg = build_registry(db);
+        let r = reg
+            .execute(
+                "sqlite_query",
+                r#"{"query":"kept_by_theme","params":{"theme":"Privacy enforcement"}}"#,
+            )
+            .await
+            .unwrap();
+        let parsed = parse_rows(&r.output);
+        // Theme has 3 candidates total but only 2 kept (ids 1 and 3;
+        // id 2 was skipped).
+        assert_eq!(parsed["count"], 2);
+    }
+
+    #[tokio::test]
+    async fn kept_by_source_filters_by_source_name() {
+        let tmp = TempDir::new().unwrap();
+        let db = tmp.path().join("agg.db");
+        seed_fixture_db(&db);
+        let reg = build_registry(db);
+        let r = reg
+            .execute(
+                "sqlite_query",
+                r#"{"query":"kept_by_source","params":{"source":"ftc-press"}}"#,
+            )
+            .await
+            .unwrap();
+        let parsed = parse_rows(&r.output);
+        // ftc-press has 2 candidates: id 1 (kept) and id 2 (skipped).
+        assert_eq!(parsed["count"], 1);
+        assert_eq!(parsed["rows"][0]["source"], "ftc-press");
+    }
+
+    #[tokio::test]
+    async fn kept_in_run_includes_only_kept_items_from_run() {
+        let tmp = TempDir::new().unwrap();
+        let db = tmp.path().join("agg.db");
+        seed_fixture_db(&db);
+        let reg = build_registry(db);
+        let r = reg
+            .execute(
+                "sqlite_query",
+                r#"{"query":"kept_in_run","params":{"run_id":"run-1"}}"#,
+            )
+            .await
+            .unwrap();
+        let parsed = parse_rows(&r.output);
+        assert_eq!(parsed["count"], 3);
+    }
+
+    #[tokio::test]
+    async fn kept_by_keyword_missing_term_errors() {
+        let tmp = TempDir::new().unwrap();
+        let db = tmp.path().join("agg.db");
+        seed_fixture_db(&db);
+        let reg = build_registry(db);
+        let r = reg
+            .execute("sqlite_query", r#"{"query":"kept_by_keyword","params":{}}"#)
+            .await
+            .unwrap();
+        assert!(!r.success);
+        assert!(r.output.contains("term"));
+    }
+
+    #[tokio::test]
+    async fn kept_by_keyword_empty_term_errors() {
+        let tmp = TempDir::new().unwrap();
+        let db = tmp.path().join("agg.db");
+        seed_fixture_db(&db);
+        let reg = build_registry(db);
+        let r = reg
+            .execute(
+                "sqlite_query",
+                r#"{"query":"kept_by_keyword","params":{"term":"   "}}"#,
+            )
+            .await
+            .unwrap();
+        assert!(!r.success);
+        assert!(r.output.contains("must not be empty"));
+    }
+
+    #[tokio::test]
+    async fn recent_themes_returns_themes_with_member_count() {
+        let tmp = TempDir::new().unwrap();
+        let db = tmp.path().join("agg.db");
+        seed_fixture_db(&db);
+        let reg = build_registry(db);
+        let r = reg
+            .execute(
+                "sqlite_query",
+                r#"{"query":"recent_themes","params":{"days":7}}"#,
+            )
+            .await
+            .unwrap();
+        let parsed = parse_rows(&r.output);
+        assert_eq!(parsed["count"], 2);
+        let themes = parsed["themes"].as_array().unwrap();
+        let names: Vec<&str> = themes.iter().map(|t| t["name"].as_str().unwrap()).collect();
+        assert!(names.contains(&"Privacy enforcement"));
+        assert!(names.contains(&"Cross-border transfers"));
+    }
+
+    #[tokio::test]
+    async fn skipped_items_are_excluded_from_kept_queries() {
+        let tmp = TempDir::new().unwrap();
+        let db = tmp.path().join("agg.db");
+        seed_fixture_db(&db);
+        let reg = build_registry(db);
+        // DPA fines (id 2) was skipped; should not surface.
+        let r = reg
+            .execute(
+                "sqlite_query",
+                r#"{"query":"kept_by_keyword","params":{"term":"DPA fines"}}"#,
+            )
+            .await
+            .unwrap();
+        let parsed = parse_rows(&r.output);
+        assert_eq!(parsed["count"], 0);
+    }
+
+    #[tokio::test]
+    async fn write_attempt_at_db_layer_is_refused() {
+        // Structural assertion: even if the LLM somehow constructed
+        // a write — which it can't, since SQL is hardcoded — the
+        // connection refuses writes. Direct test of read-only flag.
+        let tmp = TempDir::new().unwrap();
+        let db = tmp.path().join("agg.db");
+        seed_fixture_db(&db);
+        let conn =
+            rusqlite::Connection::open_with_flags(&db, rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY)
+                .unwrap();
+        let err = conn
+            .execute("DELETE FROM candidates WHERE id = 1", [])
+            .unwrap_err();
+        assert!(
+            format!("{err}").to_lowercase().contains("read"),
+            "expected read-only error, got: {err}"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// C-Librarian piece 2: end-to-end slash → skill body → sqlite_query → rows
+// ---------------------------------------------------------------------------
+
+mod librarian_e2e {
+    use std::path::Path;
+
+    use rusqlite::params;
+    use tempfile::TempDir;
+
+    use crate::inbound_interceptor::{InboundInterceptor, InterceptResult, InterceptorContext};
+    use crate::skill::SkillLoader;
+    use crate::slash::SlashInterceptor;
+    use crate::tool::{ToolConfig, ToolRegistry};
+
+    const LIBRARIAN_SKILL_MD: &str = r#"---
+name: librarian
+description: Read-only retrieval over the kept set
+disable-model-invocation: true
+permissions:
+  tools:
+    allow: [sqlite_query]
+  egress:
+    mode: deny
+  filesystem:
+    read_paths: ["~/.wirken/zirkel"]
+    write_paths: []
+  inference:
+    allow: ["*"]
+---
+
+You are the Zirkel librarian. Use sqlite_query with one of: kept_recent, kept_by_keyword, kept_by_theme, kept_by_source, kept_in_run, recent_themes. Render returned rows verbatim — do not paraphrase, do not summarize.
+"#;
+
+    fn write_librarian_skill(skills_dir: &Path) {
+        let lib_dir = skills_dir.join("librarian");
+        std::fs::create_dir_all(&lib_dir).unwrap();
+        std::fs::write(lib_dir.join("SKILL.md"), LIBRARIAN_SKILL_MD).unwrap();
+    }
+
+    fn seed_zirkel_db(db_path: &Path) {
+        let conn = rusqlite::Connection::open(db_path).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE candidates ( \
+                id INTEGER PRIMARY KEY AUTOINCREMENT, \
+                source_name TEXT NOT NULL, url TEXT NOT NULL, \
+                fetched_at TEXT NOT NULL DEFAULT (datetime('now')), \
+                body TEXT NOT NULL, run_id TEXT NOT NULL DEFAULT '', \
+                title TEXT NOT NULL DEFAULT '', published_at TEXT, \
+                matched_keywords TEXT NOT NULL DEFAULT '[]', \
+                keyword_match_score INTEGER NOT NULL DEFAULT 0, \
+                llm_relevance_score REAL, llm_why_surfaced TEXT, \
+                cluster_id INTEGER, source_metadata TEXT NOT NULL DEFAULT '{}' \
+            ); \
+            CREATE TABLE themes ( \
+                id INTEGER PRIMARY KEY AUTOINCREMENT, run_id TEXT NOT NULL, \
+                name TEXT NOT NULL, member_count INTEGER NOT NULL, \
+                created_at TEXT NOT NULL DEFAULT (datetime('now')) \
+            ); \
+            CREATE TABLE digests ( \
+                id INTEGER PRIMARY KEY AUTOINCREMENT, run_id TEXT NOT NULL, \
+                agent_id TEXT NOT NULL, \
+                sent_at TEXT NOT NULL DEFAULT (datetime('now')), resolved_at TEXT \
+            ); \
+            CREATE TABLE digest_items ( \
+                digest_id INTEGER NOT NULL, idx INTEGER NOT NULL, \
+                candidate_id INTEGER NOT NULL, decision TEXT, \
+                PRIMARY KEY (digest_id, idx) \
+            );",
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO candidates (id, source_name, url, body, run_id, title, published_at, llm_relevance_score, llm_why_surfaced) \
+             VALUES (1, 'consumerfinance-blog', 'https://x/1', 'CFPB body', 'run-1', 'CFPB updates blog on small-dollar lending', '2026-04-27', 90.0, 'matches consumer-protection interest')",
+            [],
+        ).unwrap();
+        conn.execute(
+            "INSERT INTO candidates (id, source_name, url, body, run_id, title, published_at, llm_relevance_score, llm_why_surfaced) \
+             VALUES (2, 'consumerfinance-blog', 'https://x/2', 'CFPB body 2', 'run-1', 'CFPB issues final rule on overdraft', '2026-04-26', 85.0, 'rulemaking signal')",
+            [],
+        ).unwrap();
+        conn.execute(
+            "INSERT INTO candidates (id, source_name, url, body, run_id, title, published_at, llm_relevance_score, llm_why_surfaced) \
+             VALUES (3, 'edpb-news', 'https://x/3', 'EU body', 'run-1', 'EDPB adopts new SCC guidance', '2026-04-25', 70.0, 'cross-border transfers')",
+            [],
+        ).unwrap();
+        conn.execute(
+            "INSERT INTO digests (id, run_id, agent_id, sent_at, resolved_at) \
+             VALUES (1, 'run-1', 'default', datetime('now', '-1 day'), datetime('now', '-1 day'))",
+            [],
+        )
+        .unwrap();
+        for (idx, candidate_id) in [(1, 1), (2, 2), (3, 3)] {
+            conn.execute(
+                "INSERT INTO digest_items (digest_id, idx, candidate_id, decision) VALUES (1, ?1, ?2, 'kept')",
+                params![idx as i64, candidate_id as i64],
+            )
+            .unwrap();
+        }
+    }
+
+    /// E2E: operator types `/librarian what did I keep about CFPB`,
+    /// the slash interceptor recognises the prefix, looks up the
+    /// loaded `librarian` skill, and rewrites the message so the
+    /// LLM sees skill body + user request. The agent's tool
+    /// registry has `sqlite_query` available bound to the zirkel
+    /// DB; invoking it returns the kept rows verbatim.
+    #[tokio::test]
+    async fn slash_inlines_librarian_body_and_tool_returns_rows() {
+        let tmp = TempDir::new().unwrap();
+
+        let skills_dir = tmp.path().join("skills");
+        write_librarian_skill(&skills_dir);
+        let skills = SkillLoader::load_dir(&skills_dir).unwrap();
+        assert_eq!(skills.len(), 1);
+        assert_eq!(skills[0].name, "librarian");
+        assert!(
+            skills[0].disable_model_invocation,
+            "librarian must be slash-only"
+        );
+
+        let interceptor = SlashInterceptor;
+        let ctx = InterceptorContext {
+            agent_id: "default",
+            skills: &skills,
+        };
+        let result = interceptor.intercept("/librarian what did I keep about CFPB", &ctx);
+        let rewritten = match result {
+            InterceptResult::Rewrite(s) => s,
+            other => panic!("expected Rewrite, got {other:?}"),
+        };
+        assert!(rewritten.contains("# Skill: librarian"));
+        assert!(rewritten.contains("kept_by_keyword"));
+        assert!(rewritten.contains("Render returned rows verbatim"));
+        assert!(rewritten.contains("what did I keep about CFPB"));
+        let body_idx = rewritten.find("kept_by_keyword").unwrap();
+        let request_idx = rewritten.find("what did I keep").unwrap();
+        assert!(
+            body_idx < request_idx,
+            "skill body must precede user request"
+        );
+
+        let db_path = tmp.path().join("zirkel-aggregator.db");
+        seed_zirkel_db(&db_path);
+
+        let workspace = tmp.path().join("ws");
+        std::fs::create_dir_all(&workspace).unwrap();
+        let mut tools = ToolRegistry::new(workspace, ToolConfig::default()).unwrap();
+        tools.set_zirkel_db_path(db_path);
+
+        let r = tools
+            .execute(
+                "sqlite_query",
+                r#"{"query":"kept_by_keyword","params":{"term":"CFPB"}}"#,
+            )
+            .await
+            .unwrap();
+        assert!(r.success, "tool output: {}", r.output);
+
+        let parsed: serde_json::Value = serde_json::from_str(&r.output).unwrap();
+        assert_eq!(parsed["count"], 2);
+        let rows = parsed["rows"].as_array().unwrap();
+        let titles: Vec<&str> = rows.iter().map(|r| r["title"].as_str().unwrap()).collect();
+        assert!(titles.contains(&"CFPB updates blog on small-dollar lending"));
+        assert!(titles.contains(&"CFPB issues final rule on overdraft"));
+        for row in rows {
+            assert_eq!(row["source"], "consumerfinance-blog");
+            assert!(row["url"].as_str().unwrap().starts_with("https://"));
+            assert!(!row["date"].as_str().unwrap().is_empty());
+            // Non-CFPB item must not surface — no false positives
+            // from the LLM's training-set knowledge.
+            assert_ne!(row["title"], "EDPB adopts new SCC guidance");
+        }
+    }
+
+    /// A keyword that matches no kept item produces an empty result
+    /// set the librarian surfaces plainly. The trust posture's "do
+    /// not invent items" rule has something honest to render —
+    /// count: 0, rows: [].
+    #[tokio::test]
+    async fn keyword_with_no_matches_returns_empty_set() {
+        let tmp = TempDir::new().unwrap();
+        let db_path = tmp.path().join("zirkel-aggregator.db");
+        seed_zirkel_db(&db_path);
+        let workspace = tmp.path().join("ws");
+        std::fs::create_dir_all(&workspace).unwrap();
+        let mut tools = ToolRegistry::new(workspace, ToolConfig::default()).unwrap();
+        tools.set_zirkel_db_path(db_path);
+
+        let r = tools
+            .execute(
+                "sqlite_query",
+                r#"{"query":"kept_by_keyword","params":{"term":"unicorn"}}"#,
+            )
+            .await
+            .unwrap();
+        assert!(r.success);
+        let parsed: serde_json::Value = serde_json::from_str(&r.output).unwrap();
+        assert_eq!(parsed["count"], 0);
+        assert_eq!(parsed["rows"].as_array().unwrap().len(), 0);
     }
 }

--- a/crates/agent/src/tool.rs
+++ b/crates/agent/src/tool.rs
@@ -67,6 +67,12 @@ pub struct ToolRegistry {
     /// lifetime of this registry — restart `wirken run` to retry.
     sandbox: tokio::sync::OnceCell<Option<DockerSandbox>>,
     sandbox_config: SandboxConfig,
+    /// Path to the zirkel aggregator SQLite database, set when the
+    /// agent is configured for the librarian skill. `None` means the
+    /// `sqlite_query` tool is unavailable for this agent (it returns
+    /// a clear error rather than silently failing). Set via
+    /// [`Self::set_zirkel_db_path`].
+    zirkel_db_path: Option<PathBuf>,
 }
 
 impl ToolRegistry {
@@ -191,6 +197,43 @@ impl ToolRegistry {
         );
 
         tools.insert(
+            "sqlite_query".into(),
+            ToolDef {
+                name: "sqlite_query".into(),
+                description: "Run a named query against the zirkel kept-items database. \
+                              Returns structured JSON rows verbatim; do not paraphrase \
+                              or summarize the results. Available named queries: \
+                              kept_recent (params: days), kept_by_keyword (params: term), \
+                              kept_by_theme (params: theme), kept_by_source (params: source), \
+                              kept_in_run (params: run_id), recent_themes (params: days)."
+                    .into(),
+                parameters: serde_json::json!({
+                    "type": "object",
+                    "properties": {
+                        "query": {
+                            "type": "string",
+                            "enum": [
+                                "kept_recent",
+                                "kept_by_keyword",
+                                "kept_by_theme",
+                                "kept_by_source",
+                                "kept_in_run",
+                                "recent_themes"
+                            ],
+                            "description": "Name of the query to run"
+                        },
+                        "params": {
+                            "type": "object",
+                            "description": "Parameters per the named query's signature",
+                            "additionalProperties": true
+                        }
+                    },
+                    "required": ["query"]
+                }),
+            },
+        );
+
+        tools.insert(
             "generate_image".into(),
             ToolDef {
                 name: "generate_image".into(),
@@ -228,7 +271,17 @@ impl ToolRegistry {
             config,
             sandbox: tokio::sync::OnceCell::new(),
             sandbox_config,
+            zirkel_db_path: None,
         })
+    }
+
+    /// Configure the path the `sqlite_query` librarian tool opens.
+    /// Called by the agent factory when the agent's static config
+    /// names a zirkel-bound database. The tool itself enforces
+    /// read-only access via `SQLITE_OPEN_READ_ONLY`; the path here
+    /// is the only DB the tool will ever touch.
+    pub fn set_zirkel_db_path(&mut self, path: PathBuf) {
+        self.zirkel_db_path = Some(path);
     }
 
     /// Whether the sandbox `OnceCell` has been initialized. Test-only helper
@@ -336,6 +389,7 @@ impl ToolRegistry {
             "write_file" => self.write_file(&args).await,
             "list_files" => self.list_files(&args).await,
             "web_search" => self.web_search(&args).await,
+            "sqlite_query" => self.sqlite_query(&args).await,
             "generate_image" => self.generate_image(&args).await,
             _ => Err(AgentError::ToolNotFound(name.to_string())),
         }
@@ -579,6 +633,66 @@ impl ToolRegistry {
         })
     }
 
+    /// Run a named query against the zirkel kept-items database.
+    ///
+    /// Trust posture (the load-bearing decision for the C-Librarian
+    /// slice): the LLM does not write SQL. It picks one of a small
+    /// set of named queries and fills typed parameters; the tool
+    /// runs the parameterized SQL the librarian skill committed to.
+    /// Free-form SQL would let the LLM hallucinate column names,
+    /// construct unbounded scans, or drift from the audit log's
+    /// expected query shape — exactly the trust posture this slice
+    /// rejects.
+    ///
+    /// The DB connection is opened with `SQLITE_OPEN_READ_ONLY`, so
+    /// a write attempt is refused at the connection layer (not by
+    /// string-pattern checks on the SQL). Caller must have set
+    /// `zirkel_db_path` via [`Self::set_zirkel_db_path`]; otherwise
+    /// the tool returns a clear error.
+    ///
+    /// Output is structured JSON. The librarian skill body
+    /// instructs the LLM to render rows verbatim — title, source,
+    /// date, url — without paraphrase. That's how retrieval-only
+    /// becomes structural rather than aspirational.
+    async fn sqlite_query(&self, args: &serde_json::Value) -> Result<ToolResult, AgentError> {
+        let Some(db_path) = self.zirkel_db_path.clone() else {
+            return Ok(ToolResult {
+                output: "sqlite_query is not configured for this agent (no zirkel database path bound). \
+                         Bind a librarian skill on an agent whose static config sets zirkel_db_path."
+                    .into(),
+                success: false,
+            });
+        };
+
+        let query_name = args
+            .get("query")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| AgentError::Tool("missing required 'query' parameter".into()))?
+            .to_string();
+        let params = args
+            .get("params")
+            .cloned()
+            .unwrap_or_else(|| serde_json::json!({}));
+
+        // Run blocking SQLite ops on a tokio blocking task so the
+        // async runtime isn't held up by file I/O.
+        let result =
+            tokio::task::spawn_blocking(move || run_named_query(&db_path, &query_name, &params))
+                .await
+                .map_err(|e| AgentError::Tool(format!("sqlite_query task panic: {e}")))?;
+
+        match result {
+            Ok(rows_json) => Ok(ToolResult {
+                output: rows_json,
+                success: true,
+            }),
+            Err(e) => Ok(ToolResult {
+                output: format!("sqlite_query error: {e}"),
+                success: false,
+            }),
+        }
+    }
+
     async fn generate_image(&self, args: &serde_json::Value) -> Result<ToolResult, AgentError> {
         let provider = self.config.provider.as_deref().unwrap_or("unknown");
         if !matches!(provider, "openai" | "custom") {
@@ -708,6 +822,261 @@ struct SearchResult {
 
 /// Map an [`crate::egress::HttpAccessDenied`] from the wrapped HTTP
 /// client into an [`AgentError`]. The agent's tool dispatcher (#76
+/// Run one of the librarian's named queries against the zirkel
+/// database. Read-only by construction (`SQLITE_OPEN_READ_ONLY`);
+/// caller has already verified that the path is configured.
+///
+/// Each branch hardcodes the SQL — the LLM cannot inject column
+/// names or join shape. Parameters are bound positionally so a
+/// hostile param value (which a typo'd name could synthesize)
+/// cannot escape into the query body.
+///
+/// Result is JSON-serialized as `{"rows": [...], "count": N}` for
+/// item-shaped queries, or `{"themes": [...], "count": N}` for the
+/// `recent_themes` query. The librarian skill body tells the LLM
+/// which key to read and to relay rows verbatim — title, source,
+/// date, url — without paraphrase.
+fn run_named_query(
+    db_path: &Path,
+    query_name: &str,
+    params: &serde_json::Value,
+) -> Result<String, String> {
+    let conn = rusqlite::Connection::open_with_flags(
+        db_path,
+        rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    )
+    .map_err(|e| format!("open zirkel db: {e}"))?;
+
+    match query_name {
+        "kept_recent" => kept_recent(&conn, params),
+        "kept_by_keyword" => kept_by_keyword(&conn, params),
+        "kept_by_theme" => kept_by_theme(&conn, params),
+        "kept_by_source" => kept_by_source(&conn, params),
+        "kept_in_run" => kept_in_run(&conn, params),
+        "recent_themes" => recent_themes(&conn, params),
+        other => Err(format!(
+            "unknown named query '{other}'. Known: kept_recent, kept_by_keyword, kept_by_theme, kept_by_source, kept_in_run, recent_themes"
+        )),
+    }
+}
+
+/// Cap on rows returned per query. Bounds the response payload so
+/// a query that would otherwise return thousands of rows stays
+/// manageable for the LLM's context. The librarian skill explains
+/// this to the operator: "if you want everything, narrow the
+/// query."
+const KEPT_ROW_LIMIT: i64 = 100;
+const THEMES_ROW_LIMIT: i64 = 50;
+
+fn kept_recent(conn: &rusqlite::Connection, params: &serde_json::Value) -> Result<String, String> {
+    let days = extract_days(params, 7);
+    let mut stmt = conn
+        .prepare(
+            "SELECT c.title, c.source_name, c.url, COALESCE(c.published_at, '') AS pub_date, \
+                    COALESCE(c.llm_why_surfaced, '') AS why, \
+                    d.resolved_at AS kept_at, COALESCE(t.name, '') AS theme \
+             FROM digest_items di \
+             JOIN candidates c ON c.id = di.candidate_id \
+             JOIN digests d ON d.id = di.digest_id \
+             LEFT JOIN themes t ON t.id = c.cluster_id \
+             WHERE di.decision = 'kept' \
+               AND d.resolved_at IS NOT NULL \
+               AND d.resolved_at >= datetime('now', ?1 || ' days') \
+             ORDER BY d.resolved_at DESC, c.llm_relevance_score DESC \
+             LIMIT ?2",
+        )
+        .map_err(|e| format!("prepare kept_recent: {e}"))?;
+    let days_arg = format!("-{days}");
+    let rows = collect_kept_rows(&mut stmt, rusqlite::params![days_arg, KEPT_ROW_LIMIT])?;
+    Ok(serialize_rows("rows", rows))
+}
+
+fn kept_by_keyword(
+    conn: &rusqlite::Connection,
+    params: &serde_json::Value,
+) -> Result<String, String> {
+    let term = extract_required_string(params, "term")?;
+    let pattern = format!("%{}%", term.to_lowercase());
+    let mut stmt = conn
+        .prepare(
+            "SELECT c.title, c.source_name, c.url, COALESCE(c.published_at, '') AS pub_date, \
+                    COALESCE(c.llm_why_surfaced, '') AS why, \
+                    d.resolved_at AS kept_at, COALESCE(t.name, '') AS theme \
+             FROM digest_items di \
+             JOIN candidates c ON c.id = di.candidate_id \
+             JOIN digests d ON d.id = di.digest_id \
+             LEFT JOIN themes t ON t.id = c.cluster_id \
+             WHERE di.decision = 'kept' \
+               AND d.resolved_at IS NOT NULL \
+               AND (LOWER(c.title) LIKE ?1 OR LOWER(c.body) LIKE ?1) \
+             ORDER BY d.resolved_at DESC \
+             LIMIT ?2",
+        )
+        .map_err(|e| format!("prepare kept_by_keyword: {e}"))?;
+    let rows = collect_kept_rows(&mut stmt, rusqlite::params![pattern, KEPT_ROW_LIMIT])?;
+    Ok(serialize_rows("rows", rows))
+}
+
+fn kept_by_theme(
+    conn: &rusqlite::Connection,
+    params: &serde_json::Value,
+) -> Result<String, String> {
+    let theme = extract_required_string(params, "theme")?;
+    let mut stmt = conn
+        .prepare(
+            "SELECT c.title, c.source_name, c.url, COALESCE(c.published_at, '') AS pub_date, \
+                    COALESCE(c.llm_why_surfaced, '') AS why, \
+                    d.resolved_at AS kept_at, t.name AS theme \
+             FROM digest_items di \
+             JOIN candidates c ON c.id = di.candidate_id \
+             JOIN digests d ON d.id = di.digest_id \
+             JOIN themes t ON t.id = c.cluster_id \
+             WHERE di.decision = 'kept' \
+               AND d.resolved_at IS NOT NULL \
+               AND LOWER(t.name) = LOWER(?1) \
+             ORDER BY d.resolved_at DESC \
+             LIMIT ?2",
+        )
+        .map_err(|e| format!("prepare kept_by_theme: {e}"))?;
+    let rows = collect_kept_rows(&mut stmt, rusqlite::params![theme, KEPT_ROW_LIMIT])?;
+    Ok(serialize_rows("rows", rows))
+}
+
+fn kept_by_source(
+    conn: &rusqlite::Connection,
+    params: &serde_json::Value,
+) -> Result<String, String> {
+    let source = extract_required_string(params, "source")?;
+    let mut stmt = conn
+        .prepare(
+            "SELECT c.title, c.source_name, c.url, COALESCE(c.published_at, '') AS pub_date, \
+                    COALESCE(c.llm_why_surfaced, '') AS why, \
+                    d.resolved_at AS kept_at, COALESCE(t.name, '') AS theme \
+             FROM digest_items di \
+             JOIN candidates c ON c.id = di.candidate_id \
+             JOIN digests d ON d.id = di.digest_id \
+             LEFT JOIN themes t ON t.id = c.cluster_id \
+             WHERE di.decision = 'kept' \
+               AND d.resolved_at IS NOT NULL \
+               AND c.source_name = ?1 \
+             ORDER BY d.resolved_at DESC \
+             LIMIT ?2",
+        )
+        .map_err(|e| format!("prepare kept_by_source: {e}"))?;
+    let rows = collect_kept_rows(&mut stmt, rusqlite::params![source, KEPT_ROW_LIMIT])?;
+    Ok(serialize_rows("rows", rows))
+}
+
+fn kept_in_run(conn: &rusqlite::Connection, params: &serde_json::Value) -> Result<String, String> {
+    let run_id = extract_required_string(params, "run_id")?;
+    let mut stmt = conn
+        .prepare(
+            "SELECT c.title, c.source_name, c.url, COALESCE(c.published_at, '') AS pub_date, \
+                    COALESCE(c.llm_why_surfaced, '') AS why, \
+                    d.resolved_at AS kept_at, COALESCE(t.name, '') AS theme \
+             FROM digest_items di \
+             JOIN candidates c ON c.id = di.candidate_id \
+             JOIN digests d ON d.id = di.digest_id \
+             LEFT JOIN themes t ON t.id = c.cluster_id \
+             WHERE di.decision = 'kept' \
+               AND c.run_id = ?1 \
+             ORDER BY c.llm_relevance_score DESC, c.id ASC \
+             LIMIT ?2",
+        )
+        .map_err(|e| format!("prepare kept_in_run: {e}"))?;
+    let rows = collect_kept_rows(&mut stmt, rusqlite::params![run_id, KEPT_ROW_LIMIT])?;
+    Ok(serialize_rows("rows", rows))
+}
+
+fn recent_themes(
+    conn: &rusqlite::Connection,
+    params: &serde_json::Value,
+) -> Result<String, String> {
+    let days = extract_days(params, 7);
+    let mut stmt = conn
+        .prepare(
+            "SELECT name, member_count, run_id, created_at \
+             FROM themes \
+             WHERE created_at >= datetime('now', ?1 || ' days') \
+             ORDER BY created_at DESC, member_count DESC \
+             LIMIT ?2",
+        )
+        .map_err(|e| format!("prepare recent_themes: {e}"))?;
+    let days_arg = format!("-{days}");
+    let mut rows: Vec<serde_json::Value> = Vec::new();
+    let mapped = stmt
+        .query_map(rusqlite::params![days_arg, THEMES_ROW_LIMIT], |row| {
+            Ok(serde_json::json!({
+                "name": row.get::<_, String>(0)?,
+                "member_count": row.get::<_, i64>(1)?,
+                "run_id": row.get::<_, String>(2)?,
+                "created_at": row.get::<_, String>(3)?,
+            }))
+        })
+        .map_err(|e| format!("query recent_themes: {e}"))?;
+    for r in mapped {
+        rows.push(r.map_err(|e| format!("read theme row: {e}"))?);
+    }
+    Ok(serialize_rows("themes", rows))
+}
+
+/// Build the JSON envelope the LLM sees. Always includes `count`
+/// so the librarian skill body can say "you have 5 items kept this
+/// week" without relying on the LLM to count an array.
+fn serialize_rows(key: &str, rows: Vec<serde_json::Value>) -> String {
+    let count = rows.len();
+    let envelope = serde_json::json!({
+        key: rows,
+        "count": count,
+    });
+    serde_json::to_string(&envelope).unwrap_or_else(|_| "{}".to_string())
+}
+
+fn collect_kept_rows<P: rusqlite::Params>(
+    stmt: &mut rusqlite::Statement<'_>,
+    params: P,
+) -> Result<Vec<serde_json::Value>, String> {
+    let mapped = stmt
+        .query_map(params, |row| {
+            Ok(serde_json::json!({
+                "title": row.get::<_, String>(0)?,
+                "source": row.get::<_, String>(1)?,
+                "url": row.get::<_, String>(2)?,
+                "date": row.get::<_, String>(3)?,
+                "why_surfaced": row.get::<_, String>(4)?,
+                "kept_at": row.get::<_, String>(5)?,
+                "theme": row.get::<_, String>(6)?,
+            }))
+        })
+        .map_err(|e| format!("query: {e}"))?;
+    let mut out = Vec::new();
+    for r in mapped {
+        out.push(r.map_err(|e| format!("read row: {e}"))?);
+    }
+    Ok(out)
+}
+
+fn extract_days(params: &serde_json::Value, default_days: i64) -> i64 {
+    params
+        .get("days")
+        .and_then(|v| v.as_i64())
+        .filter(|n| *n > 0 && *n <= 365)
+        .unwrap_or(default_days)
+}
+
+fn extract_required_string(params: &serde_json::Value, name: &str) -> Result<String, String> {
+    let s = params
+        .get(name)
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| format!("missing required parameter '{name}' (expected string)"))?
+        .trim()
+        .to_string();
+    if s.is_empty() {
+        return Err(format!("parameter '{name}' must not be empty"));
+    }
+    Ok(s)
+}
+
 /// Phase 2.2) intercepts both variants and emits the appropriate
 /// `SkillPermissionDenied` audit event before surfacing a non-success
 /// `ToolResult`. The agent-tool case (web_search / generate_image)

--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -287,6 +287,7 @@ pub async fn run(port: Option<u16>) -> Result<()> {
                     allowed_subagents: agent_cfg.allowed_subagents.clone(),
                     sandbox: super::load_sandbox_config(&cfg.data_dir),
                     extra_interceptors: vec![],
+                    zirkel_db_path: None,
                 },
             );
         }
@@ -373,6 +374,7 @@ pub async fn run(port: Option<u16>) -> Result<()> {
                 allowed_subagents: Default::default(),
                 sandbox: super::load_sandbox_config(&cfg.data_dir),
                 extra_interceptors: vec![],
+                zirkel_db_path: None,
             },
         );
     }

--- a/crates/cli/src/commands/session.rs
+++ b/crates/cli/src/commands/session.rs
@@ -268,6 +268,7 @@ pub async fn verify(session_id: &str, strict: bool) -> Result<()> {
             // independent of the runtime sandbox selection.
             sandbox: Default::default(),
             extra_interceptors: vec![],
+            zirkel_db_path: None,
         },
     );
     let factory =

--- a/preset/zirkel/skills/librarian/SKILL.md
+++ b/preset/zirkel/skills/librarian/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: librarian
-description: Retrieval-only chat over the kept set in SQLite — no live fetch, no synthesized factual claims about the world
+description: Read-only retrieval over the daily-digest kept set. Slash-invoke with `/librarian <question>`; returns items verbatim with citations.
 disable-model-invocation: true
 permissions:
   tools:
-    allow: [exec, read_file]
+    allow: [sqlite_query]
   egress:
     mode: deny
   filesystem:
@@ -17,30 +17,55 @@ permissions:
 
 # Librarian
 
-Answers chat queries against the kept set of candidates in `~/.wirken/zirkel/zirkel.db`. Retrieval-only. No live fetch — that's the aggregator's job. No synthesized factual claims about the world.
+You answer questions about the operator's kept set — the items they explicitly chose to keep when their daily digest arrived. You are slash-invoked with `/librarian <question>`. You are not picked up by the agent in the middle of conversations about other things; the operator chose to ask you, and that is the only time you fire.
 
-Reach this skill via `/librarian <query>`.
+You have one tool: `sqlite_query`. It runs one of these named queries:
 
-## What it returns
+- `kept_recent` — items kept in the last N days. Param: `days` (default 7).
+- `kept_by_keyword` — items whose title or body contains a term. Param: `term` (string).
+- `kept_by_theme` — items in a specific theme. Param: `theme` (string, matched case-insensitively against the theme name).
+- `kept_by_source` — items from a specific source. Param: `source` (string, e.g. `ftc-press`).
+- `kept_in_run` — items from a specific run. Param: `run_id` (string).
+- `recent_themes` — themes that have appeared in the last N days. Param: `days` (default 7).
 
-For each query the librarian:
+## How to answer
 
-1. Looks up matching candidates in SQLite by interest-match, keyword, or theme.
-2. Returns the matched candidates: `title`, `source`, `date`, `url`, `why_surfaced`.
-3. If asked to characterize *what the matched documents say*, answers strictly with attribution: *"per the FTC press release of 2026-04-12: …"*. Never as the librarian's own claim.
-4. When no kept candidate matches, refuses the question with a clear message: *"the kept set has nothing on this. Suggest you broaden the interests file or wait for tomorrow's run."* No guess, no fall-through to the LLM's training-set knowledge.
+1. Pick the named query that best matches the operator's question.
+2. Call `sqlite_query` with that query and the appropriate params.
+3. Render the returned rows as a numbered list. Use the `title`, `source`, `date`, and `url` fields exactly as provided.
 
-## What it will not do
+## Rules
 
-- Reach the network. The `permissions.egress.mode = deny` block ensures this is enforced in code, not just prose.
-- Answer based on the LLM's training set rather than the retrieval result.
-- Aggregate a "summary of what the regulators said this month" that goes beyond paraphrase of specific kept items with attribution.
+- Use titles verbatim. Do not paraphrase.
+- Render each row as listed. Do not summarize.
+- Do not add commentary, opinions, or interpretation.
+- If the result count is zero, say so plainly. Do not invent items.
+- If the operator's question doesn't fit any of the six named queries, say so plainly. Suggest a query that does fit, or ask them to refine.
+
+You are a librarian, not an analyst. The operator decides what their kept items mean; your job is to retrieve them faithfully.
+
+## What you will not do
+
+- Reach the network. The `permissions.egress.mode = deny` block enforces this in code, not just prose.
+- Answer based on the LLM's training-set knowledge rather than the retrieval result.
+- Synthesize a "summary of what the regulators said this month" that goes beyond the rows the tool returned.
 - Write to the kept set. The `permissions.filesystem.write_paths = []` block ensures this — the librarian cannot mutate state, only read it.
 
-## Sharing state with the aggregator
+## How to format the response
 
-The librarian reads the same `~/.wirken/zirkel/` directory the aggregator writes. The aggregator declares write access; the librarian declares read access; the agent's effective filesystem profile (union) covers both.
+A typical response:
 
-## What runtime pieces are not yet implemented
+```
+Found 3 items kept in the last 7 days mentioning "CFPB":
 
-The SQLite retrieval surface, query parser, and feedback-mark commands are deferred to follow-up scopes. This skill declares the contract; the agent attaches it as part of the Zirkel preset; a later scope wires it to actual database queries.
+1. CFPB updates blog on small-dollar lending
+   consumerfinance-blog · 2026-04-27 · https://www.consumerfinance.gov/blog/...
+2. ...
+3. ...
+```
+
+A zero-count response:
+
+```
+No items in your kept set match that query. You could broaden the term, try a different keyword, or check `recent_themes` to see what topics have surfaced this week.
+```


### PR DESCRIPTION
## Zirkel v1 ships

Aggregator + Librarian. Four fetcher kinds (RSS, Federal Register, congress.gov, GovInfo). Signal delivery with keep/skip resolution. Retrieval-only chat surface against the kept set.

The structural commitments are all enforced in code, not stated in prose:

- **Per-skill permissions** (four axes — tools, egress, filesystem, inference) merged at attach time, gated at call time, audited per denial. Aggregator and Librarian share the same `~/.wirken/zirkel/` data dir via filesystem permissions union — aggregator declares write, librarian declares read, the agent's effective profile is the union.
- **Rate-limit-as-transport** — every outbound HTTP request crosses a `RateLimitedClient` with a per-host daily budget. Authenticated APIs declare their published quota at the fetcher level; unauthenticated hosts stay at the polite 2/day default. There is no other HTTP path through which a fetcher can route.
- **No headless browser** — `docs/zirkel.md` documents this as an architectural commitment, not a backlog item. SPA-only sources are out of scope; the conversation when one becomes important is "should Wirken's architecture change?" not "can we add Chrome to Zirkel?"
- **Vault-isolated credentials** — api.data.gov keys land in the operator's vault encrypted at rest; resolved at orchestrator-run time by the operator's UID; injected into the `X-Api-Key` header at fetch time; never reach the agent or LLM. Structurally tested in C-API's e2e where mock servers reject requests without the expected header.
- **Retrieval-only, no synthesis** — this slice. The librarian tool runs hardcoded SQL, returns rows verbatim, and the skill body instructs the LLM to render them as listed without paraphrase. The trust posture is that a librarian who occasionally hallucinates a SELECT against a column that doesn't exist is not a librarian at all; the structural commitment makes that hallucination impossible.

## What this slice adds

**`sqlite_query` tool** (`crates/agent/src/tool.rs`). Net-new built-in. Read-only SQLite via `SQLITE_OPEN_READ_ONLY` against the zirkel aggregator DB. Six named queries — `kept_recent`, `kept_by_keyword`, `kept_by_theme`, `kept_by_source`, `kept_in_run`, `recent_themes`. The query name is a JSON-schema enum on the tool def, so the function-calling layer rejects invalid names at the SDK level; the LLM cannot try to invoke a query that doesn't exist. Parameters bound positionally; SQL never sees an LLM-provided string except as a bound value. Output is structured JSON with a stable shape: `title`, `source`, `url`, `date`, `kept_at`, `theme`, `why_surfaced`. 13 unit tests covering each named query, case-insensitive keyword matching, missing-param errors, skipped-items-excluded, write-refused-at-DB-layer.

**Librarian skill** (`preset/zirkel/skills/librarian/SKILL.md`). Slash-invocable per #79 (`disable-model-invocation: true`). Permissions: `tools.allow: [sqlite_query]`, `egress.mode: deny`, `filesystem.write_paths: []`. The body lists the six queries and their parameters, and states the verbatim-rendering rules in active voice:

> Use titles verbatim. Do not paraphrase.
> Render each row as listed. Do not summarize.
> Do not add commentary, opinions, or interpretation.
> If the result count is zero, say so plainly. Do not invent items.
>
> You are a librarian, not an analyst.

**Path-wiring shape** mirroring `extra_interceptors` from C-Signal: `AgentStaticConfig.zirkel_db_path: Option<PathBuf>` → `Agent::attach_zirkel_db` → `ToolRegistry::set_zirkel_db_path` propagated through factory wake. Future skills that need their own DB connection copy this shape.

**End-to-end test** (`tests::librarian_e2e`). Operator types `/librarian what did I keep about CFPB`; slash interceptor recognises the prefix, looks up the loaded librarian skill from a fixture preset directory, rewrites the message so the LLM sees skill-body-then-question; tool registry has `sqlite_query` available against a seeded zirkel DB; invoking it returns the kept rows with verbatim titles, source, URL, and date. The non-CFPB seeded item must not surface — structural assertion against false positives from the LLM's training-set knowledge.

## v1 slice list

The path from preset declaration to lawyer-facing surface:

| Slice | What it landed |
|---|---|
| C-foundation | Per-skill SQLite store, RSS fetcher, keyword screen, dedup, audit event variants |
| C-LLM | Synthetic-tool structured output, ollama embeddings, hdbscan clustering, theme naming |
| C-Signal | Digest push IPC, keep/skip interceptor, bind CLI |
| C-API | Fetcher trait, Federal Register + Congress + GovInfo fetchers, auth-set CLI |
| C-Librarian (this) | `sqlite_query` tool with named queries; librarian skill body |

After this lands, `wirken zirkel run` (cron-fired) fetches across all four fetcher kinds, scores with the operator's interests file, clusters and names themes, pushes a numbered digest to the bound channel; the operator replies `keep 1,3,5` and the kept set is recorded; `/librarian` queries the kept set with retrieval-only verbatim rendering.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace` clean (15 sqlite_query + librarian_e2e tests pass; 0 regressions)
- [ ] Manual: install zirkel preset, configure interests + bindings + api keys, fire `wirken zirkel run`, verify Signal digest arrives
- [ ] Manual: reply `keep <N>` on Signal, verify decisions land in `digest_items`
- [ ] Manual: `/librarian what did I keep this week` on Signal, verify rendered list matches kept set verbatim