### PR TITLE
Normalize credential --host bindings to lowercase punycode at store time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6839,6 +6839,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "url",
  "uuid",
  "wirken-adapter-discord",
  "wirken-adapter-google-chat",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -29,6 +29,7 @@ wirken-adapter-imessage = { path = "../adapter-imessage" }
 capnp = { workspace = true }
 ed25519-dalek = { workspace = true }
 uuid = { version = "1", features = ["v4"] }
+url = "2"
 reqwest = { workspace = true }
 clap = { workspace = true }
 dialoguer = { workspace = true }

--- a/crates/cli/src/commands/credential.rs
+++ b/crates/cli/src/commands/credential.rs
@@ -1,5 +1,6 @@
 use anyhow::{Context, Result, anyhow};
 use dialoguer::Password;
+use url::Url;
 
 use wirken_mcp_proxy::{
     OAuthCredential, load_oauth_public, lookup_provider, run_authorization_code_flow, store_oauth,
@@ -295,6 +296,14 @@ impl ValueSource {
     }
 }
 
+fn normalize_host(raw: &str) -> Result<String> {
+    let url = Url::parse(&format!("https://{raw}/"))
+        .map_err(|e| anyhow!("invalid --host '{raw}': {e}"))?;
+    url.host_str()
+        .map(str::to_string)
+        .ok_or_else(|| anyhow!("invalid --host '{raw}': no host"))
+}
+
 pub async fn add(
     name: &str,
     channel: Option<&str>,
@@ -307,6 +316,11 @@ pub async fn add(
     if value.is_empty() {
         anyhow::bail!("empty value");
     }
+
+    let allowed_hosts = allowed_hosts
+        .iter()
+        .map(|h| normalize_host(h))
+        .collect::<Result<Vec<String>>>()?;
 
     let keychain = probe_keychain(&cfg.data_dir, || {
         Password::new()
@@ -326,7 +340,7 @@ pub async fn add(
             &secret,
             None,
             None,
-            allowed_hosts,
+            &allowed_hosts,
         )
         .context(format!("Failed to store '{name}'"))?;
 
@@ -511,5 +525,18 @@ mod tests {
 
         let (retrieved, _) = store.retrieve("my-mcp-token").expect("retrieve");
         assert_eq!(retrieved.expose(), "hunter2");
+    }
+
+    #[test]
+    fn normalize_host_lowercases_and_punycodes() {
+        assert_eq!(normalize_host("café.example").unwrap(), "xn--caf-dma.example");
+        assert_eq!(normalize_host("Example.COM").unwrap(), "example.com");
+        assert_eq!(normalize_host("api.example.com").unwrap(), "api.example.com");
+    }
+
+    #[test]
+    fn normalize_host_rejects_invalid_input() {
+        assert!(normalize_host("").is_err());
+        assert!(normalize_host("not a host!!").is_err());
     }
 }


### PR DESCRIPTION
Fixes #176.

`CredentialMetadata::permits_host` compares stored `allowed_hosts`
against the request URL's host, which the `url` crate returns as
lowercase ASCII/punycode. `credential add --host` stored the operator's
input verbatim, so a unicode host (e.g. `café.example`) was stored as
typed and never matched its request-time punycode form
(`xn--caf-dma.example`) -- the binding silently never worked. Fail-closed
(an unmatched binding denies), so no security impact, but a real
usability footgun, as the issue describes.

Normalizes in `credential::add`, before `store_with_hosts` is called:
parses `https://{host}/` and takes `host_str()`, rejecting input with no
host. Adds `url` as a direct dependency of the cli crate (already a
transitive dependency via wirken-agent).

Tested: two new unit tests (valid normalization including the exact
unicode case from the issue, and rejection of invalid input), full crate
test suite passing (9/9), clippy clean.